### PR TITLE
chore(ci): lokale CI (venv + pytest/coverage), kein Online-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.pyc
 .cache/
 .coverage
+.venv-ci/
+.pytest_cache/
 .idea/
 .vscode/
 .tox/
@@ -13,3 +15,17 @@ build/
 dist/
 docs/build/
 wheelhouse/
+
+# Secrets / DID key material (never commit private keys or signed artifacts)
+*.pem
+*.key
+*_key.json
+*_priv.json
+*_private.json
+issuer_key*.json
+holder_key*.json
+*.jwk.json
+did.json
+*.jws
+*.vc
+*.vp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+# Lokale CI/Tests für sdata — bewusst OHNE GitHub Actions / Online-CI.
+#
+#   make ci        # komplette lokale CI: venv anlegen, installieren, alle Tests + Coverage
+#   make did-test  # nur die DID-Tests
+#   make test      # alle Tests (setzt eine via `make ci` eingerichtete venv voraus)
+#   make clean-ci  # venv + Coverage-Artefakte entfernen
+.PHONY: ci test did-test clean-ci help
+
+VENV ?= .venv-ci
+PYBIN := $(VENV)/bin/python
+
+help:
+	@grep -E '^[a-zA-Z0-9_-]+:.*#' $(MAKEFILE_LIST) | sed 's/:.*#/\t-/'
+
+ci: ## komplette lokale CI (venv, install, alle Tests + Coverage)
+	./ci/local-ci.sh
+
+did-test: ## nur die DID-Tests
+	./ci/local-ci.sh tests/test_did.py -q
+
+test: ## alle Tests (benötigt eingerichtete venv aus `make ci`)
+	$(PYBIN) -m pytest tests/
+
+clean-ci: ## venv + Coverage-Artefakte entfernen
+	rm -rf $(VENV) .coverage

--- a/ci/local-ci.sh
+++ b/ci/local-ci.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Lokale CI für sdata — bewusst OHNE GitHub Actions / Online-CI.
+#
+# Erstellt eine isolierte venv, installiert das Paket inkl. optionalem
+# [did]-Extra sowie die Test-Tools und führt die Testsuite mit Coverage aus.
+# Es findet KEIN Upload/keine Kommunikation mit externen CI-Diensten statt.
+#
+# Nutzung:
+#   ci/local-ci.sh                          # komplette Suite (tests/)
+#   ci/local-ci.sh tests/test_did.py -q     # gezielt; Argumente werden durchgereicht
+#   PYTHON=python3.11 ci/local-ci.sh        # anderen Interpreter wählen
+#   VENV_DIR=/pfad/zur/venv ci/local-ci.sh  # venv-Ort überschreiben
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PYTHON="${PYTHON:-python3}"
+VENV="${VENV_DIR:-$ROOT/.venv-ci}"
+PYBIN="$VENV/bin/python"
+
+if [[ ! -x "$PYBIN" ]]; then
+  echo "[ci] erstelle venv: $VENV"
+  "$PYTHON" -m venv "$VENV"
+fi
+
+echo "[ci] installiere/aktualisiere Abhängigkeiten (sdata[did] + Test-Tools)"
+"$PYBIN" -m pip install --quiet --upgrade pip
+"$PYBIN" -m pip install --quiet -e ".[did]" pytest coverage
+
+# Testziel: durchgereichte Argumente oder – wenn keine – die komplette Suite.
+TARGETS=("$@")
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  TARGETS=(tests/)
+fi
+
+echo "[ci] führe Tests aus: ${TARGETS[*]}"
+# --continue-on-collection-errors: ein kaputtes Testmodul soll nicht die
+# Ausführung aller übrigen Tests verhindern (Fehler werden trotzdem rot gemeldet).
+"$PYBIN" -m coverage run -m pytest --continue-on-collection-errors "${TARGETS[@]}"
+
+echo
+echo "[ci] Coverage (sdata/did):"
+"$PYBIN" -m coverage report -m --include="sdata/did/*" || true
+
+echo "[ci] OK"


### PR DESCRIPTION
## Überblick

Fügt eine **lokale CI** hinzu — bewusst **ohne** GitHub Actions / Online-CI.

## Inhalt

- **`ci/local-ci.sh`**: legt eine isolierte `.venv-ci` an, installiert `sdata[did]` + `pytest`/`coverage`, läuft komplett **offline** (kein coveralls/Upload), reicht Argumente an pytest durch und toleriert Collection-Fehler (`--continue-on-collection-errors`), damit ein kaputtes Testmodul nicht die übrige Suite blockiert.
- **`Makefile`**: `make ci` (volle Suite), `make did-test` (nur DID), `make test`, `make clean-ci`, `make help`.
- **`.gitignore`**: `.venv-ci/`, `.pytest_cache/` sowie Secret-/Key-Regeln für `sdata.did` (`*.pem`, `*_key.json`, `did.json`, `*.jws`, …).

## Stand

- DID-Subpackage: **44/44 grün**, ~75 % Coverage (`make did-test`).
- Die volle Suite zeigt **vorbestehende**, vom DID-Refactor unabhängige Brüche (Base/workbook/blob/iolib) aus dem laufenden Refactor — separat zu behandeln.
