### PR TITLE
refactor(did): sdata.did als dokumentiertes Subpackage + Tests

### DIFF
--- a/sdata/did/README.md
+++ b/sdata/did/README.md
@@ -1,0 +1,106 @@
+# sdata.did — Decentralized Identifiers & Verifiable Credentials
+
+Schlanke, **pure-Python** Bausteine für Self-Sovereign Identity (SSI) rund um
+Ed25519: Schlüssel als JWK, Compact-JWS (JOSE/EdDSA), Verifiable Credentials &
+Presentations sowie mehrere DID-Methoden.
+
+## Installation
+
+Die DID-Funktionen brauchen zwei optionale Abhängigkeiten:
+
+```bash
+pip install "sdata[did]"     # zieht ecdsa + base58
+```
+
+## Unterstützte Standards
+
+| Bereich | Standard |
+|---|---|
+| DID-Dokumente | [W3C DID Core](https://www.w3.org/TR/did-core/) |
+| DID-Methoden | [did:web](https://w3c-ccg.github.io/did-method-web/), [did:key](https://w3c-ccg.github.io/did-method-key/), [did:peer:4](https://identity.foundation/peer-did-method-spec/), `did:github` (projektspezifisch) |
+| Credentials | [W3C Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) (JWT-VC) |
+| Signatur | [JOSE/JWS RFC 7515](https://www.rfc-editor.org/rfc/rfc7515), [EdDSA RFC 8037](https://www.rfc-editor.org/rfc/rfc8037) |
+| Thumbprint | [JWK Thumbprint RFC 7638](https://www.rfc-editor.org/rfc/rfc7638) |
+
+## ⚠️ Sicherheitshinweis
+
+Der produktive Krypto-Pfad nutzt `python-ecdsa` (reine Python-Implementierung).
+Sie ist dependency-arm, aber **nicht garantiert constant-time** (Timing-
+Seitenkanal-Risiko). Für hochsensible Umgebungen ein libsodium-Backend (PyNaCl)
+oder `cryptography` (OpenSSL) erwägen.
+
+Das Modul `ed25519.py` ist eine reine **Lern-Referenz** (RFC 8032) und wird vom
+Funktionspfad **nicht** verwendet.
+
+## Modulübersicht
+
+| Modul | Inhalt |
+|---|---|
+| `errors.py` | Ausnahmehierarchie (`DidError`, `EncodingError`, `ResolutionError`, `VerificationError`) |
+| `keys.py` | Ed25519-JWK erzeugen/ableiten (CLI) |
+| `utils_didkey.py` | JWK ↔ `did:key`, RFC-7638-Thumbprint, `kid`-Helfer |
+| `jose.py` | Compact-JWS signieren/verifizieren (EdDSA) |
+| `issue_vc.py` | VC/VP ausstellen (ProductPassport, CLI) |
+| `verify_vp.py` | VP+VC verifizieren (`verify_presentation`, CLI) |
+| `did_web.py` | `did:web`-Dokumente bauen/auflösen (CLI) |
+| `did_peer4.py` | `did:peer:4` (abhängigkeitsfrei) |
+| `did_github.py` | `did:github`-Auflösung über GitHub-Rohinhalte |
+| `ed25519.py` | Lern-Referenz Ed25519 (nicht für Produktion) |
+| `diddoc.py` | Demo: DIDComm-JWS |
+
+## Schnellstart (Bibliothek)
+
+```python
+from sdata.did import (
+    gen_ed25519_jwk, pub_from_priv_jwk, did_key_from_jwk_ed25519,
+    sign_compact, verify_compact,
+)
+
+jwk = gen_ed25519_jwk()                       # privates JWK (x + d)
+pub = pub_from_priv_jwk(jwk)                   # nur x
+did = did_key_from_jwk_ed25519(pub)           # did:key:z…
+kid = f"{did}#{did.split(':', 2)[2]}"
+
+jws = sign_compact({"hello": "world"}, jwk, kid=kid, typ="JWT")
+assert verify_compact(jws, pub)["hello"] == "world"
+```
+
+### VC ausstellen & Presentation verifizieren
+
+```python
+from sdata.did import verify_presentation, VerificationError
+
+result = verify_presentation(vp_jws, expected_aud="https://verifier.example.org",
+                             expected_nonce=nonce)
+print(result["issuer"], result["credentialSubject"]["gtin"])
+```
+
+## CLI (als Modul, `-m`)
+
+```bash
+# Schlüssel
+python -m sdata.did.keys gen   --out issuer_key.json
+python -m sdata.did.keys pub   --in  issuer_key.json --out issuer_pub.json
+python -m sdata.did.keys thumb --in  issuer_pub.json
+
+# did:web-Dokument
+python -m sdata.did.did_web build --domain example.com \
+    --pub issuer_pub.json --out did.json --format jwk
+python -m sdata.did.did_web resolve --kid did:web:example.com#key-1
+
+# VC ausstellen / VP verifizieren
+python -m sdata.did.issue_vc --issuer-domain issuer.example \
+    --issuer-key issuer_key.json --gtin 04012345678901 --serial SN-42 \
+    --co2 12.5 --recycled 80 --out product.vc
+python -m sdata.did.verify_vp --vp product.vp \
+    --expected-aud https://verifier.example.org
+```
+
+## Tests
+
+```bash
+pytest tests/test_did.py
+```
+
+Die Tests laufen ohne Netzwerk (HTTP wird gemockt) und überspringen sich
+sauber (`skip`), falls optionale Abhängigkeiten fehlen.

--- a/sdata/did/__init__.py
+++ b/sdata/did/__init__.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""``sdata.did`` – Decentralized Identifiers (DID) & Verifiable Credentials (VC).
+
+Dieses Subpackage bündelt eine schlanke, **pure-Python** Umsetzung gängiger
+SSI-Bausteine (Self-Sovereign Identity) rund um Ed25519:
+
+============================  ====================================================
+Bereich                       Modul / Funktionen
+============================  ====================================================
+Schlüssel (Ed25519/JWK)       :mod:`~sdata.did.keys` – :func:`gen_ed25519_jwk`, :func:`pub_from_priv_jwk`
+JWK / did:key / Thumbprint    :mod:`~sdata.did.utils_didkey`
+JOSE / Compact-JWS (EdDSA)    :mod:`~sdata.did.jose` – :func:`sign_compact`, :func:`verify_compact`
+VC / VP ausstellen            :mod:`~sdata.did.issue_vc` – :func:`issue_vc`, :func:`make_vp`
+VC / VP verifizieren          :mod:`~sdata.did.verify_vp` – :func:`verify_presentation`
+did:web                       :mod:`~sdata.did.did_web` – :func:`build_did_document`, :func:`resolve_did_web`
+did:key                       :mod:`~sdata.did.utils_didkey` – :func:`did_key_from_jwk_ed25519`, :func:`pub_jwk_from_did_key`
+did:peer:4                    :mod:`~sdata.did.did_peer4` – :func:`did_peer4_from_payload`, :func:`resolve_long_form`
+did:github                    :mod:`~sdata.did.did_github` – :func:`resolve_did_github`
+============================  ====================================================
+
+Unterstützte Standards: W3C DID Core, did:web, did:key, did:peer:4,
+W3C Verifiable Credentials (JWT-VC), JOSE/JWS (RFC 7515), EdDSA (RFC 8037),
+JWK-Thumbprint (RFC 7638).
+
+Installation
+------------
+Die DID-Funktionen benötigen die Extra-Abhängigkeiten ``ecdsa`` und ``base58``::
+
+    pip install "sdata[did]"
+
+.. warning::
+   **Sicherheit / SOTA-Hinweis.** Der produktive Krypto-Pfad nutzt
+   ``python-ecdsa`` (reine Python-Implementierung von Ed25519). Diese ist
+   bewusst dependency-arm, aber **nicht garantiert constant-time** und damit
+   potenziell anfällig für Timing-Seitenkanäle. Für hochsensible Umgebungen ein
+   libsodium-Backend (PyNaCl) oder ``cryptography`` (OpenSSL) erwägen.
+   Das Modul :mod:`sdata.did.ed25519` ist eine reine **Lern-Referenz** und
+   wird vom Funktionspfad nicht verwendet.
+
+Beispiel
+--------
+::
+
+    from sdata.did import (gen_ed25519_jwk, pub_from_priv_jwk,
+                           did_key_from_jwk_ed25519, sign_compact, verify_compact)
+
+    jwk = gen_ed25519_jwk()
+    did = did_key_from_jwk_ed25519(pub_from_priv_jwk(jwk))
+    kid = f"{did}#{did.split(':', 2)[2]}"
+    jws = sign_compact({"hello": "world"}, jwk, kid=kid, typ="JWT")
+    assert verify_compact(jws, pub_from_priv_jwk(jwk))["hello"] == "world"
+"""
+from __future__ import annotations
+
+import importlib
+
+# Lazy-Loading (PEP 562): Submodule werden erst beim Zugriff importiert. Vorteile:
+#   * ``python -m sdata.did.<modul>`` löst keine runpy-Doppelimport-Warnung aus,
+#   * ``import sdata.did`` ist leichtgewichtig – die optionalen Krypto-Deps
+#     (ecdsa/base58) werden erst geladen, wenn eine sie nutzende Funktion
+#     tatsächlich angefasst wird.
+# Mapping: exportierter Name -> "submodul"  oder  ("submodul", "originalname").
+_EXPORTS = {
+    # Fehler
+    "DidError": "errors", "EncodingError": "errors",
+    "ResolutionError": "errors", "VerificationError": "errors",
+    # Schlüssel / JWK / did:key
+    "gen_ed25519_jwk": "keys", "pub_from_priv_jwk": "keys",
+    "b64url": "utils_didkey", "b64url_decode": "utils_didkey",
+    "jwk_thumbprint_rfc7638": "utils_didkey",
+    "did_key_from_jwk_ed25519": "utils_didkey",
+    "did_key_fragment_from_jwk": "utils_didkey",
+    "pub_jwk_from_did_key": "utils_didkey",
+    "kid_for_did_web": "utils_didkey", "kid_for_did_key": "utils_didkey",
+    # JOSE / JWS
+    "sign_compact": "jose", "verify_compact": "jose", "decode_header": "jose",
+    # VC / VP
+    "issue_vc": "issue_vc", "make_vp": "issue_vc", "sign_compact_jws": "issue_vc",
+    "verify_presentation": "verify_vp", "jws_header": "verify_vp",
+    "jws_verify": "verify_vp", "resolve_public_jwk_for_kid": "verify_vp",
+    # DID-Methoden
+    "build_did_document": "did_web", "did_web_to_url": "did_web",
+    "resolve_did_web": ("did_web", "resolve_public_jwk_for_kid"),
+    "did_peer4_from_payload": "did_peer4", "resolve_long_form": "did_peer4",
+    "resolve_did_github": "did_github", "parse_did_github": "did_github",
+}
+
+
+def __getattr__(name):
+    """Importiere das zugehörige Submodul beim ersten Zugriff (PEP 562)."""
+    target = _EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(
+            "module {!r} has no attribute {!r}".format(__name__, name))
+    modname, attrname = target if isinstance(target, tuple) else (target, name)
+    mod = importlib.import_module("." + modname, __name__)
+    value = getattr(mod, attrname)
+    globals()[name] = value  # cachen, damit __getattr__ nur einmal feuert
+    return value
+
+
+def __dir__():
+    return sorted(__all__)
+
+
+__all__ = [
+    # Fehler
+    "DidError", "EncodingError", "ResolutionError", "VerificationError",
+    # Schlüssel / JWK / did:key
+    "gen_ed25519_jwk", "pub_from_priv_jwk",
+    "b64url", "b64url_decode", "jwk_thumbprint_rfc7638",
+    "did_key_from_jwk_ed25519", "did_key_fragment_from_jwk", "pub_jwk_from_did_key",
+    "kid_for_did_web", "kid_for_did_key",
+    # JOSE / JWS
+    "sign_compact", "verify_compact", "decode_header",
+    # VC / VP
+    "issue_vc", "make_vp", "sign_compact_jws",
+    "verify_presentation", "resolve_public_jwk_for_kid", "jws_header", "jws_verify",
+    # DID-Methoden
+    "build_did_document", "did_web_to_url", "resolve_did_web",
+    "did_peer4_from_payload", "resolve_long_form",
+    "resolve_did_github", "parse_did_github",
+]

--- a/sdata/did/did_github.py
+++ b/sdata/did/did_github.py
@@ -1,26 +1,54 @@
+# -*- coding: utf-8 -*-
+"""``did:github``: DID-Dokumente aus GitHub-Repositories auflösen.
+
+Eine ``did:github``-DID verweist auf ein ``did.json`` in einem GitHub-Repo und
+wird über ``raw.githubusercontent.com`` geladen. Formen::
+
+    did:github:<user>:<repo>
+    did:github:<user>:<repo>:<ref>
+    did:github:<user>:<repo>:<ref>:<subpath>
+
+Im ``subpath`` darf ``__`` als ``/``-Ersatz verwendet werden (CLI-freundlich).
+Gesucht werden ``<subpath>/.well-known/did.json``, ``<subpath>/did.json`` sowie
+die Repo-Wurzel – in dieser Reihenfolge, für die Refs ``<ref>``, ``main``, ``master``.
+
+Ein optionales ``GITHUB_TOKEN`` (Umgebungsvariable) erhöht das Rate-Limit und
+erlaubt Zugriff auf private Repos.
+
+.. note::
+   ``did:github`` ist **keine** registrierte W3C-DID-Methode, sondern eine
+   pragmatische, projektspezifische Auflösung über GitHub-Rohinhalte.
+"""
 from __future__ import annotations
 
 import os
 import re
 import json
+import logging
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Optional, Tuple, List
+from typing import List, Optional, Tuple
 
 import requests
 
+from .errors import EncodingError, ResolutionError
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["DidGithub", "parse_did_github", "resolve_did_github"]
 
 DID_GITHUB_METHOD = "did:github"
 RAW_BASE = "https://raw.githubusercontent.com"
+HTTP_TIMEOUT = 10
 
 
 @dataclass(frozen=True)
 class DidGithub:
-    """Interne Repräsentation von did:github Identifiers."""
+    """Geparste ``did:github``-Identität."""
     user: str
     repo: str
-    ref: Optional[str] = None           # z.B. "main", "master", Tag oder Commit
-    subpath: Optional[str] = None       # optionaler Unterordner innerhalb des Repos
+    ref: Optional[str] = None       # z. B. "main", "master", Tag oder Commit
+    subpath: Optional[str] = None   # optionaler Unterordner im Repo
 
     @property
     def did(self) -> str:
@@ -32,140 +60,94 @@ class DidGithub:
         return ":".join(parts)
 
 
-def parse_did_github(did: str) -> DidGithub:
-    """
-    Erwartete Formen:
-      - did:github:<user>:<repo>
-      - did:github:<user>:<repo>:<ref>
-      - did:github:<user>:<repo>:<ref>:<subpath-with-slashes-replaced-by-__>
-      - oder mit beliebigen weiteren :... Segmenten → subpath kann Doppelpunkte enthalten,
-        wir mappen diese später auf '/'. Praktischer ist unten make_subpath().
-    """
-    if not did.startswith(DID_GITHUB_METHOD + ":"):
-        raise ValueError("Kein did:github Identifier")
-
-    parts = did.split(":")
-    if len(parts) < 4:
-        raise ValueError("Form: did:github:<user>:<repo>[:<ref>[:<subpath>]]")
-
-    _, _, user, repo, *rest = parts
-    ref = rest[0] if rest else None
-    subpath = ":".join(rest[1:]) if len(rest) > 1 else None
-
-    # Optionales Mapping: Erlaube __ als Slash-Ersatz im subpath (CLI-freundlich)
-    subpath = make_subpath(subpath)
-    return DidGithub(user=user, repo=repo, ref=ref, subpath=subpath)
-
-
 def make_subpath(raw: Optional[str]) -> Optional[str]:
+    """Mappe ``__`` auf ``/`` (echte Slashes bleiben erhalten)."""
     if not raw:
         return None
-    # Erlaube zwei Schreibweisen:
-    # 1) raw enthält echte Slashes → übernehmen
-    # 2) raw verwendet "__" als Platzhalter für '/' → zurückmappen
     return raw.replace("__", "/")
 
 
-def candidate_paths(dg: DidGithub) -> List[Tuple[str, str]]:
-    """
-    Liefert eine geordnete Liste (ref, path) von Kandidaten
-    für die Auflösung. path ist der Pfad *im Repo*.
-    """
-    well_known = ".well-known/did.json"
-    root = "did.json"
+def parse_did_github(did: str) -> DidGithub:
+    """Parse eine ``did:github``-DID.
 
-    # Wenn Subpath angegeben: dort zuerst suchen
+    Raises:
+        EncodingError: wenn ``did`` keine gültige ``did:github``-DID ist.
+    """
+    if not did.startswith(DID_GITHUB_METHOD + ":"):
+        raise EncodingError("kein did:github-Identifier")
+    parts = did.split(":")
+    if len(parts) < 4:
+        raise EncodingError("Form: did:github:<user>:<repo>[:<ref>[:<subpath>]]")
+    _, _, user, repo, *rest = parts
+    ref = rest[0] if rest else None
+    subpath = make_subpath(":".join(rest[1:]) if len(rest) > 1 else None)
+    return DidGithub(user=user, repo=repo, ref=ref, subpath=subpath)
+
+
+def candidate_paths(dg: DidGithub) -> List[Tuple[str, str]]:
+    """Geordnete ``(ref, path)``-Kandidaten für die Auflösung."""
+    well_known, root = ".well-known/did.json", "did.json"
     sub_candidates = []
     if dg.subpath:
-        sub_candidates = [f"{dg.subpath.rstrip('/')}/{well_known}",
-                          f"{dg.subpath.rstrip('/')}/{root}"]
-
-    base_candidates = [well_known, root]
-
-    paths = sub_candidates + base_candidates
-
-    # Branch-/Ref-Reihenfolge
+        base = dg.subpath.rstrip("/")
+        sub_candidates = ["{}/{}".format(base, well_known), "{}/{}".format(base, root)]
+    paths = sub_candidates + [well_known, root]
     refs = [r for r in [dg.ref, "main", "master"] if r]
-
     return [(r, p) for r in refs for p in paths]
 
 
 def _raw_url(user: str, repo: str, ref: str, path: str) -> str:
-    return f"{RAW_BASE}/{user}/{repo}/{ref}/{path}"
+    return "{}/{}/{}/{}/{}".format(RAW_BASE, user, repo, ref, path)
 
 
 def _headers() -> dict:
-    h = {"Accept": "application/json"}
+    headers = {"Accept": "application/json"}
     token = os.getenv("GITHUB_TOKEN")
     if token:
-        # Höhere Ratenlimits und private Repos (falls Token Zugriff hat)
-        h["Authorization"] = f"Bearer {token}"
-    return h
-
-
-@lru_cache(maxsize=256)
-def fetch_json(url: str) -> Optional[dict]:
-    resp = requests.get(url, headers=_headers(), timeout=10)
-    if resp.status_code == 200:
-        try:
-            return json.loads(resp.text)
-        except json.JSONDecodeError:
-            # Manchmal ist die Datei als JSON-LD mit Kommentaren gespeichert → optional säubern
-            cleaned = _strip_json_comments(resp.text)
-            return json.loads(cleaned)
-    return None
+        headers["Authorization"] = "Bearer {}".format(token)
+    return headers
 
 
 def _strip_json_comments(text: str) -> str:
-    # rudimentär: entferne // ... und /* ... */ (nur für einfache Fälle)
+    """Entferne ``/* … */`` und ``// …`` (rudimentär, für einfache Fälle)."""
     text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
     text = re.sub(r"//.*?$", "", text, flags=re.M)
     return text
 
 
+@lru_cache(maxsize=256)
+def fetch_json(url: str) -> Optional[dict]:
+    """Lade JSON von ``url`` (mit kleinem Cache); ``None`` bei Status != 200."""
+    resp = requests.get(url, headers=_headers(), timeout=HTTP_TIMEOUT)
+    if resp.status_code != 200:
+        return None
+    try:
+        return json.loads(resp.text)
+    except json.JSONDecodeError:
+        return json.loads(_strip_json_comments(resp.text))
+
+
 def resolve_did_github(did: str) -> dict:
-    """
-    Gibt das DID-Dokument (dict) zurück oder wirft ValueError.
-    Validiert minimale DID-Core-Felder.
+    """Löse eine ``did:github``-DID zum DID-Dokument auf.
+
+    Raises:
+        EncodingError: bei ungültiger DID.
+        ResolutionError: wenn kein gültiges ``did.json`` gefunden wird.
+        EncodingError: wenn ein gefundenes Dokument ``@context``/``id`` vermisst.
     """
     dg = parse_did_github(did)
     tried = []
-
     for ref, path in candidate_paths(dg):
         url = _raw_url(dg.user, dg.repo, ref, path)
         tried.append(url)
         doc = fetch_json(url)
         if doc is None:
             continue
-
-        # Minimale Validierung
         if "@context" not in doc:
-            raise ValueError(f"DID-Dokument gefunden, aber @context fehlt ({url})")
+            raise EncodingError("DID-Dokument ohne @context ({})".format(url))
         if "id" not in doc:
-            raise ValueError(f"DID-Dokument gefunden, aber id fehlt ({url})")
-
-        # Optional: Konsistenzprüfung der id
-        # Wir tolerieren Abweichungen, warnen aber per Exception-Message, wenn strenger Modus gewünscht ist
-        # Hier permissiv:
+            raise EncodingError("DID-Dokument ohne id ({})".format(url))
+        logger.debug("did:github aufgelöst via %s", url)
         return doc
-
-    raise ValueError(
-        "did:github konnte nicht aufgelöst werden.\n"
-        f"Versuchte URLs:\n- " + "\n- ".join(tried)
-    )
-
-
-# ---------- Beispielnutzung ----------
-if __name__ == "__main__":
-    # Beispiele:
-    did = "did:github:lepy:cudi2"
-    did = "did:github:lepy:cudi2:main"
-    # did = "did:github:lepy:cudi2:main:did"          # sucht did/.well-known/did.json etc.
-    # did = "did:github:orgname:repo123:v1.2.3"
-    #did = os.environ.get("DID_EXAMPLE", "did:github:someone:some-repo")
-
-    try:
-        doc = resolve_did_github(did)
-        print(json.dumps(doc, indent=2, ensure_ascii=False))
-    except Exception as e:
-        print(f"Fehler: {e}")
+    raise ResolutionError(
+        "did:github konnte nicht aufgelöst werden. Versucht:\n- " + "\n- ".join(tried))

--- a/sdata/did/did_peer4.py
+++ b/sdata/did/did_peer4.py
@@ -1,34 +1,66 @@
-import json, hashlib
+# -*- coding: utf-8 -*-
+"""``did:peer:4``: statische, self-zertifizierende Peer-DIDs (Long-/Short-Form).
+
+Diese Implementierung ist bewusst **abhängigkeitsfrei** (nur Standardbibliothek)
+und bringt eine eigene base58btc- und varint-Kodierung mit – passend zum
+pure-Python-Designziel des Subpackages.
+
+Aufbau einer Long-Form::
+
+    did:peer:4{hash}:{encoded_document}
+
+* ``encoded_document`` = multibase(base58btc, multicodec(JSON) + kanonisches JSON),
+* ``hash``             = multibase(base58btc, multihash(sha2-256, encoded_document)).
+
+Die Short-Form ``did:peer:4{hash}`` ist self-zertifizierend: beim Auflösen der
+Long-Form wird der Hash gegen das eingebettete Dokument validiert.
+
+Referenzen:
+    * `did:peer Method, Variante 4 <https://identity.foundation/peer-did-method-spec/>`_
+"""
+from __future__ import annotations
+
+import json
+import hashlib
 from typing import Dict, Tuple
 
-# --- Base58 (BTC) ------------------------------------------------------------
-_B58_ALPHABET = b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+from .errors import EncodingError, VerificationError
+
+__all__ = ["did_peer4_from_payload", "resolve_long_form", "b58encode", "b58decode"]
+
+# --- Base58 (Bitcoin-Alphabet) --------------------------------------------
+_B58_ALPHABET = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
 def b58encode(b: bytes) -> str:
-    n = int.from_bytes(b, 'big', signed=False)
+    """Kodiere Bytes als base58btc (führende Nullbytes bleiben als ``1`` erhalten)."""
+    n = int.from_bytes(b, "big", signed=False)
     out = bytearray()
     while n > 0:
         n, r = divmod(n, 58)
         out.append(_B58_ALPHABET[r])
-    # führende Nullen beibehalten
     pad = 0
     for byte in b:
         if byte == 0:
             pad += 1
         else:
             break
-    return ('1' * pad) + out[::-1].decode()
+    return ("1" * pad) + out[::-1].decode()
+
 
 def b58decode(s: str) -> bytes:
+    """Dekodiere einen base58btc-String zurück zu Bytes."""
     n = 0
     for ch in s.encode():
         n = n * 58 + _B58_ALPHABET.index(ch)
-    # führende '1' -> führende 0x00
-    pad = len(s) - len(s.lstrip('1'))
-    full = n.to_bytes((n.bit_length() + 7) // 8, 'big') if n else b''
-    return b'\x00' * pad + full
+    pad = len(s) - len(s.lstrip("1"))
+    full = n.to_bytes((n.bit_length() + 7) // 8, "big") if n else b""
+    return b"\x00" * pad + full
 
-# --- Varint (LEB128, wie in multicodec) -------------------------------------
+
+# --- Varint (LEB128, wie in multicodec) -----------------------------------
 def varint_encode(n: int) -> bytes:
+    """Kodiere ``n`` als unsigned LEB128-varint."""
     out = bytearray()
     while True:
         to_write = n & 0x7F
@@ -40,156 +72,110 @@ def varint_encode(n: int) -> bytes:
             break
     return bytes(out)
 
-# --- Multicodec & Multihash Konstanten ---------------------------------------
-# multicodec für JSON = 0x0200 (siehe Spezifikation)
-MULTICODEC_JSON = 0x0200
-# multihash: sha2-256 = 0x12, Länge 32 Bytes = 0x20
-MH_SHA256 = 0x12
+
+def varint_decode(b: bytes) -> Tuple[int, int]:
+    """Dekodiere einen unsigned LEB128-varint; gibt ``(wert, gelesene_bytes)`` zurück."""
+    shift = 0
+    value = 0
+    for i, byte in enumerate(b):
+        value |= (byte & 0x7F) << shift
+        if not (byte & 0x80):
+            return value, i + 1
+        shift += 7
+    raise EncodingError("ungültiger varint")
+
+
+# --- Multicodec- & Multihash-Konstanten -----------------------------------
+MULTICODEC_JSON = 0x0200   # multicodec-Code für JSON
+MH_SHA256 = 0x12           # multihash: sha2-256
 MH_SHA256_LEN = 32
 
+
 def _canonical_json_bytes(payload: Dict) -> bytes:
-    # Stabil: Keys sortieren, keine Spaces (für deterministische Hashes)
-    s = json.dumps(payload, separators=(',', ':'), sort_keys=True, ensure_ascii=False)
-    return s.encode('utf-8')
+    """Deterministische JSON-Serialisierung (Keys sortiert, ohne Whitespace)."""
+    s = json.dumps(payload, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+    return s.encode("utf-8")
+
 
 def encode_document(payload: Dict) -> bytes:
-    """
-    Multicodec-„Framing“: varint(code) + raw JSON bytes
-    """
+    """Multicodec-Framing: ``varint(JSON-Code) + kanonisches JSON``."""
     return varint_encode(MULTICODEC_JSON) + _canonical_json_bytes(payload)
 
+
 def multibase_b58btc(data: bytes) -> str:
-    return 'z' + b58encode(data)
+    """Präfix ``z`` (base58btc) gemäß Multibase."""
+    return "z" + b58encode(data)
+
 
 def multihash_sha256(data: bytes) -> bytes:
-    digest = hashlib.sha256(data).digest()
-    return bytes([MH_SHA256, MH_SHA256_LEN]) + digest
+    """``multihash(sha2-256, data)`` = ``0x12 0x20 || sha256(data)``."""
+    return bytes([MH_SHA256, MH_SHA256_LEN]) + hashlib.sha256(data).digest()
 
-# ---------------- did:peer:4 Erzeugung & Auflösung ---------------------------
+
+# --- did:peer:4 Erzeugung & Auflösung -------------------------------------
 def did_peer4_from_payload(payload: Dict) -> Tuple[str, str, Dict]:
+    """Erzeuge Long-Form, Short-Form und kontextualisiertes DID-Dokument.
+
+    Args:
+        payload: DID-Dokument **ohne** ``id`` (relative Fragmente wie ``#key-0``
+            sind erlaubt).
+
+    Returns:
+        ``(long_form, short_form, did_document)``.
     """
-    Erzeugt:
-      - long_form: did:peer:4{hash_b58mb}:{doc_b58mb}
-      - short_form: did:peer:4{hash_b58mb}
-    und gibt zusätzlich das „kontextualisierte“ DID Document zurück.
-    """
-    # 1) Encoded Document (multicodec-framed JSON), dann multibase (b58btc)
     encoded_doc_bytes = encode_document(payload)
-    encoded_doc_mb = multibase_b58btc(encoded_doc_bytes)   # 'z...'
+    encoded_doc_mb = multibase_b58btc(encoded_doc_bytes)
+    mh_mb = multibase_b58btc(multihash_sha256(encoded_doc_bytes))
 
-    # 2) Hash über die *roh bytes* des encoded_doc (multicodec+json)
-    #    (Hinweis: Einige Implementierungen hashen die selben Bytes; wenn du
-    #    stattdessen die multibase-Zeichenkette hashen willst, tausche data=...)
-    mh = multihash_sha256(encoded_doc_bytes)
-    mh_mb = multibase_b58btc(mh)
-
-    long_form = f"did:peer:4{mh_mb}:{encoded_doc_mb}"
-    short_form = f"did:peer:4{mh_mb}"
-
+    long_form = "did:peer:4{}:{}".format(mh_mb, encoded_doc_mb)
+    short_form = "did:peer:4{}".format(mh_mb)
     did_doc = _contextualize_did_doc(payload, did_long=long_form, did_short=short_form)
     return long_form, short_form, did_doc
 
+
 def resolve_long_form(did_long: str) -> Dict:
-    """
-    Löst eine Long-Form did:peer:4 auf:
-      - extrahiert hash & encoded document
-      - validiert Hash
-      - setzt id/controller/alsoKnownAs
+    """Löse eine Long-Form ``did:peer:4`` auf und validiere den Hash.
+
+    Raises:
+        EncodingError: bei strukturell ungültiger DID oder falschem multicodec/multihash.
+        VerificationError: wenn der eingebettete Hash nicht zum Dokument passt.
     """
     if not did_long.startswith("did:peer:4"):
-        raise ValueError("Kein did:peer:4")
+        raise EncodingError("keine did:peer:4")
     try:
         _, rest = did_long.split("did:peer:4", 1)
         hash_mb, doc_mb = rest.split(":", 1)
     except ValueError:
-        raise ValueError("Erwarte Long-Form: did:peer:4{hash}:{doc}")
+        raise EncodingError("erwarte Long-Form: did:peer:4{hash}:{doc}")
 
-    if not (hash_mb.startswith('z') and doc_mb.startswith('z')):
-        raise ValueError("Erwarte multibase base58-btc ('z'-Präfix)")
+    if not (hash_mb.startswith("z") and doc_mb.startswith("z")):
+        raise EncodingError("erwarte multibase base58btc ('z'-Präfix)")
 
     mh = b58decode(hash_mb[1:])
     encoded_doc_bytes = b58decode(doc_mb[1:])
 
-    # validate multicodec prefix
-    # decode varint (einfaches Lesen)
-    def varint_decode(b: bytes) -> Tuple[int, int]:
-        shift = 0; value = 0
-        for i, byte in enumerate(b):
-            value |= (byte & 0x7F) << shift
-            if not (byte & 0x80):
-                return value, i + 1
-            shift += 7
-        raise ValueError("Ungültige varint")
-
     code, offset = varint_decode(encoded_doc_bytes)
     if code != MULTICODEC_JSON:
-        raise ValueError("Multicodec-Code ist nicht JSON (0x0200)")
+        raise EncodingError("multicodec-Code ist nicht JSON (0x0200)")
     json_bytes = encoded_doc_bytes[offset:]
 
-    # verify multihash (sha2-256, 32)
     if len(mh) < 2 or mh[0] != MH_SHA256 or mh[1] != MH_SHA256_LEN:
-        raise ValueError("Multihash nicht sha2-256/32")
-    expected = hashlib.sha256(encoded_doc_bytes).digest()
-    if mh[2:] != expected:
-        raise ValueError("Hash-Validierung fehlgeschlagen")
+        raise EncodingError("multihash ist nicht sha2-256/32")
+    if mh[2:] != hashlib.sha256(encoded_doc_bytes).digest():
+        raise VerificationError("Hash-Validierung fehlgeschlagen")
 
-    payload = json.loads(json_bytes.decode('utf-8'))
-    did_short = f"did:peer:4{'z'+b58encode(mh)}"
-    did_doc = _contextualize_did_doc(payload, did_long=did_long, did_short=did_short)
-    return did_doc
+    payload = json.loads(json_bytes.decode("utf-8"))
+    did_short = "did:peer:4{}".format(multibase_b58btc(mh))
+    return _contextualize_did_doc(payload, did_long=did_long, did_short=did_short)
+
 
 def _contextualize_did_doc(payload: Dict, *, did_long: str, did_short: str) -> Dict:
-    """
-    Setzt 'id', 'alsoKnownAs' und füllt fehlende 'controller' in verificationMethod.
-    Relative Fragments (#key-0) bleiben gültig.
-    """
-    doc = json.loads(json.dumps(payload))  # flache Kopie
-    doc['id'] = did_long
-    doc.setdefault('alsoKnownAs', [])
-    if did_short not in doc['alsoKnownAs']:
-        doc['alsoKnownAs'].append(did_short)
-
-    for vm in doc.get('verificationMethod', []):
-        vm.setdefault('controller', did_long)
-
-        # Falls relative IDs ohne DID: auf DID referenzierbar lassen; Resolver dürfen
-        # „as-is“ belassen, viele Implementierungen lassen "#key-0" stehen.
-
-    # Gleiches Schema für andere Beziehungen (authentication, assertionMethod, service ...)
+    """Setze ``id``/``alsoKnownAs`` und ergänze fehlende ``controller``-Felder."""
+    doc = json.loads(json.dumps(payload))  # tiefe Kopie
+    doc["id"] = did_long
+    doc.setdefault("alsoKnownAs", [])
+    if did_short not in doc["alsoKnownAs"]:
+        doc["alsoKnownAs"].append(did_short)
+    for vm in doc.get("verificationMethod", []):
+        vm.setdefault("controller", did_long)
     return doc
-
-# --------------------------- Demo --------------------------------------------
-if __name__ == "__main__":
-    # Minimale Beispiel-Payload (ohne root 'id'!)
-    payload = {
-        "@context": ["https://www.w3.org/ns/did/v1"],
-        "verificationMethod": [{
-            "id": "#key-0",
-            "type": "JsonWebKey2020",
-            "publicKeyJwk": {
-                "kty": "OKP",
-                "crv": "Ed25519",
-                # Beispielwert; hier gehört dein Base64url-encodierter Ed25519 Public Key rein:
-                "x": "qhqVmPevNBx1W-amRiTzOizsqtVHiOVGQMRMBM29cE0"
-            }
-            # 'controller' wird beim Kontextualisieren gesetzt
-        }],
-        "authentication": ["#key-0"],
-        "assertionMethod": ["#key-0"],
-        "service": [{
-            "id": "#inbox",
-            "type": "DIDCommMessaging",
-            "serviceEndpoint": "https://example.org/inbox"
-        }]
-    }
-
-    did_long, did_short, did_doc = did_peer4_from_payload(payload)
-    print("LONG :", did_long)
-    print("SHORT:", did_short)
-
-    # Auflösung (inkl. Hash-Validierung)
-    resolved = resolve_long_form(did_long)
-    assert resolved['id'] == did_long
-    assert did_short in resolved.get('alsoKnownAs', [])
-    print("OK: resolve_long_form() validiert und kontextualisiert.")
-    print(resolved)

--- a/sdata/did/did_web.py
+++ b/sdata/did/did_web.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+"""``did:web``: DID-Dokumente erzeugen und über HTTPS auflösen.
+
+Zwei Schlüsseldarstellungen werden unterstützt:
+
+* **JWK** (empfohlen für JWS/JWT): ``JsonWebKey2020`` + ``publicKeyJwk`` (jws-2020),
+* **Multibase**: ``Ed25519VerificationKey2020`` + ``publicKeyMultibase`` (ed25519-2020).
+
+``did:web:example.com`` wird zu ``https://example.com/.well-known/did.json``
+aufgelöst; mit Pfadanteilen (``did:web:example.com:user:alice``) entsprechend zu
+``https://example.com/user/alice/did.json``.
+
+CLI::
+
+    python -m sdata.did.did_web build --domain example.com \\
+        --pub issuer_pub.json --out did.json --format jwk
+    python -m sdata.did.did_web resolve --kid did:web:example.com#key-1
+
+Referenzen:
+    * `did:web Method <https://w3c-ccg.github.io/did-method-web/>`_
+"""
+from __future__ import annotations
+
+import json
+import logging
+import argparse
+from urllib.parse import quote
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import requests
+import base58
+
+from .errors import EncodingError, ResolutionError
+from .utils_didkey import pub_jwk_from_did_key, b64url_decode
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["build_did_document", "did_web_to_url", "resolve_public_jwk_for_kid"]
+
+JWS2020_CONTEXT = "https://w3id.org/security/suites/jws-2020/v1"
+ED25519_2020_CONTEXT = "https://w3id.org/security/suites/ed25519-2020/v1"
+DID_CORE_CONTEXT = "https://www.w3.org/ns/did/v1"
+
+#: HTTP-Timeout (Sekunden) für die Auflösung.
+HTTP_TIMEOUT = 15
+
+
+def did_web(domain: str) -> str:
+    """``'example.com'`` → ``'did:web:example.com'``."""
+    return "did:web:{}".format(domain)
+
+
+def _load_pub_input(path: str) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Lade die ``--pub``-Eingabe.
+
+    Returns:
+        ``("jwk", jwk_dict)`` oder ``("multibase", {"mb": "z…"})``.
+
+    Akzeptiert ein JWK-JSON (``kty=OKP``/``crv=Ed25519``/``x``), ein
+    ``{"multibase": "z…"}``-JSON oder eine Textdatei mit einem ``z…``-String.
+
+    Raises:
+        EncodingError: wenn die Eingabe weder JWK noch gültige Multibase ist.
+    """
+    text = Path(path).read_text().strip()
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError:
+        obj = None
+
+    if isinstance(obj, dict):
+        if obj.get("kty") == "OKP" and obj.get("crv") == "Ed25519" and "x" in obj:
+            return "jwk", obj
+        if "multibase" in obj and str(obj["multibase"]).startswith("z"):
+            return "multibase", {"mb": str(obj["multibase"])}
+
+    if text.startswith("z"):
+        return "multibase", {"mb": text}
+
+    raise EncodingError(
+        "--pub '{}' ist weder JWK-JSON noch eine gültige Multibase (z…)".format(path))
+
+
+def _did_context(add_security: str, variant: str):
+    """Stelle die ``@context``-Liste zusammen (``add_security``: 'auto'|'on'|'off')."""
+    ctx = [DID_CORE_CONTEXT]
+    if add_security == "off":
+        return ctx
+    security = JWS2020_CONTEXT if variant == "jwk" else ED25519_2020_CONTEXT
+    ctx.append(security)
+    return ctx
+
+
+def build_did_document(domain: str, public_input_path: str,
+                       key_id_suffix: str = "key-1", variant: str = "jwk",
+                       add_security_context: str = "auto") -> Dict[str, Any]:
+    """Erzeuge ein DID-Dokument (``did.json``) für ``did:web:<domain>``.
+
+    Args:
+        domain: Domain des Issuers.
+        public_input_path: Pfad zu Public-JWK-JSON **oder** Multibase-Datei.
+        key_id_suffix: Fragment der ``verificationMethod``-ID (Default ``key-1``).
+        variant: ``'jwk'`` (JsonWebKey2020) oder ``'multibase'`` (Ed25519VerificationKey2020).
+        add_security_context: ``'auto'`` | ``'on'`` | ``'off'``.
+
+    Raises:
+        EncodingError: bei ungültiger ``variant`` oder Eingabe.
+    """
+    if variant not in ("jwk", "multibase"):
+        raise EncodingError("variant muss 'jwk' oder 'multibase' sein")
+
+    kind, data = _load_pub_input(public_input_path)
+    did = did_web(domain)
+    vm_id = "{}#{}".format(did, key_id_suffix)
+    ctx = _did_context(add_security_context, variant)
+
+    if variant == "jwk":
+        jwk_pub = pub_jwk_from_did_key(data["mb"]) if kind == "multibase" else data
+        vm = {"id": vm_id, "type": "JsonWebKey2020", "controller": did,
+              "publicKeyJwk": jwk_pub}
+    else:
+        if kind == "jwk":
+            raw = b64url_decode(data["x"])
+            mb = "z" + base58.b58encode(bytes([0xED, 0x01]) + raw).decode()
+        else:
+            mb = data["mb"]
+        vm = {"id": vm_id, "type": "Ed25519VerificationKey2020", "controller": did,
+              "publicKeyMultibase": mb}
+
+    return {
+        "@context": ctx,
+        "id": did,
+        "verificationMethod": [vm],
+        "assertionMethod": [vm_id],
+        "authentication": [vm_id],
+    }
+
+
+def did_web_to_url(did: str) -> str:
+    """Bilde die HTTPS-URL des ``did.json`` für eine ``did:web``-DID.
+
+    Raises:
+        EncodingError: wenn ``did`` keine ``did:web``-DID ist.
+    """
+    if not did.startswith("did:web:"):
+        raise EncodingError("keine did:web-DID: {}".format(did))
+    segments = ":".join(did.split(":")[2:]).split(":")
+    host = segments[0]
+    path = "/".join(map(quote, segments[1:]))
+    if path:
+        return "https://{}/{}/did.json".format(host, path)
+    return "https://{}/.well-known/did.json".format(host)
+
+
+def resolve_public_jwk_for_kid(kid: str) -> Dict[str, str]:
+    """Lade das ``did.json`` und liefere immer einen Public-**JWK** zur ``kid``.
+
+    Unterstützt sowohl ``publicKeyJwk`` als auch ``publicKeyMultibase``
+    (Letzteres wird zu JWK konvertiert).
+
+    Raises:
+        ResolutionError: bei Netzwerkfehlern oder wenn die ``kid`` nicht gefunden
+            bzw. kein Schlüsselmaterial vorhanden ist.
+    """
+    did = kid.split("#")[0]
+    url = did_web_to_url(did)
+    try:
+        resp = requests.get(url, timeout=HTTP_TIMEOUT)
+        resp.raise_for_status()
+        doc = resp.json()
+    except requests.RequestException as exc:
+        raise ResolutionError("did:web-Auflösung fehlgeschlagen ({}): {}".format(url, exc))
+
+    by_id = {vm.get("id"): vm for vm in doc.get("verificationMethod", [])}
+    vm = by_id.get(kid)
+    if not vm:
+        raise ResolutionError("Schlüssel {} nicht im did.json gefunden".format(kid))
+
+    if "publicKeyJwk" in vm:
+        return vm["publicKeyJwk"]
+    mb = vm.get("publicKeyMultibase")
+    if isinstance(mb, str) and mb.startswith("z"):
+        return pub_jwk_from_did_key(mb)
+    raise ResolutionError("weder publicKeyJwk noch publicKeyMultibase gefunden")
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+def main(argv=None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    ap = argparse.ArgumentParser(description="did:web-Dokumente erzeugen/auflösen")
+    sub = ap.add_subparsers(required=True)
+
+    p = sub.add_parser("build", help="did.json erzeugen")
+    p.add_argument("--domain", required=True)
+    p.add_argument("--pub", required=True, help="Public-JWK-JSON ODER Datei mit Multibase (z…)")
+    p.add_argument("--out", required=True)
+    p.add_argument("--key-id", default="key-1")
+    p.add_argument("--format", choices=["jwk", "multibase"], default="jwk")
+    p.add_argument("--context", choices=["auto", "on", "off"], default="auto")
+    p.set_defaults(cmd="build")
+
+    p = sub.add_parser("resolve", help="Public-JWK per kid auflösen")
+    p.add_argument("--kid", required=True)
+    p.set_defaults(cmd="resolve")
+
+    args = ap.parse_args(argv)
+    if args.cmd == "build":
+        doc = build_did_document(args.domain, args.pub, key_id_suffix=args.key_id,
+                                 variant=args.format, add_security_context=args.context)
+        with open(args.out, "w") as fh:
+            json.dump(doc, fh, indent=2)
+        logger.info("✔ did.json erzeugt: %s", args.out)
+    else:
+        logger.info("%s", json.dumps(resolve_public_jwk_for_kid(args.kid), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/sdata/did/diddoc.py
+++ b/sdata/did/diddoc.py
@@ -1,52 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Lern-/Demo-Modul: Signieren einer DIDComm-Nachricht als Flattened JWS.
+
+.. warning::
+   Nur zu Demonstrationszwecken. Es nutzt :mod:`sdata.did.ed25519`, eine
+   **nicht** für den Produktiveinsatz geeignete (nicht constant-time)
+   Referenzimplementierung. Für echte Anwendungen :mod:`sdata.did.jose`
+   (python-ecdsa) bzw. ein libsodium-Backend verwenden.
+
+Ausführen::
+
+    python -m sdata.did.diddoc
+"""
+from __future__ import annotations
+
 import base64
 import json
-def base64url_encode(data):
-    return base64.urlsafe_b64encode(data).rstrip(b'=')
+import logging
 
-def base64url_decode(data):
-    return base64.urlsafe_b64decode(data + b'=' * (4 - len(data) % 4))
+from .ed25519 import sign, publickey
 
-from sdata.did.ed25519 import signature
+logger = logging.getLogger(__name__)
 
-if __name__ == '__main__':
+__all__ = ["base64url_encode", "base64url_decode", "build_didcomm_jws"]
 
-    # DIDComm-Nachricht als JSON
-    didcomm_message = {
+
+def base64url_encode(data: bytes) -> bytes:
+    return base64.urlsafe_b64encode(data).rstrip(b"=")
+
+
+def base64url_decode(data: bytes) -> bytes:
+    return base64.urlsafe_b64decode(data + b"=" * (4 - len(data) % 4))
+
+
+def build_didcomm_jws(message: dict, seed: bytes, kid: str = "did:example:alice#key-1") -> dict:
+    """Signiere eine DIDComm-Nachricht und gib die Flattened-JWS-Struktur zurück.
+
+    Args:
+        message: Die DIDComm-Nachricht (wird als JSON serialisiert).
+        seed: 32-Byte-Ed25519-Seed (privater Schlüssel; nur Demo!).
+        kid: Schlüssel-ID für den JWS-Header.
+    """
+    pk = publickey(seed)
+    header = {"typ": "JWM", "alg": "EdDSA", "kid": kid}
+    protected = base64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    payload = base64url_encode(json.dumps(message, separators=(",", ":")).encode())
+    sig = sign(protected + b"." + payload, seed, pk)
+    return {
+        "payload": payload.decode("utf-8"),
+        "signatures": [{
+            "protected": protected.decode("utf-8"),
+            "signature": base64url_encode(sig).decode("utf-8"),
+            "header": {"kid": kid},
+        }],
+    }
+
+
+def _demo() -> dict:
+    import os
+    message = {
         "id": "1234567890",
         "type": "http://example.com/protocols/lets_do_lunch/1.0/proposal",
         "from": "did:example:alice",
         "to": ["did:example:bob"],
         "created_time": 1516269022,
         "expires_time": 1516385931,
-        "body": {"messagespecificattribute": "and its value"}
+        "body": {"messagespecificattribute": "and its value"},
     }
-    message_json = json.dumps(didcomm_message, separators=(',', ':')).encode('utf-8')
+    return build_didcomm_jws(message, seed=os.urandom(32))
 
-    # JWS Header
-    header = {
-        "typ": "JWM",
-        "alg": "EdDSA",
-        "kid": "did:example:alice#key-1"
-    }
-    header_json = json.dumps(header, separators=(',', ':')).encode('utf-8')
 
-    protected = base64url_encode(header_json)
-    payload = base64url_encode(message_json)
-    signing_string = protected + b'.' + payload
-
-    # Signiere mit Ed25519 (beachte: DIDComm verwendet die raw Signatur)
-    sig = signature(signing_string, sk, pk)
-    signature_base64 = base64url_encode(sig)
-
-    # Finale JWS-Struktur (Flattened JSON)
-    jws = {
-        "payload": payload.decode('utf-8'),
-        "signatures": [{
-            "protected": protected.decode('utf-8'),
-            "signature": signature_base64.decode('utf-8'),
-            "header": {"kid": header["kid"]}
-        }]
-    }
-
-    print("Signierte DIDComm-Nachricht (JWS):")
-    print(json.dumps(jws, indent=2))
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logger.info("Signierte DIDComm-Nachricht (JWS):")
+    logger.info("%s", json.dumps(_demo(), indent=2))

--- a/sdata/did/ed25519.py
+++ b/sdata/did/ed25519.py
@@ -1,6 +1,21 @@
 # ed25519_typed.py
 """
-Lern-/Test-Implementierung von Ed25519 (pure), nicht constant-time.
+Lern-/Test-Implementierung von Ed25519 (pure Python).
+
+================================ SICHERHEITSHINWEIS ================================
+NICHT FÜR DEN PRODUKTIVEINSATZ GEEIGNET.
+
+Dieser Code dient ausschließlich Lehr- und Testzwecken (z. B. zum Nachvollziehen
+des RFC-8032-Testvektors). Er ist:
+  - NICHT constant-time → anfällig für Timing-/Seitenkanalangriffe, die den
+    privaten Schlüssel preisgeben können,
+  - nicht gehärtet gegen Fault-Injection und andere Angriffe,
+  - nicht unabhängig auditiert.
+
+Für echte Signaturen/Verifikation eine geprüfte Bibliothek verwenden, z. B.
+PyNaCl (libsodium), `cryptography` oder python-ecdsa (wie im übrigen did-Modul).
+===================================================================================
+
 Verwendet:
 - Point: typing.NamedTuple (x, y)
 - KeyPair: @dataclass (sk, pk)
@@ -179,12 +194,16 @@ def keypair_from_seed(seed32: bytes) -> KeyPair:
 # --- Demo & Testvektor ---
 if __name__ == "__main__":
     import os
+    import logging
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logger = logging.getLogger(__name__)
 
     # Demo
     kp = keypair_from_seed(os.urandom(32))
     msg = b"Hallo, DIDComm!"
     sig = sign(msg, kp.sk, kp.pk)
-    print("Sig OK?:", verify(sig, msg, kp.pk))
+    logger.info("Sig OK?: %s", verify(sig, msg, kp.pk))
 
     # RFC 8032 Testvektor (leere Nachricht)
     sk_tv = bytes.fromhex(
@@ -202,5 +221,5 @@ if __name__ == "__main__":
         "d25bf5f0595bbe24655141438e7a100b"
     )
     kp_tv = keypair_from_seed(sk_tv)
-    print("RFC PK OK:", kp_tv.pk == pk_tv)
-    print("RFC SIG OK:", verify(sig_tv, b"", kp_tv.pk))
+    logger.info("RFC PK OK: %s", kp_tv.pk == pk_tv)
+    logger.info("RFC SIG OK: %s", verify(sig_tv, b"", kp_tv.pk))

--- a/sdata/did/errors.py
+++ b/sdata/did/errors.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Ausnahmehierarchie für das :mod:`sdata.did`-Subpackage.
+
+Bibliotheksfunktionen werfen ausschließlich diese Ausnahmen (nie ``SystemExit``),
+damit Aufrufer sie gezielt behandeln können::
+
+    from sdata.did import verify_presentation, VerificationError
+    try:
+        verify_presentation(vp_jws)
+    except VerificationError as exc:
+        ...
+
+Hierarchie::
+
+    DidError                     # Basisklasse für alles in sdata.did
+    ├── EncodingError            # ungültiges Format (JWK, Multibase, JWS-Struktur)
+    ├── ResolutionError          # DID/Schlüssel konnte nicht aufgelöst werden
+    └── VerificationError        # Signatur, Hash oder Claims ungültig
+
+``EncodingError`` erbt zusätzlich von :class:`ValueError`, damit bestehender Code,
+der ``ValueError`` abfängt, weiterhin funktioniert.
+"""
+
+__all__ = ["DidError", "EncodingError", "ResolutionError", "VerificationError"]
+
+
+class DidError(Exception):
+    """Basisklasse aller Fehler des ``sdata.did``-Subpackages."""
+
+
+class EncodingError(DidError, ValueError):
+    """Ein Wert hat ein ungültiges/unerwartetes Format (JWK, Multibase, JWS …)."""
+
+
+class ResolutionError(DidError):
+    """Eine DID oder ein Schlüssel konnte nicht aufgelöst werden."""
+
+
+class VerificationError(DidError):
+    """Eine Signatur, ein Hash oder eine Claim-Prüfung ist fehlgeschlagen."""

--- a/sdata/did/issue_vc.py
+++ b/sdata/did/issue_vc.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+"""Ausstellung von Verifiable Credentials (VC) und Verifiable Presentations (VP).
+
+Signaturformat: **JWT-VC** als Compact-JWS (EdDSA/Ed25519) über
+:mod:`sdata.did.jose`. Der Issuer wird als ``did:web`` modelliert, der Holder
+wahlweise als ``did:key`` (Multibase) oder als beliebige DID.
+
+Das hier ausgestellte Credential ist ein einfacher **Digital Product Passport**
+(``ProductPassport``) im Sinne von GS1/EU-DPP: GTIN, Seriennummer, GS1 Digital
+Link sowie CO₂-Fußabdruck und Rezyklatanteil.
+
+CLI::
+
+    python -m sdata.did.issue_vc \\
+        --issuer-domain issuer.example --issuer-key issuer_key.json \\
+        --gtin 04012345678901 --serial SN-42 --co2 12.5 --recycled 80 \\
+        --out product.vc
+
+Referenzen:
+    * `W3C VC Data Model <https://www.w3.org/TR/vc-data-model/>`_
+    * `GS1 Digital Link <https://www.gs1.org/standards/gs1-digital-link>`_
+"""
+from __future__ import annotations
+
+import json
+import time
+import uuid
+import logging
+import argparse
+from typing import Any, Dict
+
+from . import jose
+from .keys import pub_from_priv_jwk
+from .utils_didkey import did_key_from_jwk_ed25519
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["issue_vc", "make_vp", "sign_compact_jws"]
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _in_days(days: int) -> int:
+    return _now() + days * 24 * 3600
+
+
+def _load_priv_jwk(path: str) -> Dict:
+    with open(path, "r") as fh:
+        return json.load(fh)
+
+
+def sign_compact_jws(payload: Dict[str, Any], priv_jwk: Dict, kid: str, typ: str) -> str:
+    """Signiere ``payload`` als Compact-JWS.
+
+    Dünner Wrapper um :func:`sdata.did.jose.sign_compact`; aus Kompatibilität
+    mit dem bisherigen API-Namen erhalten geblieben.
+    """
+    return jose.sign_compact(payload, priv_jwk, kid=kid, typ=typ)
+
+
+def issue_vc(issuer_domain: str, issuer_key_path: str, gtin: str, serial: str,
+             co2: float, recycled: float,
+             subject_did: str = "did:example:product-xyz",
+             validity_days: int = 365 * 3) -> str:
+    """Stelle ein ``ProductPassport``-VC aus und gib es als Compact-JWS zurück.
+
+    Args:
+        issuer_domain: Domain des Issuers; ergibt ``did:web:<domain>``.
+        issuer_key_path: Pfad zum **privaten** Issuer-JWK.
+        gtin: GS1 GTIN (Global Trade Item Number).
+        serial: Seriennummer des Produkts.
+        co2: CO₂-Fußabdruck in kg CO₂e.
+        recycled: Rezyklatanteil in Prozent.
+        subject_did: DID des Credential-Subjects.
+        validity_days: Gültigkeitsdauer ab jetzt (Default: 3 Jahre).
+
+    Returns:
+        Das signierte VC als Compact-JWS (``vc+ld+jwt``).
+    """
+    issuer_did = "did:web:{}".format(issuer_domain)
+    kid = "{}#key-1".format(issuer_did)
+    jwk_priv = _load_priv_jwk(issuer_key_path)
+    payload = {
+        "iss": issuer_did,
+        "sub": subject_did,
+        "nbf": _now(),
+        "iat": _now(),
+        "exp": _in_days(validity_days),
+        "jti": "urn:uuid:{}".format(uuid.uuid4()),
+        "vc": {
+            "@context": ["https://www.w3.org/2018/credentials/v1"],
+            "type": ["VerifiableCredential", "ProductPassport"],
+            "credentialSubject": {
+                "gtin": gtin,
+                "serialNumber": serial,
+                "gs1DigitalLink": "https://id.gs1.org/01/{}/21/{}".format(gtin, serial),
+                "co2Footprint": {"value": co2, "unitText": "kg CO2e"},
+                "recycledContent": {"value": recycled, "unitText": "%"},
+            },
+            "credentialStatus": {
+                "id": "https://{}/status/pp-2025#1".format(issuer_domain),
+                "type": "StatusList2021Entry",
+            },
+        },
+    }
+    return sign_compact_jws(payload, jwk_priv, kid=kid, typ="vc+ld+jwt")
+
+
+def make_vp(holder_key_path: str, holder_did: str, vc_jws: str,
+            aud: str, nonce: str) -> str:
+    """Baue eine Verifiable Presentation um ein VC und signiere sie (Holder).
+
+    Für ``did:key``-Holder wird die konventionelle ``kid``
+    ``did:key:<mb>#<mb>`` gesetzt, sonst ``<holder_did>#key-1``.
+    """
+    holder_jwk = _load_priv_jwk(holder_key_path)
+    if holder_did.startswith("did:key:"):
+        frag = did_key_from_jwk_ed25519(pub_from_priv_jwk(holder_jwk)).split(":", 2)[2]
+        holder_kid = "{}#{}".format(holder_did, frag)
+    else:
+        holder_kid = "{}#key-1".format(holder_did)
+
+    payload = {
+        "holder": holder_did,
+        "vp": {"type": ["VerifiablePresentation"], "verifiableCredential": [vc_jws]},
+        "aud": aud,
+        "nonce": nonce,
+    }
+    return sign_compact_jws(payload, holder_jwk, kid=holder_kid, typ="vp+jwt")
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+def _build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description="Verifiable Credential / Presentation ausstellen")
+    ap.add_argument("--issuer-domain", required=True)
+    ap.add_argument("--issuer-key", required=True)
+    ap.add_argument("--gtin", required=True)
+    ap.add_argument("--serial", required=True)
+    ap.add_argument("--co2", type=float, required=True)
+    ap.add_argument("--recycled", type=float, required=True)
+    ap.add_argument("--subject", default="did:example:product-xyz")
+    ap.add_argument("--out", required=True)
+
+    ap.add_argument("--make-vp", action="store_true")
+    ap.add_argument("--holder-key")
+    ap.add_argument("--holder-did", default=None)
+    ap.add_argument("--aud", default="https://verifier.example.org")
+    ap.add_argument("--nonce", default=None)
+    return ap
+
+
+def main(argv=None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = _build_parser().parse_args(argv)
+
+    vc_jws = issue_vc(
+        issuer_domain=args.issuer_domain,
+        issuer_key_path=args.issuer_key,
+        gtin=args.gtin,
+        serial=args.serial,
+        co2=args.co2,
+        recycled=args.recycled,
+        subject_did=args.subject,
+    )
+
+    if not args.make_vp:
+        with open(args.out, "w") as fh:
+            fh.write(vc_jws)
+        logger.info("✔ VC geschrieben: %s", args.out)
+        return
+
+    if not args.holder_key:
+        raise SystemExit("--make-vp benötigt --holder-key")
+
+    if args.holder_did:
+        holder_did = args.holder_did
+    else:
+        holder_jwk = _load_priv_jwk(args.holder_key)
+        holder_did = did_key_from_jwk_ed25519(pub_from_priv_jwk(holder_jwk))
+
+    nonce = args.nonce or str(uuid.uuid4())
+    vp_jws = make_vp(args.holder_key, holder_did, vc_jws, aud=args.aud, nonce=nonce)
+    with open(args.out, "w") as fh:
+        fh.write(vp_jws)
+    logger.info("✔ VP geschrieben: %s (enthält eingebettetes VC)", args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdata/did/jose.py
+++ b/sdata/did/jose.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""Kompakte JWS-Schicht (JOSE) für EdDSA/Ed25519 – gemeinsame Basis für VC & VP.
+
+Diese Modul bündelt das Signieren/Verifizieren von **Compact-JWS**
+(``header.payload.signature``, base64url), das zuvor doppelt in
+``issue_vc`` und ``verify_vp`` implementiert war.
+
+Krypto-Backend: ``python-ecdsa`` (reine Python-Implementierung von Ed25519).
+
+.. warning::
+   ``python-ecdsa`` ist nicht garantiert constant-time. Für hochsensible
+   Produktivumgebungen mit Seitenkanal-Anforderungen sollte ein
+   libsodium-basiertes Backend (PyNaCl) oder ``cryptography`` erwogen werden.
+   Siehe auch das Paket-Docstring von :mod:`sdata.did`.
+
+Referenzen:
+    * `RFC 7515 <https://www.rfc-editor.org/rfc/rfc7515>`_ – JWS
+    * `RFC 8037 <https://www.rfc-editor.org/rfc/rfc8037>`_ – EdDSA in JOSE
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from ecdsa import SigningKey, VerifyingKey, Ed25519, BadSignatureError
+
+from .errors import EncodingError, VerificationError
+from .utils_didkey import b64url, b64url_decode
+
+__all__ = [
+    "b64url_json",
+    "protected_header",
+    "signing_key_from_jwk",
+    "verifying_key_from_jwk",
+    "sign_compact",
+    "decode_header",
+    "verify_compact",
+]
+
+
+def b64url_json(obj: Any) -> str:
+    """Serialisiere ``obj`` als kompaktes JSON und kodiere base64url (ohne Padding)."""
+    raw = json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode()
+    return b64url(raw)
+
+
+def protected_header(kid: str, typ: str, alg: str = "EdDSA") -> Dict[str, str]:
+    """Baue einen geschützten JWS-Header ``{alg, kid, typ}``."""
+    return {"alg": alg, "kid": kid, "typ": typ}
+
+
+def signing_key_from_jwk(jwk_priv: Dict) -> SigningKey:
+    """Erzeuge einen Ed25519-``SigningKey`` aus einem privaten JWK (Feld ``d``).
+
+    Raises:
+        EncodingError: wenn das private JWK ungültig ist oder ``d`` fehlt.
+    """
+    if not isinstance(jwk_priv, dict) or "d" not in jwk_priv:
+        raise EncodingError("privater JWK fehlt das Feld 'd'")
+    if jwk_priv.get("kty") != "OKP" or jwk_priv.get("crv") != "Ed25519":
+        raise EncodingError("nur OKP/Ed25519 wird unterstützt")
+    raw = b64url_decode(jwk_priv["d"])  # 32 Byte Seed
+    return SigningKey.from_string(raw, curve=Ed25519)
+
+
+def verifying_key_from_jwk(jwk_pub: Dict) -> VerifyingKey:
+    """Erzeuge einen Ed25519-``VerifyingKey`` aus einem öffentlichen JWK (Feld ``x``).
+
+    Raises:
+        EncodingError: wenn das öffentliche JWK ungültig ist oder ``x`` fehlt.
+    """
+    if not isinstance(jwk_pub, dict) or "x" not in jwk_pub:
+        raise EncodingError("öffentlicher JWK fehlt das Feld 'x'")
+    if jwk_pub.get("kty") != "OKP" or jwk_pub.get("crv") != "Ed25519":
+        raise EncodingError("nur OKP/Ed25519 wird unterstützt")
+    raw = b64url_decode(jwk_pub["x"])
+    return VerifyingKey.from_string(raw, curve=Ed25519)
+
+
+def sign_compact(payload: Dict[str, Any], priv_jwk: Dict, kid: str, typ: str,
+                 alg: str = "EdDSA") -> str:
+    """Signiere ``payload`` als Compact-JWS und gib ``header.payload.signature`` zurück."""
+    header_b64 = b64url_json(protected_header(kid, typ, alg))
+    payload_b64 = b64url_json(payload)
+    signing_input = "{}.{}".format(header_b64, payload_b64).encode()
+    sig = signing_key_from_jwk(priv_jwk).sign(signing_input)
+    return "{}.{}.{}".format(header_b64, payload_b64, b64url(sig))
+
+
+def decode_header(compact: str) -> Dict[str, Any]:
+    """Dekodiere (ohne Verifikation) den geschützten Header eines Compact-JWS.
+
+    Raises:
+        EncodingError: wenn das JWS strukturell ungültig ist.
+    """
+    parts = compact.split(".")
+    if len(parts) != 3:
+        raise EncodingError("kein gültiges Compact-JWS (erwarte 3 Segmente)")
+    try:
+        return json.loads(b64url_decode(parts[0]).decode())
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise EncodingError("JWS-Header nicht dekodierbar: {}".format(exc))
+
+
+def verify_compact(compact: str, pub_jwk: Dict) -> Dict[str, Any]:
+    """Verifiziere ein Compact-JWS gegen ``pub_jwk`` und gib das Payload zurück.
+
+    Raises:
+        EncodingError: bei strukturell ungültigem JWS.
+        VerificationError: wenn die Signatur ungültig ist.
+    """
+    parts = compact.split(".")
+    if len(parts) != 3:
+        raise EncodingError("kein gültiges Compact-JWS (erwarte 3 Segmente)")
+    header_b64, payload_b64, sig_b64 = parts
+    signing_input = "{}.{}".format(header_b64, payload_b64).encode()
+    vk = verifying_key_from_jwk(pub_jwk)
+    try:
+        vk.verify(b64url_decode(sig_b64), signing_input)
+    except BadSignatureError:
+        raise VerificationError("Signatur ungültig")
+    try:
+        return json.loads(b64url_decode(payload_b64).decode())
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise EncodingError("JWS-Payload nicht dekodierbar: {}".format(exc))

--- a/sdata/did/keys.py
+++ b/sdata/did/keys.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+"""Erzeugung und Verwaltung von Ed25519-Schlüsseln im JWK-Format.
+
+Schlüssel werden als JWK (RFC 8037, ``kty=OKP``, ``crv=Ed25519``) gehalten:
+
+* öffentlich: Feld ``x`` (raw 32 Byte, base64url),
+* privat:     zusätzlich Feld ``d`` (raw 32 Byte Seed, base64url – **geheim halten!**).
+
+CLI (das ``did``-Modul ist als Subpackage organisiert, daher via ``-m``)::
+
+    python -m sdata.did.keys gen   --out issuer_key.json
+    python -m sdata.did.keys pub   --in  issuer_key.json --out issuer_pub.json
+    python -m sdata.did.keys thumb --in  issuer_pub.json
+
+.. note::
+   ``gen`` schreibt einen **privaten** Schlüssel. Solche Dateien gehören nicht
+   ins Versionskontrollsystem (siehe ``.gitignore``).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import argparse
+from typing import Dict
+
+from ecdsa import SigningKey, Ed25519
+
+from .utils_didkey import b64url, jwk_thumbprint_rfc7638, did_key_from_jwk_ed25519
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["gen_ed25519_jwk", "pub_from_priv_jwk"]
+
+
+def gen_ed25519_jwk() -> Dict[str, str]:
+    """Erzeuge ein frisches privates Ed25519-JWK (mit Feldern ``x`` und ``d``)."""
+    sk = SigningKey.generate(curve=Ed25519)
+    vk = sk.get_verifying_key()
+    return {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": b64url(vk.to_string()),   # Public Key (raw 32 Byte)
+        "d": b64url(sk.to_string()),   # Private Key (raw 32 Byte – geheim halten!)
+    }
+
+
+def pub_from_priv_jwk(jwk_priv: Dict) -> Dict[str, str]:
+    """Leite den öffentlichen JWK (ohne ``d``) aus einem privaten JWK ab."""
+    return {"kty": jwk_priv["kty"], "crv": jwk_priv["crv"], "x": jwk_priv["x"]}
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+def _cmd_gen(args: argparse.Namespace) -> None:
+    with open(args.out, "w") as fh:
+        json.dump(gen_ed25519_jwk(), fh, indent=2)
+    logger.info("✔ Privates JWK gespeichert: %s", args.out)
+
+
+def _cmd_pub(args: argparse.Namespace) -> None:
+    with open(args.in_, "r") as fh:
+        jwk = json.load(fh)
+    with open(args.out, "w") as fh:
+        json.dump(pub_from_priv_jwk(jwk), fh, indent=2)
+    logger.info("✔ Öffentliches JWK gespeichert: %s", args.out)
+
+
+def _cmd_thumb(args: argparse.Namespace) -> None:
+    with open(args.in_, "r") as fh:
+        jwk_pub = json.load(fh)
+    logger.info("%s", json.dumps({
+        "thumbprint_rfc7638": jwk_thumbprint_rfc7638(jwk_pub),
+        "did_key": did_key_from_jwk_ed25519(jwk_pub),
+    }, indent=2))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description="Ed25519-JWK-Schlüsselverwaltung")
+    sub = ap.add_subparsers(required=True)
+
+    p = sub.add_parser("gen", help="Ed25519-Key erzeugen")
+    p.add_argument("--out", required=True)
+    p.set_defaults(func=_cmd_gen)
+
+    p = sub.add_parser("pub", help="Public-Part aus privatem JWK ableiten")
+    p.add_argument("--in", dest="in_", required=True)
+    p.add_argument("--out", required=True)
+    p.set_defaults(func=_cmd_pub)
+
+    p = sub.add_parser("thumb", help="RFC-7638-Thumbprint + did:key aus Public-JWK")
+    p.add_argument("--in", dest="in_", required=True)
+    p.set_defaults(func=_cmd_thumb)
+    return ap
+
+
+def main(argv=None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = _build_parser().parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdata/did/utils_didkey.py
+++ b/sdata/did/utils_didkey.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+"""Hilfsfunktionen rund um ``did:key``, JWK und RFC-7638-Thumbprints (Ed25519).
+
+Funktionsumfang:
+
+* Base64url-Kodierung ohne Padding (RFC 7515 §2),
+* RFC-7638-Thumbprint: kanonisches JSON ``{crv,kty,x}`` → SHA-256 → base64url,
+* ``did:key`` für Ed25519 erzeugen (multicodec ``0xED 0x01`` + multibase ``z``-base58btc),
+* ``did:key`` (bzw. nackte Multibase) zurück zu einem Public-JWK auflösen,
+* konventionelle ``kid``-Bildung für ``did:web`` und ``did:key``.
+
+Es werden ausschließlich **öffentliche** Schlüssel verarbeitet; private Schlüssel
+tauchen hier nicht auf. Einzige externe Abhängigkeit: ``base58``.
+
+Referenzen:
+    * `RFC 7638 <https://www.rfc-editor.org/rfc/rfc7638>`_ – JWK Thumbprint
+    * `did:key Method <https://w3c-ccg.github.io/did-method-key/>`_
+    * `Multicodec <https://github.com/multiformats/multicodec>`_ (ed25519-pub = 0xED)
+"""
+from __future__ import annotations
+
+import json
+import base64
+import hashlib
+from typing import Dict
+
+import base58
+
+from .errors import EncodingError
+
+__all__ = [
+    "b64url",
+    "b64url_decode",
+    "jwk_thumbprint_rfc7638",
+    "did_key_from_jwk_ed25519",
+    "did_key_fragment_from_jwk",
+    "pub_jwk_from_did_key",
+    "kid_for_did_web",
+    "kid_for_did_key",
+]
+
+# multicodec-Präfix (unsigned varint) für einen öffentlichen Ed25519-Schlüssel.
+_ED25519_PUB_PREFIX = bytes([0xED, 0x01])
+
+
+# --------------------------------------------------------------------------
+# Base64url-Helfer (ohne Padding, RFC 7515)
+# --------------------------------------------------------------------------
+def b64url(data: bytes) -> str:
+    """Kodiere ``data`` als base64url ohne ``=``-Padding."""
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+
+def b64url_decode(s: str) -> bytes:
+    """Dekodiere einen base64url-String; fehlendes Padding wird ergänzt."""
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+# --------------------------------------------------------------------------
+# Validierung
+# --------------------------------------------------------------------------
+def _assert_ed25519_jwk_pub(jwk_pub: Dict) -> None:
+    """Stelle sicher, dass ``jwk_pub`` ein gültiger öffentlicher Ed25519-JWK ist.
+
+    Raises:
+        EncodingError: bei falschem Typ, ``kty``/``crv`` oder Schlüssellänge.
+    """
+    if not isinstance(jwk_pub, dict):
+        raise EncodingError("jwk_pub muss ein dict sein")
+    if jwk_pub.get("kty") != "OKP" or jwk_pub.get("crv") != "Ed25519":
+        raise EncodingError("nur OKP/Ed25519 wird unterstützt")
+    if "x" not in jwk_pub:
+        raise EncodingError("JWK fehlt das Feld 'x' (Public Key)")
+    raw = b64url_decode(jwk_pub["x"])
+    if len(raw) != 32:
+        raise EncodingError(
+            "Ed25519 Public Key muss 32 Byte sein (war {})".format(len(raw)))
+
+
+def _strip_didkey_multibase(did_or_mb: str) -> str:
+    """Normalisiere ``did:key:z…``, ``#z…`` oder ``z…`` auf die nackte Multibase ``z…``."""
+    s = did_or_mb
+    if s.startswith("did:key:"):
+        s = s.split(":", 2)[2]
+    if s.startswith("#"):
+        s = s[1:]
+    return s
+
+
+# --------------------------------------------------------------------------
+# RFC-7638-Thumbprint
+# --------------------------------------------------------------------------
+def jwk_thumbprint_rfc7638(jwk_pub: Dict) -> str:
+    """Berechne den RFC-7638-Thumbprint eines öffentlichen Ed25519-JWK.
+
+    Kanonisiert wird über die Pflichtfelder ``{crv, kty, x}`` (lexikografisch
+    sortiert, ohne Whitespace); davon der SHA-256, base64url-kodiert.
+
+    Returns:
+        Der Thumbprint als base64url-String (ohne Padding).
+    """
+    _assert_ed25519_jwk_pub(jwk_pub)
+    data = {"crv": jwk_pub["crv"], "kty": jwk_pub["kty"], "x": jwk_pub["x"]}
+    canon = json.dumps(data, separators=(",", ":"), sort_keys=True).encode()
+    return b64url(hashlib.sha256(canon).digest())
+
+
+# --------------------------------------------------------------------------
+# did:key  <->  JWK
+# --------------------------------------------------------------------------
+def did_key_from_jwk_ed25519(jwk_pub: Dict) -> str:
+    """Erzeuge eine ``did:key``-DID aus einem öffentlichen Ed25519-JWK."""
+    _assert_ed25519_jwk_pub(jwk_pub)
+    raw = b64url_decode(jwk_pub["x"])  # 32 Byte
+    mb = "z" + base58.b58encode(_ED25519_PUB_PREFIX + raw).decode()
+    return "did:key:{}".format(mb)
+
+
+def did_key_fragment_from_jwk(jwk_pub: Dict) -> str:
+    """Liefere den Multibase-Teil (``z…``) – praktisch als ``kid``-Fragment."""
+    _assert_ed25519_jwk_pub(jwk_pub)
+    raw = b64url_decode(jwk_pub["x"])
+    return "z" + base58.b58encode(_ED25519_PUB_PREFIX + raw).decode()
+
+
+def pub_jwk_from_did_key(did_key_or_mb: str) -> Dict[str, str]:
+    """Gewinne den öffentlichen JWK aus einer ``did:key``-DID oder Multibase zurück.
+
+    Akzeptiert ``did:key:z…``, ``#z…`` oder die nackte Multibase ``z…``.
+
+    Raises:
+        EncodingError: bei fehlendem ``z``-Präfix oder falschem multicodec.
+    """
+    mb = _strip_didkey_multibase(did_key_or_mb)
+    if not mb.startswith("z"):
+        raise EncodingError("did:key erwartet base58btc (z-Codec)")
+    raw = base58.b58decode(mb[1:])  # 'z' entfernen
+    if not (len(raw) >= 34 and raw[0] == 0xED and raw[1] == 0x01):
+        raise EncodingError("unerwartetes multicodec-Präfix für ed25519-pub")
+    pubkey = raw[2:34]
+    return {"kty": "OKP", "crv": "Ed25519", "x": b64url(pubkey)}
+
+
+# --------------------------------------------------------------------------
+# kid-Helfer (konventionell)
+# --------------------------------------------------------------------------
+def kid_for_did_web(did_web: str, key_id: str = "key-1") -> str:
+    """``kid_for_did_web('did:web:example.com')`` → ``'did:web:example.com#key-1'``."""
+    return "{}#{}".format(did_web, key_id)
+
+
+def kid_for_did_key(did_key: str, jwk_pub: Dict = None) -> str:
+    """Bilde die konventionelle ``kid`` ``did:key:<mb>#<mb>``.
+
+    Wird ``jwk_pub`` übergeben, wird das Fragment aus dem JWK abgeleitet,
+    andernfalls die Multibase aus ``did_key`` wiederverwendet.
+    """
+    mb = _strip_didkey_multibase(did_key)
+    frag = mb if not jwk_pub else did_key_fragment_from_jwk(jwk_pub)
+    return "did:key:{}#{}".format(mb, frag)

--- a/sdata/did/verify_vp.py
+++ b/sdata/did/verify_vp.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""Verifikation von Verifiable Presentations (VP) und der eingebetteten VC.
+
+Geprüft werden:
+
+1. die Holder-Signatur der VP,
+2. optional ``aud`` und ``nonce`` (Replay-Schutz),
+3. die Issuer-Signatur des eingebetteten VC,
+4. der Gültigkeitszeitraum des VC (``nbf``/``exp``).
+
+Unterstützte DID-Methoden für die Schlüsselauflösung:
+
+* **Issuer** ``did:web`` – Auflösung via HTTPS (:mod:`sdata.did.did_web`),
+* **Holder** ``did:key`` – lokale Rückgewinnung des Public-JWK (kein Netzwerk).
+
+Die Bibliotheksfunktionen werfen :class:`sdata.did.VerificationError` /
+:class:`sdata.did.ResolutionError` (nie ``SystemExit``).
+
+CLI::
+
+    python -m sdata.did.verify_vp --vp product.vp \\
+        --expected-aud https://verifier.example.org --expected-nonce <nonce>
+"""
+from __future__ import annotations
+
+import time
+import logging
+import argparse
+from typing import Any, Dict, Optional
+
+from . import jose
+from .errors import ResolutionError, VerificationError
+from .utils_didkey import pub_jwk_from_did_key
+from .did_web import resolve_public_jwk_for_kid as resolve_web_kid
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "resolve_public_jwk_for_kid",
+    "verify_presentation",
+    "jws_header",
+    "jws_verify",
+]
+
+
+def jws_header(compact: str) -> Dict[str, Any]:
+    """Dekodiere den (ungeprüften) Header eines Compact-JWS."""
+    return jose.decode_header(compact)
+
+
+def jws_verify(compact: str, public_jwk: Dict) -> Dict[str, Any]:
+    """Verifiziere ein Compact-JWS gegen ``public_jwk`` und gib das Payload zurück."""
+    return jose.verify_compact(compact, public_jwk)
+
+
+def resolve_public_jwk_for_kid(kid: str) -> Dict[str, str]:
+    """Löse die ``kid`` zu einem öffentlichen JWK auf (``did:web`` oder ``did:key``).
+
+    Raises:
+        ResolutionError: bei nicht unterstützter DID-Methode oder Auflösefehler.
+    """
+    did = kid.split("#")[0]
+    if did.startswith("did:web:"):
+        return resolve_web_kid(kid)
+    if did.startswith("did:key:"):
+        return pub_jwk_from_did_key(did)
+    raise ResolutionError("nicht unterstützte DID-Methode in kid: {}".format(kid))
+
+
+def verify_presentation(vp_jws: str, *, expected_aud: Optional[str] = None,
+                        expected_nonce: Optional[str] = None,
+                        now: Optional[int] = None) -> Dict[str, Any]:
+    """Verifiziere eine VP samt eingebettetem VC vollständig.
+
+    Args:
+        vp_jws: Die Verifiable Presentation als Compact-JWS.
+        expected_aud: Falls gesetzt, muss ``vp.aud`` exakt übereinstimmen.
+        expected_nonce: Falls gesetzt, muss ``vp.nonce`` exakt übereinstimmen.
+        now: Referenzzeit (Unix-Sekunden) für die ``nbf``/``exp``-Prüfung;
+            Default ist die aktuelle Zeit. Nützlich für Tests.
+
+    Returns:
+        Ein Dict mit ``issuer``, ``holder``, ``credentialSubject``, ``vc`` und ``vp``.
+
+    Raises:
+        VerificationError: bei ungültiger Signatur, ``aud``/``nonce``-Mismatch,
+            fehlendem VC oder abgelaufenem/ noch nicht gültigem VC.
+        ResolutionError: wenn ein Schlüssel nicht aufgelöst werden kann.
+    """
+    now = int(time.time()) if now is None else int(now)
+
+    # 1) VP-Signatur (Holder)
+    vp_pub = resolve_public_jwk_for_kid(jws_header(vp_jws)["kid"])
+    vp = jws_verify(vp_jws, vp_pub)
+
+    # 2) aud / nonce
+    if expected_aud is not None and vp.get("aud") != expected_aud:
+        raise VerificationError("aud stimmt nicht überein")
+    if expected_nonce is not None and vp.get("nonce") != expected_nonce:
+        raise VerificationError("nonce stimmt nicht überein")
+
+    # 3) eingebettetes VC extrahieren & prüfen (Issuer)
+    creds = vp.get("vp", {}).get("verifiableCredential", [])
+    if not creds:
+        raise VerificationError("VP enthält keine verifiableCredential")
+    vc_jws = creds[0]
+    vc_pub = resolve_public_jwk_for_kid(jws_header(vc_jws)["kid"])
+    vc = jws_verify(vc_jws, vc_pub)
+
+    # 4) Gültigkeitszeitraum
+    nbf, exp = vc.get("nbf"), vc.get("exp")
+    if nbf is not None and now < nbf:
+        raise VerificationError("VC ist noch nicht gültig (nbf)")
+    if exp is not None and now > exp:
+        raise VerificationError("VC ist abgelaufen (exp)")
+
+    return {
+        "issuer": vc.get("iss"),
+        "holder": vp.get("holder"),
+        "credentialSubject": vc.get("vc", {}).get("credentialSubject", {}),
+        "vc": vc,
+        "vp": vp,
+    }
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+def main(argv=None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    ap = argparse.ArgumentParser(description="Verifiable Presentation verifizieren")
+    ap.add_argument("--vp", required=True)
+    ap.add_argument("--expected-aud")
+    ap.add_argument("--expected-nonce")
+    args = ap.parse_args(argv)
+
+    with open(args.vp, "r") as fh:
+        vp_jws = fh.read().strip()
+
+    try:
+        result = verify_presentation(
+            vp_jws,
+            expected_aud=args.expected_aud,
+            expected_nonce=args.expected_nonce,
+        )
+    except (VerificationError, ResolutionError) as exc:
+        raise SystemExit("✘ Verifikation fehlgeschlagen: {}".format(exc))
+
+    subj = result["credentialSubject"]
+    logger.info("✔ VP + VC verifiziert")
+    logger.info("Issuer: %s", result["issuer"])
+    logger.info("Holder: %s", result["holder"])
+    logger.info("GTIN: %s  SN: %s", subj.get("gtin"), subj.get("serialNumber"))
+    logger.info("CO2: %s  Recycled: %s", subj.get("co2Footprint"), subj.get("recycledContent"))
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,12 @@ with open('README.md', 'rb') as f:
 
 REQUIRES = ['numpy', 'pandas', 'tabulate', 'xlrd', 'openpyxl', 'xlsxwriter', 'pytz', 'requests', 'Pillow']
 
+# Optionale Abhängigkeiten für das DID-/VC-Subpackage (sdata.did):
+#   pip install "sdata[did]"
+EXTRAS = {
+    'did': ['ecdsa>=0.18', 'base58>=2.1'],
+}
+
 setup(
     name='sdata',
     version=version,
@@ -36,19 +42,20 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
+    python_requires='>=3.7',
 
     install_requires=REQUIRES,
-    tests_require=['coverage', 'pytest'],
+    extras_require=EXTRAS,
+    tests_require=['coverage', 'pytest', 'ecdsa', 'base58'],
     test_suite = 'tests',
     packages=find_packages(),
 )

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -1,0 +1,394 @@
+# -*- coding: utf-8 -*-
+"""Tests für das DID-/VC-Subpackage :mod:`sdata.did`.
+
+Importiert über die öffentliche Paket-API. Die Tests laufen ohne Netzwerk
+(HTTP wird via ``monkeypatch`` gemockt) und überspringen sich sauber, falls die
+optionalen Abhängigkeiten (``ecdsa``/``base58``, via ``pip install sdata[did]``)
+nicht installiert sind.
+"""
+import json
+import base64
+import hashlib
+
+import pytest
+
+# Optionale Abhängigkeiten / Paket – sonst die gesamte Datei überspringen.
+pytest.importorskip("ecdsa")
+pytest.importorskip("base58")
+pytest.importorskip("sdata.did")
+
+from sdata.did import (                                              # noqa: E402
+    gen_ed25519_jwk, pub_from_priv_jwk, did_key_from_jwk_ed25519,
+    pub_jwk_from_did_key, jwk_thumbprint_rfc7638,
+    sign_compact, verify_compact, jws_header, jws_verify,
+    issue_vc, make_vp, verify_presentation,
+    build_did_document, did_web_to_url,
+    did_peer4_from_payload, resolve_long_form,
+    parse_did_github, resolve_did_github,
+    EncodingError, ResolutionError, VerificationError,
+)
+from sdata.did import ed25519 as ed       # noqa: E402  (Lern-Referenz)
+from sdata.did import did_peer4 as dp     # noqa: E402
+from sdata.did import did_github as dgh   # noqa: E402
+from sdata.did import did_web as dw       # noqa: E402
+from sdata.did import verify_vp as vv     # noqa: E402
+from sdata.did import diddoc              # noqa: E402
+
+PUB_JWK = {"kty": "OKP", "crv": "Ed25519",
+           "x": "qhqVmPevNBx1W-amRiTzOizsqtVHiOVGQMRMBM29cE0"}
+
+
+def _b64url_decode(s):
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+# ======================================================================
+# ed25519.py  (reine Python-Referenzimplementierung)
+# ======================================================================
+class TestEd25519:
+    SK = bytes.fromhex("9d61b19deffd5a60ba844af492ec2cc4"
+                       "4449c5697b326919703bac031cae7f60")
+    PK = bytes.fromhex("d75a980182b10ab7d54bfed3c964073a"
+                       "0ee172f3daa62325af021a68f707511a")
+    SIG = bytes.fromhex("e5564300c360ac729086e2cc806e828a"
+                        "84877f1eb8e5d974d873e06522490155"
+                        "5fb8821590a33bacc61e39701cf9b46b"
+                        "d25bf5f0595bbe24655141438e7a100b")
+
+    def test_rfc8032_public_key(self):
+        assert ed.publickey(self.SK) == self.PK
+        assert ed.keypair_from_seed(self.SK).pk == self.PK
+
+    def test_rfc8032_signature_matches_vector(self):
+        assert ed.sign(b"", self.SK, self.PK) == self.SIG
+
+    def test_rfc8032_verify(self):
+        assert ed.verify(self.SIG, b"", self.PK) is True
+
+    def test_sign_verify_roundtrip(self):
+        seed = bytes(range(32))
+        pk = ed.publickey(seed)
+        sig = ed.sign(b"Hallo, DIDComm!", seed, pk)
+        assert len(sig) == 64
+        assert ed.verify(sig, b"Hallo, DIDComm!", pk) is True
+
+    def test_rejects_tampered_message(self):
+        seed = bytes(range(32))
+        pk = ed.publickey(seed)
+        sig = ed.sign(b"original", seed, pk)
+        assert ed.verify(sig, b"tampered", pk) is False
+
+    def test_rejects_tampered_signature(self):
+        seed = bytes(range(32))
+        pk = ed.publickey(seed)
+        sig = bytearray(ed.sign(b"data", seed, pk))
+        sig[0] ^= 0x01
+        assert ed.verify(bytes(sig), b"data", pk) is False
+
+    def test_rejects_bad_lengths(self):
+        assert ed.verify(b"\x00" * 63, b"x", b"\x00" * 32) is False
+        assert ed.verify(b"\x00" * 64, b"x", b"\x00" * 31) is False
+        with pytest.raises(ValueError):
+            ed.publickey(b"\x00" * 31)
+
+    def test_high_S_rejected(self):
+        seed = bytes(range(32))
+        pk = ed.publickey(seed)
+        sig = bytearray(ed.sign(b"m", seed, pk))
+        sig[32:] = ed.encodeint(ed.l + 1)
+        assert ed.verify(bytes(sig), b"m", pk) is False
+
+
+# ======================================================================
+# did_peer4.py  (abhängigkeitsfrei)
+# ======================================================================
+class TestDidPeer4:
+    PAYLOAD = {
+        "@context": ["https://www.w3.org/ns/did/v1"],
+        "verificationMethod": [{
+            "id": "#key-0", "type": "JsonWebKey2020", "publicKeyJwk": PUB_JWK}],
+        "authentication": ["#key-0"],
+        "assertionMethod": ["#key-0"],
+    }
+
+    def test_long_and_short_form(self):
+        long_form, short_form, doc = did_peer4_from_payload(self.PAYLOAD)
+        assert short_form.startswith("did:peer:4z")
+        assert long_form.startswith(short_form + ":")
+        assert doc["id"] == long_form
+        assert short_form in doc["alsoKnownAs"]
+
+    def test_resolve_roundtrip(self):
+        long_form, short_form, _ = did_peer4_from_payload(self.PAYLOAD)
+        resolved = resolve_long_form(long_form)
+        assert resolved["id"] == long_form
+        assert short_form in resolved.get("alsoKnownAs", [])
+        assert resolved["verificationMethod"][0]["controller"] == long_form
+
+    def test_hash_tampering_raises_verification_error(self):
+        long_form, _, _ = did_peer4_from_payload(self.PAYLOAD)
+        hash_part = long_form[len("did:peer:4"):].split(":", 1)[0]
+        other_long, _, _ = did_peer4_from_payload({**self.PAYLOAD, "authentication": []})
+        other_doc_part = other_long[len("did:peer:4"):].split(":", 1)[1]
+        forged = "did:peer:4{}:{}".format(hash_part, other_doc_part)
+        with pytest.raises(VerificationError):
+            resolve_long_form(forged)
+
+    def test_rejects_non_peer4(self):
+        with pytest.raises(EncodingError):
+            resolve_long_form("did:web:example.com")
+
+    def test_base58_roundtrip_with_leading_zeros(self):
+        data = b"\x00\x00hello-\xff\x01"
+        assert dp.b58decode(dp.b58encode(data)) == data
+
+
+# ======================================================================
+# diddoc.py  (Demo; Bugfix-Regression)
+# ======================================================================
+class TestDiddoc:
+    def test_import_exposes_fixed_symbols(self):
+        assert callable(diddoc.sign)
+        assert callable(diddoc.publickey)
+
+    def test_base64url_roundtrip(self):
+        data = b"hello-world-\x00\xff"
+        enc = diddoc.base64url_encode(data)
+        assert b"=" not in enc
+        assert diddoc.base64url_decode(enc) == data
+
+    def test_build_didcomm_jws_is_verifiable(self):
+        seed = bytes(range(1, 33))
+        jws = diddoc.build_didcomm_jws({"id": "1"}, seed)
+        pk = diddoc.publickey(seed)
+        protected = jws["signatures"][0]["protected"].encode()
+        payload = jws["payload"].encode()
+        sig = diddoc.base64url_decode(jws["signatures"][0]["signature"].encode())
+        assert ed.verify(sig, protected + b"." + payload, pk) is True
+
+
+# ======================================================================
+# utils_didkey.py
+# ======================================================================
+class TestUtilsDidKey:
+    def test_didkey_jwk_roundtrip(self):
+        did = did_key_from_jwk_ed25519(PUB_JWK)
+        assert did.startswith("did:key:z")
+        assert pub_jwk_from_did_key(did) == PUB_JWK
+        assert pub_jwk_from_did_key(did.split(":", 2)[2]) == PUB_JWK
+
+    def test_thumbprint_rfc7638_matches_reference(self):
+        got = jwk_thumbprint_rfc7638(PUB_JWK)
+        canon = json.dumps({"crv": "Ed25519", "kty": "OKP", "x": PUB_JWK["x"]},
+                           separators=(",", ":"), sort_keys=True).encode()
+        expected = base64.urlsafe_b64encode(
+            hashlib.sha256(canon).digest()).decode().rstrip("=")
+        assert got == expected
+        assert got == jwk_thumbprint_rfc7638(
+            {"x": PUB_JWK["x"], "crv": "Ed25519", "kty": "OKP"})
+
+    def test_validation_errors(self):
+        with pytest.raises(EncodingError):
+            did_key_from_jwk_ed25519({"kty": "RSA", "crv": "Ed25519", "x": "AA"})
+        with pytest.raises(EncodingError):
+            pub_jwk_from_did_key("did:key:Xnotmultibase")
+
+
+# ======================================================================
+# did_web.py
+# ======================================================================
+class TestDidWeb:
+    def test_url_well_known(self):
+        assert did_web_to_url("did:web:example.com") == \
+            "https://example.com/.well-known/did.json"
+
+    def test_url_with_path(self):
+        assert did_web_to_url("did:web:example.com:user:alice") == \
+            "https://example.com/user/alice/did.json"
+
+    def test_url_rejects_non_web(self):
+        with pytest.raises(EncodingError):
+            did_web_to_url("did:key:z123")
+
+    def test_build_did_document_jwk(self, tmp_path):
+        pub = tmp_path / "pub.json"
+        pub.write_text(json.dumps(PUB_JWK))
+        doc = build_did_document("example.com", str(pub), variant="jwk")
+        assert doc["id"] == "did:web:example.com"
+        vm = doc["verificationMethod"][0]
+        assert vm["type"] == "JsonWebKey2020"
+        assert vm["id"] == "did:web:example.com#key-1"
+        assert vm["publicKeyJwk"] == PUB_JWK
+        assert "did:web:example.com#key-1" in doc["assertionMethod"]
+
+    def test_build_did_document_multibase(self, tmp_path):
+        pub = tmp_path / "pub.json"
+        pub.write_text(json.dumps(PUB_JWK))
+        doc = build_did_document("example.com", str(pub), variant="multibase")
+        vm = doc["verificationMethod"][0]
+        assert vm["type"] == "Ed25519VerificationKey2020"
+        assert vm["publicKeyMultibase"].startswith("z")
+
+    def test_resolve_public_jwk_mocked(self, monkeypatch):
+        doc = {"verificationMethod": [{
+            "id": "did:web:example.com#key-1", "type": "JsonWebKey2020",
+            "publicKeyJwk": PUB_JWK}]}
+
+        class FakeResp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return doc
+
+        monkeypatch.setattr(dw.requests, "get", lambda *a, **k: FakeResp())
+        assert dw.resolve_public_jwk_for_kid("did:web:example.com#key-1") == PUB_JWK
+
+    def test_resolve_network_error_raises_resolution_error(self, monkeypatch):
+        def boom(*a, **k):
+            raise dw.requests.RequestException("boom")
+        monkeypatch.setattr(dw.requests, "get", boom)
+        with pytest.raises(ResolutionError):
+            dw.resolve_public_jwk_for_kid("did:web:example.com#key-1")
+
+
+# ======================================================================
+# did_github.py
+# ======================================================================
+class TestDidGithub:
+    def test_parse_full(self):
+        p = parse_did_github("did:github:lepy:cudi2:main:sub__dir")
+        assert (p.user, p.repo, p.ref, p.subpath) == ("lepy", "cudi2", "main", "sub/dir")
+        assert p.did == "did:github:lepy:cudi2:main:sub/dir"
+
+    def test_parse_minimal(self):
+        p = parse_did_github("did:github:alice:repo")
+        assert (p.user, p.repo, p.ref, p.subpath) == ("alice", "repo", None, None)
+
+    def test_parse_invalid(self):
+        with pytest.raises(EncodingError):
+            parse_did_github("did:web:example.com")
+        with pytest.raises(EncodingError):
+            parse_did_github("did:github:onlyuser")
+
+    def test_raw_url(self):
+        assert dgh._raw_url("u", "r", "main", "did.json") == \
+            "https://raw.githubusercontent.com/u/r/main/did.json"
+
+    def test_candidate_paths_order(self):
+        cands = dgh.candidate_paths(parse_did_github("did:github:u:r"))
+        assert cands[0] == ("main", ".well-known/did.json")
+        assert ("master", "did.json") in cands
+
+    def test_resolve_picks_first_hit(self, monkeypatch):
+        doc = {"@context": ["https://www.w3.org/ns/did/v1"], "id": "did:github:u:r"}
+        monkeypatch.setattr(
+            dgh, "fetch_json",
+            lambda url: doc if url.endswith(".well-known/did.json") else None)
+        assert resolve_did_github("did:github:u:r")["id"] == "did:github:u:r"
+
+    def test_resolve_requires_context(self, monkeypatch):
+        monkeypatch.setattr(dgh, "fetch_json", lambda url: {"id": "x"})
+        with pytest.raises(EncodingError):
+            resolve_did_github("did:github:u:r")
+
+    def test_resolve_not_found(self, monkeypatch):
+        monkeypatch.setattr(dgh, "fetch_json", lambda url: None)
+        with pytest.raises(ResolutionError):
+            resolve_did_github("did:github:u:r")
+
+
+# ======================================================================
+# jose.py / issue_vc.py / verify_vp.py
+# ======================================================================
+class TestJoseAndCredentials:
+    def _keypair_did(self):
+        jwk = gen_ed25519_jwk()
+        pub = pub_from_priv_jwk(jwk)
+        did = did_key_from_jwk_ed25519(pub)
+        kid = "{}#{}".format(did, did.split(":", 2)[2])
+        return jwk, pub, kid
+
+    def test_keygen_shape(self):
+        jwk = gen_ed25519_jwk()
+        assert jwk["kty"] == "OKP" and jwk["crv"] == "Ed25519"
+        assert "x" in jwk and "d" in jwk
+        assert "d" not in pub_from_priv_jwk(jwk)
+
+    def test_sign_and_verify_compact(self):
+        jwk, pub, kid = self._keypair_did()
+        jws = sign_compact({"iss": "x", "hello": "world"}, jwk, kid=kid, typ="JWT")
+        assert jws_header(jws)["alg"] == "EdDSA"
+        assert jws_header(jws)["kid"] == kid
+        assert verify_compact(jws, pub)["hello"] == "world"
+
+    def test_verify_via_didkey_resolution(self):
+        jwk, _, kid = self._keypair_did()
+        jws = sign_compact({"hello": "world"}, jwk, kid=kid, typ="JWT")
+        pub = vv.resolve_public_jwk_for_kid(kid)     # did:key -> lokal, kein Netz
+        assert jws_verify(jws, pub)["hello"] == "world"
+
+    def test_tampered_payload_raises_verification_error(self):
+        jwk, pub, kid = self._keypair_did()
+        h, _, s = sign_compact({"a": 1}, jwk, kid=kid, typ="x").split(".")
+        bad = base64.urlsafe_b64encode(json.dumps({"a": 2}).encode()).decode().rstrip("=")
+        with pytest.raises(VerificationError):
+            verify_compact("{}.{}.{}".format(h, bad, s), pub)
+
+    def test_malformed_jws_raises_encoding_error(self):
+        _, pub, _ = self._keypair_did()
+        with pytest.raises(EncodingError):
+            verify_compact("not-a-jws", pub)
+
+    def test_issue_vc_product_passport_schema(self, tmp_path):
+        keyfile = tmp_path / "issuer.json"
+        keyfile.write_text(json.dumps(gen_ed25519_jwk()))
+        jws = issue_vc(issuer_domain="issuer.example", issuer_key_path=str(keyfile),
+                       gtin="04012345678901", serial="SN-42", co2=12.5, recycled=80.0)
+        payload = json.loads(_b64url_decode(jws.split(".")[1]))
+        assert payload["iss"] == "did:web:issuer.example"
+        subj = payload["vc"]["credentialSubject"]
+        assert subj["gtin"] == "04012345678901"
+        assert subj["serialNumber"] == "SN-42"
+        assert subj["co2Footprint"] == {"value": 12.5, "unitText": "kg CO2e"}
+        assert subj["recycledContent"] == {"value": 80.0, "unitText": "%"}
+        assert subj["gs1DigitalLink"] == "https://id.gs1.org/01/04012345678901/21/SN-42"
+        assert {"VerifiableCredential", "ProductPassport"} <= set(payload["vc"]["type"])
+
+    # --- vollständiger Fluss: Issuer (did:web, gemockt) + Holder (did:key) ---
+    def _make_vp(self, tmp_path, monkeypatch, aud="aud1", nonce="n1"):
+        issuer = gen_ed25519_jwk()
+        holder = gen_ed25519_jwk()
+        (tmp_path / "i.json").write_text(json.dumps(issuer))
+        (tmp_path / "h.json").write_text(json.dumps(holder))
+        vc = issue_vc("issuer.example", str(tmp_path / "i.json"),
+                      gtin="01", serial="s", co2=1.0, recycled=2.0)
+        holder_did = did_key_from_jwk_ed25519(pub_from_priv_jwk(holder))
+        vp = make_vp(str(tmp_path / "h.json"), holder_did, vc, aud=aud, nonce=nonce)
+        # did:web-Auflösung des Issuers durch den Public-Key ersetzen
+        monkeypatch.setattr(vv, "resolve_web_kid",
+                            lambda kid: pub_from_priv_jwk(issuer))
+        return vp
+
+    def test_end_to_end_verify_presentation(self, tmp_path, monkeypatch):
+        vp = self._make_vp(tmp_path, monkeypatch)
+        result = verify_presentation(vp, expected_aud="aud1", expected_nonce="n1")
+        assert result["issuer"] == "did:web:issuer.example"
+        assert result["holder"].startswith("did:key:z")
+        assert result["credentialSubject"]["gtin"] == "01"
+
+    def test_verify_presentation_aud_mismatch(self, tmp_path, monkeypatch):
+        vp = self._make_vp(tmp_path, monkeypatch)
+        with pytest.raises(VerificationError):
+            verify_presentation(vp, expected_aud="WRONG")
+
+    def test_verify_presentation_nonce_mismatch(self, tmp_path, monkeypatch):
+        vp = self._make_vp(tmp_path, monkeypatch)
+        with pytest.raises(VerificationError):
+            verify_presentation(vp, expected_nonce="WRONG")
+
+    def test_verify_presentation_expired(self, tmp_path, monkeypatch):
+        vp = self._make_vp(tmp_path, monkeypatch)
+        # Referenzzeit weit in der Zukunft -> exp überschritten
+        with pytest.raises(VerificationError):
+            verify_presentation(vp, now=99999999999)


### PR DESCRIPTION
## Überblick

Refactor des `sdata/did/`-Bereichs zu einem sauberen, dokumentierten Subpackage `sdata.did` (pure-Python-Designziel beibehalten).

## Änderungen

- **Echtes Subpackage**: relative Importe, kuratiertes `__init__` mit Lazy-Loading (PEP 562) und `__all__`; CLIs via `python -m sdata.did.<modul>`.
- **Neue Module**: `errors.py` (Ausnahmehierarchie `DidError`/`EncodingError`/`ResolutionError`/`VerificationError`) und `jose.py` (gemeinsame Compact-JWS/EdDSA-Schicht — entfernt die Duplizierung zwischen `issue_vc` und `verify_vp`).
- **Robustheit**: Bibliothekscode wirft `VerificationError`/`ResolutionError` statt `SystemExit`; neue `verify_presentation()` mit `aud`/`nonce`/Gültigkeitsprüfung (`nbf`/`exp`, testbare `now=`).
- **Krypto**: pure-Python beibehalten (`python-ecdsa` + `base58`); `ed25519.py` als nicht constant-time **Lern-Referenz** markiert (nicht im Funktionspfad).
- **Logging statt print**; vollständige Type-Hints und Docstrings; `sdata/did/README.md`.
- **Packaging**: `setup.py` mit `extras_require={'did': ['ecdsa','base58']}` (behebt zuvor undeklarierte Abhängigkeiten), `python_requires>=3.7`, aktualisierte Klassifizierer.

## Tests

`tests/test_did.py`: 44 Tests über die Paket-API, ohne Netzwerk (HTTP gemockt). Lokal grün (`44 passed`).

## Sicherheitshinweis

Der produktive Krypto-Pfad (`python-ecdsa`) ist bewusst dependency-arm, aber nicht garantiert constant-time. Für hochsensible Umgebungen ist ein libsodium-/`cryptography`-Backend empfehlenswert (im Code/README dokumentiert).
