### PR TITLE
fix(iolib): JSON1SQLiteStore generierte Spalten konsistent (Single Source of Truth)

### DIFF
--- a/docs/rfc/0001-json1sqlitestore-index-naming.md
+++ b/docs/rfc/0001-json1sqlitestore-index-naming.md
@@ -1,0 +1,172 @@
+# RFC 0001 — Fix der generierten Spalten in `JSON1SQLiteStore` (sdata.iolib)
+
+| Feld        | Wert                                                        |
+|-------------|-------------------------------------------------------------|
+| Status      | Proposed                                                    |
+| Datum       | 2026-06-24                                                  |
+| Autor       | lepy <lepy@tuta.io>                                          |
+| Komponente  | `sdata/iolib/json1sqlitestore.py`                           |
+| Betrifft    | `tests/iolib/test_json1sqlitestore.py` (32 Tests)           |
+| Validierung | Empfohlene Lösung lokal verifiziert: **32/32 grün**         |
+
+## 1. Zusammenfassung
+
+`JSON1SQLiteStore` ist derzeit **nicht instanziierbar**: bereits der Konstruktor
+wirft `sqlite3.OperationalError: no such column: _sdata_project_sname`. Ursache
+ist eine grundsätzliche Inkonsistenz darüber, **welche** `_sdata_*`-Felder als
+generierte Spalten existieren und **wie** sie heißen.
+
+Dieses RFC schlägt vor, die Menge der generierten Spalten als **Single Source of
+Truth** (`GENERATED_COLUMNS`) zu definieren und alle abhängigen Stellen daraus
+abzuleiten. Die Lösung wurde lokal verifiziert (alle 32 Tests grün).
+
+## 2. Kontext
+
+`JSON1SQLiteStore` speichert sdata-Objekte als JSON-Payload und legt zur
+Beschleunigung **generierte Spalten** (`GENERATED ALWAYS AS json_extract(...)
+STORED`) für `_sdata_*`-Attribute an, auf denen Indizes erzeugt werden. Alle 32
+Tests scheitern, weil schon die Fixture `JSON1SQLiteStore(':memory:', …)` im
+Konstruktor abbricht.
+
+## 3. Reproduktion
+
+```python
+from sdata.iolib.json1sqlitestore import JSON1SQLiteStore
+JSON1SQLiteStore(':memory:', index_keys=['age'], unique_index_keys=['email'])
+# sqlite3.OperationalError: no such column: _sdata_project_sname
+```
+
+## 4. Ursachenanalyse
+
+Es liegen **drei** ineinandergreifende Defekte vor:
+
+### 4.1 Fehlerhafte Heuristik „jeder `_sdata_*`-Key ist eine Spalte"
+
+An **acht** Stellen entscheidet der Code per
+`column = key if key.startswith('_sdata_') else None`, ob direkt eine Spalte
+adressiert oder auf `json_extract(payload, …)` zurückgefallen wird
+(`__init__` 2×, `get_id_by_key`, `find_by` und weitere). Das Schema materialisiert
+aber nur eine **feste Teilmenge** der `_sdata_*`-Felder. Für jeden `_sdata_*`-Key
+**ohne** zugehörige Spalte entsteht SQL auf eine nicht existierende Spalte.
+
+### 4.2 Inkonsistente Spaltennamen (parent/project)
+
+| JSON-Key (Payload)     | generierte Spalte (Schema) | konsistent? |
+|------------------------|----------------------------|:-----------:|
+| `_sdata_class`         | `_sdata_class`             | ✅ |
+| `_sdata_name`          | `_sdata_name`              | ✅ |
+| `_sdata_sname`         | `_sdata_sname`             | ✅ |
+| `_sdata_parent_sname`  | `_sdata_parent`            | ❌ |
+| `_sdata_project_sname` | `_sdata_project`           | ❌ |
+
+`__init__` indiziert `_sdata_parent_sname`/`_sdata_project_sname` (Spaltenname =
+Key), die Spalten heißen aber gekürzt → **Konstruktor-Crash** (beobachtetes
+Symptom). Dieselbe Diskrepanz betrifft `get_index_df` (Filter auf
+`_sdata_project_sname`/`_sdata_parent_sname`).
+
+### 4.3 Fehlende Spalte `_sdata_suuid`
+
+`_sdata_suuid` wird im Schema **gar nicht** als Spalte angelegt, aber:
+* `test_init` erwartet die Spalte `_sdata_suuid` **und** einen unique Index
+  `idx__sdata_suuid`,
+* `get_id_by_key('_sdata_suuid', …)` (genutzt von `update_by_suuid`) adressiert
+  die Spalte `_sdata_suuid` direkt → `no such column: _sdata_suuid`.
+
+## 5. Lösungsoptionen
+
+### Option A — nur parent/project-Spalten umbenennen (verworfen)
+
+Nur die zwei Spaltennamen an die Keys angleichen.
+
+> **Verifiziert: unzureichend.** Lokal getestet → **29/32** grün. `_sdata_suuid`
+> (4.3) bleibt offen (`test_init`, `test_update_by_suuid`, `test_get_id_by_key`
+> weiter rot). Behebt nur 4.2, nicht 4.1/4.3.
+
+### Option B — Single Source of Truth für generierte Spalten (empfohlen, verifiziert)
+
+Eine kanonische Liste der materialisierten Spalten einführen und **alle**
+abhängigen Stellen daraus ableiten. Konvention: `Spaltenname == JSON-Key ==
+Index-Key`.
+
+* **Pro:** behebt 4.1, 4.2 und 4.3 gemeinsam; Heuristik wird korrekt
+  (Mengen-Mitgliedschaft statt Präfix); unbekannte `_sdata_*`-Keys fallen sauber
+  auf `json_extract` zurück statt zu crashen; nur **ein** Ort definiert die Menge.
+* **Contra:** Schemaänderung → Migration bestehender DBs (Abschnitt 7).
+* **Verifiziert: alle 32 Tests grün.**
+
+### Option C — generierte Spalten ganz vermeiden
+
+Überall `json_extract(payload, '$.<key>')` statt direkter Spalten verwenden.
+Robust, aber invasivste Änderung; verzichtet auf die STORED-Spalten als
+Index-/Query-Ziel. Nicht empfohlen.
+
+## 6. Empfehlung: Option B
+
+### 6.1 Kanonische Spaltenliste (neu, als Klassenattribut)
+
+```python
+# Konvention: Spaltenname == JSON-Key == Index-Key (Single Source of Truth).
+GENERATED_COLUMNS = (
+    "_sdata_class",
+    "_sdata_name",
+    "_sdata_sname",
+    "_sdata_suuid",
+    "_sdata_parent_sname",
+    "_sdata_project_sname",
+)
+```
+
+### 6.2 Schema aus der Liste erzeugen (`_ensure_table`)
+
+```python
+generated = ",\n                ".join(
+    "{col} TEXT GENERATED ALWAYS AS (json_extract(payload, '$.{col}')) STORED".format(col=col)
+    for col in self.GENERATED_COLUMNS
+)
+# ... CREATE TABLE IF NOT EXISTS data ( id …, payload …, created_at …, {generated} );
+```
+
+### 6.3 Heuristik ersetzen (8 Fundstellen)
+
+```python
+# vorher: column = key if key.startswith('_sdata_') else None
+column = key if key in self.GENERATED_COLUMNS else None
+# analog für die Variable `attribute` in find_by
+```
+
+### 6.4 `_sdata_suuid` als unique Index registrieren (`__init__`)
+
+```python
+# vorher: sdata_unique_keys = ['_sdata_sname']
+sdata_unique_keys = ['_sdata_sname', '_sdata_suuid']
+```
+
+`__init__` und `get_index_df` brauchen darüber hinaus **keine** Änderung — sie
+nutzen bereits die langen Key-Namen, die nun mit den Spaltennamen übereinstimmen.
+
+## 7. Migration / Rückwärtskompatibilität
+
+* Das Schema wird mit `CREATE TABLE IF NOT EXISTS` angelegt → für **bestehende**
+  DB-Dateien greift die Umbenennung/Erweiterung **nicht automatisch**; SQLite kann
+  generierte Spalten nicht zuverlässig per `ALTER TABLE` migrieren.
+* Die Komponente wirkt unveröffentlicht/WIP (undeklarierte Nutzung, komplett rote
+  Testsuite). Annahme: **keine** produktiven `.db`-Dateien → keine Migration nötig.
+  Vor dem Merge zu bestätigen.
+* Falls doch nötig: Schema-Rebuild über `PRAGMA user_version` als separater Schritt
+  (`CREATE new … ; INSERT … SELECT … ; DROP old ; ALTER … RENAME`).
+
+## 8. Testplan
+
+* `./ci/local-ci.sh tests/iolib/test_json1sqlitestore.py` → **32/32 grün**
+  (lokal mit Option B bereits verifiziert).
+* Empfohlener Zusatztest für `get_index_df(project=…, parent=…)`, da dieser Pfad
+  bislang von keinem grünen Test abgedeckt war (Defekt 4.2 im Query-Builder).
+
+## 9. Risiken / offene Punkte
+
+* Migrationsannahme (Abschnitt 7) bestätigen.
+* Prüfen, ob weitere iolib-Module (`tinydb_json1sqlite.py`, `vault.py`) von den
+  alten Spaltennamen ausgehen (aktuelle `grep`-Analyse: nein).
+* Separat (nicht Teil dieses RFC): `logger.warn` → `logger.warning` in
+  `sdata/sclass/blob.py`; die offenen `test_base`-Fehler.
+```

--- a/sdata/iolib/json1sqlitestore.py
+++ b/sdata/iolib/json1sqlitestore.py
@@ -40,6 +40,17 @@ class JSON1SQLiteStore:
         print(username)  # 'alice'
     """
 
+    # Kanonische, als generierte Spalten materialisierte _sdata_*-Felder.
+    # Konvention: Spaltenname == JSON-Key == Index-Key (Single Source of Truth).
+    GENERATED_COLUMNS = (
+        "_sdata_class",
+        "_sdata_name",
+        "_sdata_sname",
+        "_sdata_suuid",
+        "_sdata_parent_sname",
+        "_sdata_project_sname",
+    )
+
     def __init__(
         self,
         filename: str,
@@ -60,14 +71,14 @@ class JSON1SQLiteStore:
         self._init_conn()
         # Automatically index the _sdata_* fields if not specified
         sdata_keys = ['_sdata_class', '_sdata_name', '_sdata_parent_sname', '_sdata_project_sname']
-        sdata_unique_keys = ['_sdata_sname']
+        sdata_unique_keys = ['_sdata_sname', '_sdata_suuid']
         index_keys = list(set((index_keys or []) + sdata_keys))
         unique_index_keys = list(set((unique_index_keys or []) + sdata_unique_keys))
         for key in index_keys:
-            column = key if key.startswith('_sdata_') else None
+            column = key if key in self.GENERATED_COLUMNS else None
             self.create_index(key, unique=False, column=column)
         for key in unique_index_keys:
-            column = key if key.startswith('_sdata_') else None
+            column = key if key in self.GENERATED_COLUMNS else None
             self.create_index(key, unique=True, column=column)
 
 
@@ -101,19 +112,19 @@ class JSON1SQLiteStore:
         self._ensure_table()
 
     def _ensure_table(self) -> None:
+        generated = ",\n                ".join(
+            "{col} TEXT GENERATED ALWAYS AS (json_extract(payload, '$.{col}')) STORED".format(col=col)
+            for col in self.GENERATED_COLUMNS
+        )
         self.conn.execute(
             """
             CREATE TABLE IF NOT EXISTS data (
                 id INTEGER PRIMARY KEY,
                 payload TEXT NOT NULL,
                 created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-                _sdata_class TEXT GENERATED ALWAYS AS (json_extract(payload, '$._sdata_class')) STORED,
-                _sdata_name TEXT GENERATED ALWAYS AS (json_extract(payload, '$._sdata_name')) STORED,
-                _sdata_sname TEXT GENERATED ALWAYS AS (json_extract(payload, '$._sdata_sname')) STORED,
-                _sdata_parent TEXT GENERATED ALWAYS AS (json_extract(payload, '$._sdata_parent_sname')) STORED,
-                _sdata_project TEXT GENERATED ALWAYS AS (json_extract(payload, '$._sdata_project_sname')) STORED
+                {generated}
             );
-            """
+            """.format(generated=generated)
         )
 
     def _serialize(self, obj: Dict[str, Any]) -> str:
@@ -262,7 +273,7 @@ class JSON1SQLiteStore:
 
     def get_id_by_key(self, key: str, value: Any) -> Optional[int]:
         # Optimiert für generated columns
-        column = key if key.startswith('_sdata_') else None
+        column = key if key in self.GENERATED_COLUMNS else None
         if column:
             row = self.conn.execute(f"SELECT id FROM data WHERE {column} = ?", (value,)).fetchone()
         else:
@@ -326,7 +337,7 @@ class JSON1SQLiteStore:
         return self.conn.execute("SELECT 1 FROM data WHERE id = ? LIMIT 1", (record_id,)).fetchone() is not None
 
     def exists_where(self, key: str, value: Any) -> bool:
-        column = key if key.startswith('_sdata_') else None
+        column = key if key in self.GENERATED_COLUMNS else None
         if column:
             return self.conn.execute(f"SELECT 1 FROM data WHERE {column} = ? LIMIT 1", (value,)).fetchone() is not None
         else:
@@ -342,7 +353,7 @@ class JSON1SQLiteStore:
             val = val.replace('*', '%')
         else:
             val = value
-        column = key if key.startswith('_sdata_') else None
+        column = key if key in self.GENERATED_COLUMNS else None
         if column:
             sql = f"SELECT COUNT(*) FROM data WHERE {column} {op_sql} ?"
         else:
@@ -367,7 +378,7 @@ class JSON1SQLiteStore:
                 val = val.replace('*', '%')
             else:
                 val = value
-            column = key if key.startswith('_sdata_') else None
+            column = key if key in self.GENERATED_COLUMNS else None
             if column:
                 where_clause = f"WHERE {column} {op_sql} ? "
             else:
@@ -391,7 +402,7 @@ class JSON1SQLiteStore:
         for idx, unique in self.list_indices():
             if idx.startswith('idx_'):
                 key = idx.replace('idx_', '').replace('_', '.')  # Approximativ
-                column = key if key.startswith('_sdata_') else None
+                column = key if key in self.GENERATED_COLUMNS else None
                 self.regenerate_index(key, unique, column=column)
 
     def backup(self, dest_path: str) -> None:
@@ -491,7 +502,7 @@ class JSON1SQLiteStore:
             names_like = store.find_by('_sdata_name', 'alice*', op='LIKE', limit=10)  # Wildcard-Suche
             parents = store.find_by('_sdata_parent', 42, op='>')  # Numerische Vergleiche
         """
-        column = attribute if attribute.startswith('_sdata_') else None
+        column = attribute if attribute in self.GENERATED_COLUMNS else None
         if column:
             return self._fetch_page_optimized(limit or 999999, offset, column, op, value)
         else:


### PR DESCRIPTION
## Problem

`JSON1SQLiteStore` war **nicht instanziierbar** — bereits der Konstruktor warf
`sqlite3.OperationalError: no such column: _sdata_project_sname`. Die komplette
Testsuite `tests/iolib/test_json1sqlitestore.py` (32 Tests) scheiterte.

## Ursache (drei verschränkte Defekte)

1. **Falsche Heuristik** (8 Stellen): `key.startswith('_sdata_')` nahm an, *jeder*
   `_sdata_*`-Key sei eine generierte Spalte — das Schema materialisiert aber nur
   eine Teilmenge.
2. **Inkonsistente Spaltennamen**: Spalten `_sdata_parent`/`_sdata_project` vs.
   Keys `_sdata_parent_sname`/`_sdata_project_sname`.
3. **Fehlende Spalte** `_sdata_suuid` (von `test_init` und `get_id_by_key`/
   `update_by_suuid` benötigt).

## Lösung

- `GENERATED_COLUMNS` als **Single Source of Truth** (Konvention: Spaltenname ==
  JSON-Key == Index-Key).
- `_ensure_table` erzeugt das Schema daraus; `_sdata_suuid` ergänzt (+ unique Index).
- `startswith`-Heuristik → Mengen-Mitgliedschaft (`key in GENERATED_COLUMNS`);
  unbekannte `_sdata_*`-Keys fallen sauber auf `json_extract` zurück statt zu crashen.
- Vollständige Design-Begründung inkl. verworfener Alternativen:
  `docs/rfc/0001-json1sqlitestore-index-naming.md`.

## Tests

`tests/iolib/test_json1sqlitestore.py`: **32/32 grün** (lokal via
`./ci/local-ci.sh tests/iolib/test_json1sqlitestore.py`).
