### PR TITLE
feat(suuid): sdata.suuid auf das suuid-Package umstellen (Adapter)

### DIFF
--- a/sdata/base.py
+++ b/sdata/base.py
@@ -77,19 +77,17 @@ class Base:
             self.SDATA_PROJECT_SNAME, project_sname, dtype="str",
             description="sname of the project"
         )
-        ns_name = project_sname or None
+        # Namespace: expliziter ns_name-Kwarg hat Vorrang, sonst die Projekt-sname
+        # (hierarchisches Scoping), sonst der Default-Namespace.
+        ns_name = kwargs.get("ns_name") or project_sname or None
 
         _suuid = kwargs.get("suuid", None)
         if _suuid and isinstance(_suuid, SUUID):
             suuid = _suuid
-        elif ns_name is not None: # namespace = self.project.sname
-            suuid = SUUID.from_name(
-                class_name=self.__class__.__name__,
-                name=SUUID.generate_safe_filename(name),
-                ns_name=kwargs.get("ns_name", "")
-            )
         else:
-            suuid = SUUID(self.__class__.__name__, name=SUUID.generate_safe_filename(name))
+            # Deterministisch und (falls vorhanden) ns-gescopt; suuid.from_name
+            # normalisiert den Namen S3-sicher.
+            suuid = SUUID.from_name(self.__class__.__name__, name, ns_name=ns_name)
 
         self.default_attributes: List[Dict[str, Any]] = []
 

--- a/sdata/suuid.py
+++ b/sdata/suuid.py
@@ -1,291 +1,136 @@
-import uuid
-import base64
-import hashlib
-import os
-import re
-import unicodedata
-import logging
+"""sdata.suuid — Adapter auf das eigenständige ``suuid``-Package.
+
+Ab jetzt ist **``suuid``** (``pip install "suuid>=0.2.0"``) die Single Source of
+Truth für semantische, S3-sichere IDs der Form ``Class__safe_name__huuid``.
+Dieses Modul ist ein dünner Rückwärtskompatibilitäts-Adapter: es bildet die
+historisch in sdata genutzte SUUID-API auf das ``suuid``-Package ab.
+
+Mapping (sdata → suuid):
+  ``suuid_str`` / ``suuid_bytes``        → :attr:`suuid.SUUID.compact_token`
+  ``uuid`` / ``get_uuid()``              → :meth:`suuid.SUUID.as_uuid`
+  ``from_name(ns_name=…)``               → :meth:`suuid.SUUID.from_name` (``ns=…``)
+  ``from_suuid_sname(strict=False)``     → :meth:`suuid.SUUID.from_sname`
+  ``from_suuid_str`` / ``from_suuid_bytes`` → :meth:`suuid.SUUID.from_compact_token`
+  ``generate_safe_filename``             → :func:`suuid.safe_name`
+
+Damit gilt durchgängig die in ``suuid`` eingefrorene, 100% S3-sichere
+Normalisierung (kein führendes ``_``, kein ``@``, ``sname`` ∈ ``[A-Za-z0-9_]``).
 """
-SUUID
-"""
+from __future__ import annotations
+
+import uuid as _uuid
+from typing import Optional
+
+from suuid import SUUID as _SUUID, OID_NAMESPACE, safe_name  # noqa: F401
+from suuid.core import clean_class_name
+
+__all__ = ["SUUID"]
 
 
-class SUUID:
-    """ SUUID = b64(huuid + class_name + SEP + name)
+class SUUID(_SUUID):
+    """sdata-Adapter um :class:`suuid.SUUID` mit Kompatibilitäts-Aliassen.
 
-        Eine semantische UUID, die Klasse, Name und eine UUID kombiniert.
-
-        Examples:
-            >>> sid = SUUID.from_name(class_name="MyClass", name="MyName")
-            >>> str(sid)
-            '(MyClass@MyName@78bc2bf739005a7bbc14019f767dbdc1)'
-
-            >>> sid.suuid
-            b'NzhiyzJiZjczOTAwNWE3YmJjMTQwMTlmNzY3ZGJkYzFNeUNsYXNzQE15TmFtZQ=='
-
-            >>> sid.suuid_str
-            'NzhiyzJiZjczOTAwNWE3YmJjMTQwMTlmNzY3ZGJkYzFNeUNsYXNzQE15TmFtZQ=='
-
-            >>> sid.to_dict()
-            {'class_name': 'MyClass',
-             'name': 'MyName',
-             'huuid': '78bc2bf739005a7bbc14019f767dbdc1',
-             'suuid': 'NzhiyzJiZjczOTAwNWE3YmJjMTQwMTlmNzY3ZGJkYzFNeUNsYXNzQE15TmFtZQ=='}
+    Erbt Immutabilität, Wertgleichheit und die S3-sichere Normalisierung von
+    :class:`suuid.SUUID`; ergänzt nur die in sdata genutzten Alias-Namen.
     """
 
+    #: Separator (Kompat-Konstante; identisch zu ``suuid`` ``SEP``).
     SEP = "__"
 
-    def __init__(self, class_name, name=None, huuid=None):
-        """Generiert ein SUUID-Objekt.
-
-        :param class_name: Name der Klasse, z.B. 'Data' (erforderlich, nicht-leerer String)
-        :param name: Name des Objekts, z.B. 'Otto' (optional, default: "")
-        :param huuid: Hex-String einer UUID, z.B. 'e1e9eaa45eba5cc1b5f035317771b22c' (optional, default: uuid4().hex)
-        """
-        if not class_name or not isinstance(class_name, str):
-            raise ValueError("class_name muss ein nicht-leerer String sein")
-        class_name = re.sub(r'[_.-]+', '_', class_name)
-        self.class_name = class_name
-        name = name or ""
-        self.name = self.generate_safe_filename(name)
-        self.huuid = huuid or uuid.uuid4().hex
-        if len(self.huuid) != 32 or not all(c in '0123456789abcdefABCDEF' for c in self.huuid):
-            raise ValueError(f"huuid muss ein 32-Zeichen langer Hex-String sein '{self.huuid}'")
-
-    @staticmethod
-    def generate_safe_filename(original_name: str) -> str:
-        r"""
-        Generiert einen sicheren Dateinamen, der kompatibel mit Linux, Windows, AWS S3 und als Datenbank-Spaltenname oder Index-Name ist.
-
-        - Konvertiert zu Lowercase.
-        - Ersetzt Umlaute und Sonderzeichen durch ASCII-Äquivalente oder Unterstriche.
-        - Erlaubt nur alphanumerische Zeichen (a-z, 0-9), Unterstriche (_) und Punkte (.).
-        - Entfernt verbotene Zeichen für Windows (z.B. < > : " / \ | ? *).
-        - Reduziert multiple Unterstriche zu einem.
-        - Entfernt leading/trailing Unterstriche oder Punkte.
-        - Stellt sicher, dass der Name mit einem Buchstaben oder Unterstrich beginnt (für DB-Kompatibilität).
-        - Begrenzt die Länge auf 255 Zeichen (sichere Grenze für die meisten Dateisysteme).
-
-        :param original_name: Der ursprüngliche Name (str).
-        :return: Der sichere Dateiname (str).
-        """
-        if not isinstance(original_name, str):
-            original_name = str(original_name)
-
-        # Ersetze verbotene Zeichen für Windows und allgemeine Sicherheit
-        forbidden = r'[<>:"/\\|?*]'
-        original_name = re.sub(forbidden, '_', original_name)
-
-        # Konvertiere Umlaute und andere diakritische Zeichen zu ASCII
-        mapper = {
-            "ä": "ae", "ö": "oe", "ü": "ue", "Ä": "Ae", "Ö": "Oe", "Ü": "Ue",
-            "ß": "ss", "é": "e", "è": "e", "ê": "e", "ë": "e",
-            "á": "a", "à": "a", "â": "a", "ã": "a", "å": "a",
-            "ç": "c", "ñ": "n", "ø": "o", " ": "_", "!": "_", "@": "_at_",
-            "#": "_", "$": "_", "%": "_", "^": "_", "&": "_", "*": "_",
-            "(": "_", ")": "_", ";": "_", ",": "_", "+": "_", "=": "_",
-            "[": "_", "]": "_", "{": "_", "}": "_", "`": "_", "~": "_"
-        }
-        for k, v in mapper.items():
-            original_name = original_name.replace(k, v)
-
-        # Normalisiere zu ASCII und entferne nicht-ASCII-Zeichen
-        original_name = unicodedata.normalize('NFKD', original_name).encode('ascii', 'ignore').decode('ascii')
-
-        # Zu Lowercase
-        name = original_name.lower()
-
-        # Ersetze ungültige Zeichen mit _
-        # Erlaube nur a-z, 0-9, _, .
-        name = re.sub(r'[^a-z0-9_.]', '_', name)
-
-        # Reduziere multiple _ oder . zu _
-        name = re.sub(r'[_.-]+', '_', name)
-
-        # Entferne leading/trailing _ oder .
-        name = name.strip('_.')
-
-        # Stelle sicher, dass es mit einem Buchstaben oder _ beginnt (für DB)
-        if name and (name[0].isdigit() or name[0] == '.'):
-            name = '_' + name
-
-        # Begrenze auf 255 Zeichen
-        if len(name) > 255:
-            name = name[:255]
-
-        # Falls der Name leer wird, fallback zu einem Standard
-        if not name:
-            name = 'noname'
-
-        return name
-
-    def __str__(self):
-        return f"<SUUID:{self.class_name}{self.SEP}{self.name}{self.SEP}{self.huuid}>"
-
-    def __repr__(self):
-        return f"<SUUID:{self.class_name}{self.SEP}{self.name}{self.SEP}{self.huuid}>"
-
-    def get_uuid(self):
-        """UUID-Objekt aus huuid."""
-        return uuid.UUID(hex=self.huuid)
+    # --- Property-Aliasse ------------------------------------------------
+    @property
+    def suuid_str(self) -> str:
+        """Kompakter Base64-Token (Alias auf :attr:`compact_token`)."""
+        return self.compact_token
 
     @property
-    def uuid(self):
-        """UUID-Objekt aus huuid."""
-        return uuid.UUID(hex=self.huuid)
+    def suuid_bytes(self) -> bytes:
+        """:attr:`suuid_str` als UTF-8-Bytes."""
+        return self.compact_token.encode()
 
     @property
-    def did(self):
-        """DID"""
-        return f"did:sdata-suuid:{self.sname}"
+    def uuid(self) -> _uuid.UUID:
+        """Das :class:`uuid.UUID`-Objekt hinter ``huuid``."""
+        return self.as_uuid()
 
-    @property
-    def hex(self):
-        """Hex-String der UUID."""
-        return self.huuid
+    def get_uuid(self) -> _uuid.UUID:
+        """Wie :attr:`uuid`."""
+        return self.as_uuid()
 
-    def to_list(self):
-        """Gibt eine Liste mit [suuid_str, class_name, name, huuid] zurück."""
+    def to_list(self) -> list:
+        """``[sname, suuid_str, class_name, name, huuid]`` (sdata-Kompat)."""
         return [self.sname, self.suuid_str, self.class_name, self.name, self.huuid]
 
-    def to_dict(self):
-        """Gibt ein Dict mit class_name, name, huuid und suuid_str zurück."""
-        return {
-            "class_name": self.class_name,
-            "name": self.name,
-            "huuid": self.huuid,
-            "suuid": self.suuid_str,
-            "sname": self.sname,
-        }
+    def to_dict(self) -> dict:
+        """Wie :meth:`suuid.SUUID.to_dict`, plus sdata-Alias ``suuid``."""
+        d = super().to_dict()
+        d["suuid"] = self.suuid_str
+        return d
 
-    @property
-    def sname(self):
-        """String-Repräsentation: class_name@name@huuid"""
-        return self.SEP.join([self.class_name, self.name, self.huuid])
-
-    @property
-    def suuid_bytes(self):
-        """Base64-kodierte Bytes: huuid + class_name + SEP + name"""
-        s = self.huuid + self.class_name + self.SEP + self.name
-        return base64.b64encode(s.encode())
-
-    @property
-    def suuid_str(self):
-        """Base64-kodierter String (decoded von suuid)."""
-        return self.suuid_bytes.decode().strip()
+    # --- Konstruktoren mit sdata-Signaturen ------------------------------
+    @classmethod
+    def from_name(cls, class_name: str, name: str = "",
+                  ns_name: Optional[str] = None) -> "SUUID":
+        """Deterministische SUUID; ``ns_name`` (String) scoped die ID."""
+        ns = OID_NAMESPACE if not ns_name else ns_name
+        return super().from_name(class_name, name, ns=ns)
 
     @classmethod
-    def from_uuid(cls, class_name, uuid_obj):
-        """Erstellt SUUID aus class_name und UUID-Objekt (ohne name)."""
-        return cls(class_name, name="", huuid=uuid_obj.hex)
+    def from_suuid_sname(cls, s, strict: bool = False):
+        """Parse einen ``sname``; ``strict=False`` (Default) → ``None`` bei Fehler."""
+        return super().from_sname(s, strict=strict)
 
     @classmethod
-    def get_namespace_from_name(cls, name):
-        """Generiert Namespace-UUID aus String."""
-        return uuid.uuid5(uuid.NAMESPACE_OID, name.upper())
+    def from_suuid_str(cls, s: str) -> "SUUID":
+        """Aus :attr:`suuid_str`/compact-token rekonstruieren."""
+        return super().from_compact_token(s)
 
     @classmethod
-    def get_uuid_from_name(cls, name, ns_name=None):
-        """Generiert deterministische UUID aus name und optionalem Namespace."""
-        nsuuid = uuid.NAMESPACE_OID if ns_name is None else cls.get_namespace_from_name(ns_name)
-        return uuid.uuid5(nsuuid, name.upper())
+    def from_suuid_bytes(cls, b) -> "SUUID":
+        """Aus :attr:`suuid_bytes` rekonstruieren."""
+        token = b.decode() if isinstance(b, (bytes, bytearray)) else b
+        return super().from_compact_token(token)
 
     @classmethod
-    def from_name(cls, class_name, name, ns_name=None):
-        """Erstellt SUUID deterministisch aus class_name, name und optionalem Namespace."""
-        cleaned_name = cls.generate_safe_filename(name)
-        uid = cls.get_uuid_from_name(name=class_name + cleaned_name, ns_name=ns_name)
-        return cls(class_name=class_name, name=cleaned_name, huuid=uid.hex)
+    def from_file(cls, class_name: str, filepath, ns_name: Optional[str] = None) -> "SUUID":
+        """Content-adressierte SUUID aus Dateiinhalt (``name`` = Basename)."""
+        ns = OID_NAMESPACE if not ns_name else ns_name
+        return super().from_file(class_name, filepath, ns=ns)
 
     @classmethod
-    def get_suuid_from_name(cls, class_name, name, ns_name=None):
-        """Gibt den Base64-Bytes-SUUID aus from_name zurück."""
-        suuid_obj = cls.from_name(class_name, name, ns_name)
-        return suuid_obj.suuid_bytes
+    def from_str(cls, class_name: str, s: str, ns_name: Optional[str] = None) -> "SUUID":
+        """Content-adressierte SUUID aus einem String."""
+        ns = OID_NAMESPACE if not ns_name else ns_name
+        return super().from_content(class_name, "", s.encode("utf-8"), ns=ns)
 
     @classmethod
-    def get_sname_from_name(cls, class_name, name, ns_name=None):
-        """Gibt den sname-String aus from_name zurück."""
-        suuid_obj = cls.from_name(class_name, name, ns_name)
-        return suuid_obj.sname
+    def from_uuid(cls, class_name: str, uuid_obj: _uuid.UUID) -> "SUUID":
+        """SUUID aus ``class_name`` und einem :class:`uuid.UUID` (ohne Name)."""
+        return cls(class_name=clean_class_name(class_name), name="", huuid=uuid_obj.hex)
 
     @classmethod
-    def from_file(cls, class_name, filepath, ns_name=None):
-        """Erstellt SUUID aus Dateiinhalt (Hash) und Dateinamen."""
-        sh = hashlib.sha3_256()
-        with open(filepath, "rb") as fh:
-            sh.update(fh.read())
-        content_hash = sh.hexdigest()
-        basename = os.path.basename(filepath)
-        suuid_obj = cls.from_name(class_name=class_name, name=content_hash, ns_name=ns_name)
-        suuid_obj.name = cls.generate_safe_filename(basename)  # Überschreibt name mit Dateinamen
-        return suuid_obj
+    def from_obj(cls, obj, class_name: Optional[str] = None):
+        """Koerziere ein Base-artiges Objekt, einen ``sname`` oder String zu SUUID."""
+        if obj is None:
+            return None
+        if hasattr(obj, "sname"):
+            return cls.from_suuid_sname(obj.sname, strict=False)
+        if isinstance(obj, str):
+            parsed = cls.from_suuid_sname(obj, strict=False)
+            return parsed if parsed is not None else cls.from_name(class_name or cls.__name__, obj)
+        return None
 
-    @classmethod
-    def from_str(cls, class_name, s, ns_name=None):
-        """Erstellt SUUID aus String-Inhalt (Hash)."""
-        sh = hashlib.sha3_256()
-        sh.update(s.encode('utf-8', errors='strict'))  # Raise bei Encoding-Fehlern
-        content_hash = "_" + sh.hexdigest()
-        return cls.from_name(class_name=class_name, name=content_hash, ns_name=ns_name)
+    # --- Statics ---------------------------------------------------------
+    @staticmethod
+    def generate_safe_filename(name: str) -> str:
+        """100% S3-sichere Normalisierung (Alias auf :func:`suuid.safe_name`)."""
+        return safe_name(name)
 
-    @classmethod
-    def from_suuid_bytes(cls, bytestring):
-        """Erstellt SUUID aus Base64-Bytes."""
-        id_string = base64.b64decode(bytestring).decode('utf-8')
-        return cls.from_idstr(id_string)
-
-    @classmethod
-    def from_suuid_str(cls, string):
-        """Erstellt SUUID aus Base64-String."""
-        id_string = base64.b64decode(string.encode('utf-8')).decode('utf-8')
-        return cls.from_idstr(id_string)
-
-    @classmethod
-    def from_suuid_sname(cls, s, strict=False):
-        """Erstellt SUUID aus sname-String (class_name@name@huuid)."""
+    @staticmethod
+    def is_valid_suuid_str(s: str) -> bool:
+        """``True``, wenn ``s`` ein gültiger :attr:`suuid_str` ist."""
         try:
-            parts = s.split(cls.SEP)
-            if len(parts) != 3:
-                raise ValueError(f"Ungültiger sname-Format: Muss genau zwei Separatoren enthalten '{parts}'")
-            class_name, name, huuid = parts
-            return cls(class_name=class_name, name=name, huuid=huuid)
-        except Exception as e:
-            if strict:
-                logging.warning(e)
-                raise
-            return
-
-    @classmethod
-    def from_idstr(cls, id_string):
-        """Erstellt SUUID aus decoded Base64-String (huuidclass_name@name)."""
-        if len(id_string) < 32:
-            raise ValueError("Ungültiger id_string: Zu kurz")
-        huuid = id_string[:32]
-        rest = id_string[32:]
-        try:
-            class_name, name = rest.split(cls.SEP, maxsplit=1)
-        except ValueError:
-            class_name = rest
-            name = ""
-        return cls(class_name=class_name, name=name, huuid=huuid)
-
-    @classmethod
-    def from_obj(cls, obj, class_name=None):
-        if class_name is None:
-            class_name = cls.__name__
-        suuid = None
-        if obj is not None and hasattr(obj, "sname"):
-            suuid = SUUID.from_suuid_sname(obj.sname)
-        elif obj is not None and issubclass(obj.__class__, (str,)):
-            try:
-                suuid = SUUID.from_suuid_sname(obj)
-            except ValueError:
-                suuid = SUUID.from_name(class_name, str(obj), ns_name="")
-        return suuid
-
-if __name__ == '__main__':
-    sid = SUUID.from_name(class_name="DATA", name="otto")
-    print(sid)
-    print(sid.suuid)
-    print(sid.to_dict())
+            _SUUID.from_compact_token(s)
+            return True
+        except Exception:
+            return False

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('sdata/__init__.py', 'r') as f:
 with open('README.md', 'rb') as f:
     readme = f.read().decode('utf-8')
 
-REQUIRES = ['numpy', 'pandas', 'tabulate', 'xlrd', 'openpyxl', 'xlsxwriter', 'pytz', 'requests', 'Pillow']
+REQUIRES = ['numpy', 'pandas', 'tabulate', 'xlrd', 'openpyxl', 'xlsxwriter', 'pytz', 'requests', 'Pillow', 'suuid>=0.2.0']
 
 # Optionale Abhängigkeiten für das DID-/VC-Subpackage (sdata.did):
 #   pip install "sdata[did]"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -53,18 +53,20 @@ def test_base_init_with_project(base_instance):
 def test_base_init_with_ns_name():
     b = Base(name="test", ns_name="namespace")
     # Since SUUID.from_name is called, assume it's reproducible
-    assert b.suuid.sname.startswith("Base@")  # Based on stub
+    assert b.suuid.sname.startswith("Base__")  # suuid '__'-Format
 
 def test_osname(base_instance):
     base_instance.name = "Häl[l]o.csv"
     assert base_instance.osname == 'hael_l_o_csv'
 
 def test_suuid_properties(base_instance):
+    from sdata import SUUID
     assert isinstance(base_instance.uuid, uuid.UUID)
     assert isinstance(base_instance.huuid, str)
     assert len(base_instance.huuid) == 32
-    assert base_instance.suuid_str == "MmY1YzY5MjQ0OWU5NWY5MGE3MTU4NjFmMjgzM2QzNWFCYXNlQHRlc3RfbmFtZQ=="
-    assert base_instance.suuid_bytes == b"MmY1YzY5MjQ0OWU5NWY5MGE3MTU4NjFmMjgzM2QzNWFCYXNlQHRlc3RfbmFtZQ=="
+    # suuid_str ist der kompakte Token und round-trippt zum selben sname
+    assert SUUID.from_suuid_str(base_instance.suuid_str).sname == base_instance.sname
+    assert base_instance.suuid_bytes == base_instance.suuid_str.encode()
 
 # def test_set_suuid_invalid(base_instance):
 #     with pytest.raises(SdataUuidException, match="Invalid SUUID string"):

--- a/tests/test_suuid.py
+++ b/tests/test_suuid.py
@@ -2,43 +2,23 @@
 import logging
 logger = logging.getLogger("sdata")
 
-import sys
-import os
-import pandas as pd
-
-modulepath = os.path.dirname(__file__)
-
-sys.path.insert(0, os.path.join(modulepath, "..", "..", "src"))
-
 import sdata
-import uuid
+
 
 def test_suuid():
-    suuid = sdata.SUUID("Data", "Otto")
-    suuid, suuid.to_list()
-    assert suuid.name == "otto"
+    sid = sdata.SUUID.from_name("Data", "Otto")
+    assert sid.class_name == "Data"
+    assert sid.name == "otto"                       # S3-sicher normalisiert
+    assert sid.sname == f"Data__otto__{sid.huuid}"
+
 
 def test_suuid_from_name():
-    suuid = sdata.SUUID.from_name(class_name="MyClass", name="Otto")
-    suuid, suuid.to_list()
-    #((MyClass|Otto|9120846d11185cbd9c06742056d757ad),
- # ['OTEyMDg0NmQxMTE4NWNiZDljMDY3NDIwNTZkNzU3YWRNeUNsYXNzfE90dG8=',
- #  'MyClass',
- #  'Otto',
- #  '9120846d11185cbd9c06742056d757ad'])
-    print(suuid.huuid)
-    print(suuid.suuid_str)
-    print(suuid.sname)
+    sid = sdata.SUUID.from_name(class_name="MyClass", name="Otto")
+    assert sid.huuid == "d090bdae83315b8b935ea4c71ef86b2f"   # golden (unverändert)
+    assert sid.name == "otto"
+    assert sid.class_name == "MyClass"
 
-
-    assert suuid.huuid=='d090bdae83315b8b935ea4c71ef86b2f'
-    assert suuid.name == 'otto'
-    assert suuid.suuid_str == 'ZDA5MGJkYWU4MzMxNWI4YjkzNWVhNGM3MWVmODZiMmZNeUNsYXNzQG90dG8='
-    assert suuid.class_name == 'MyClass'
-
-    s = sdata.SUUID.from_suuid_str(suuid.suuid_str)
-    assert s.huuid=='d090bdae83315b8b935ea4c71ef86b2f'
-    assert s.name == 'otto'
-    assert s.suuid_str == 'ZDA5MGJkYWU4MzMxNWI4YjkzNWVhNGM3MWVmODZiMmZNeUNsYXNzQG90dG8='
-    assert s.class_name == 'MyClass'
-
+    # Roundtrip über den kompakten Token (suuid_str)
+    restored = sdata.SUUID.from_suuid_str(sid.suuid_str)
+    assert restored == sid
+    assert restored.huuid == sid.huuid

--- a/tests/test_suuid_class.py
+++ b/tests/test_suuid_class.py
@@ -1,184 +1,121 @@
-import pytest
+# -*- coding: utf-8 -*-
+"""Tests für den sdata.suuid-Adapter über das eigenständige ``suuid``-Package.
+
+Der Adapter erbt Format, Determinismus und die 100% S3-sichere Normalisierung von
+``suuid``; getestet wird hier die sdata-Kompat-Fläche (Alias-Namen, Signaturen).
+Die huuid-Goldenwerte bleiben gegenüber der alten Implementierung gültig (gleicher
+uuid5-Algorithmus); ``sname``/``suuid_str`` tragen jetzt das ``__``-Format.
+"""
+import re
 import uuid
-import base64
-import hashlib
-import os
-import tempfile
 
-from sdata.suuid import SUUID  # Angenommen, der Code ist in suuid.py gespeichert
+import pytest
 
-@pytest.fixture
-def temp_file():
-    with tempfile.NamedTemporaryFile(delete=False) as tmp:
-        tmp.write(b"test content")
-        tmp_path = tmp.name
-    yield tmp_path
-    os.unlink(tmp_path)
+from sdata.suuid import SUUID
+
+HEX = "1234567890abcdef1234567890abcdef"
+S3_SAFE = re.compile(r"[A-Za-z0-9_]+")
+
 
 class TestSUUID:
 
-    def test_init_valid(self):
-        sid = SUUID(class_name="Test", name="name", huuid="1234567890abcdef1234567890abcdef")
-        assert sid.class_name == "Test"
-        assert sid.name == "name"
-        assert sid.huuid == "1234567890abcdef1234567890abcdef"
+    # --- Konstruktion / Komponenten -------------------------------------
+    def test_direct_construction(self):
+        sid = SUUID(class_name="Test", name="name", huuid=HEX)
+        assert (sid.class_name, sid.name, sid.huuid) == ("Test", "name", HEX)
 
-    def test_init_default_huuid(self):
-        sid = SUUID(class_name="Test")
-        assert len(sid.huuid) == 32
-        assert all(c in '0123456789abcdefABCDEF' for c in sid.huuid)
-        assert sid.name == "noname"
+    def test_huuid_required_and_validated(self):
+        with pytest.raises(ValueError):
+            SUUID(class_name="Test", name="x", huuid="invalid")
+        with pytest.raises(ValueError):
+            SUUID(class_name="", name="x", huuid=HEX)
 
-    def test_init_invalid_class_name(self):
-        with pytest.raises(ValueError, match="class_name muss ein nicht-leerer String sein"):
-            SUUID(class_name="")
-        with pytest.raises(ValueError, match="class_name muss ein nicht-leerer String sein"):
-            SUUID(class_name=123)
-
-    def test_init_invalid_huuid(self):
-        with pytest.raises(ValueError, match="huuid muss ein 32-Zeichen langer Hex-String sein"):
-            SUUID(class_name="Test", huuid="invalid")
-        with pytest.raises(ValueError, match="huuid muss ein 32-Zeichen langer Hex-String sein"):
-            SUUID(class_name="Test", huuid="1234567890abcdef1234567890abcde")  # Zu kurz
-
-    def test_clean_name(self):
-        assert SUUID.generate_safe_filename("name@|;\n\rbad") == "name_bad"
-        assert SUUID.generate_safe_filename("") == "noname"
-        assert SUUID.generate_safe_filename("clean") == "clean"
-
-    def test_str_and_repr(self):
-        sid = SUUID(class_name="Test", name="name", huuid="1234567890abcdef1234567890abcdef")
-        assert str(sid) == "(Test@name@1234567890abcdef1234567890abcdef)"
-        assert repr(sid) == "(Test@name@1234567890abcdef1234567890abcdef)"
-
-    def test_uuid_property(self):
-        sid = SUUID(class_name="Test", huuid="1234567890abcdef1234567890abcdef")
-        assert isinstance(sid.get_uuid(), uuid.UUID)
-        assert sid.get_uuid().hex == "1234567890abcdef1234567890abcdef"
-
-    def test_hex_property(self):
-        sid = SUUID(class_name="Test", huuid="1234567890abcdef1234567890abcdef")
-        assert sid.hex == "1234567890abcdef1234567890abcdef"
-
-    def test_to_list(self):
-        sid = SUUID(class_name="Test", name="name", huuid="1234567890abcdef1234567890abcdef")
-        expected_suuid_str = "MTIzNDU2Nzg5MGFiY2RlZjEyMzQ1Njc4OTBhYmNkZWZUZXN0QG5hbWU="
-        assert sid.to_list() == [expected_suuid_str, "Test", "name", "1234567890abcdef1234567890abcdef"]
-
-    def test_to_dict(self):
-        sid = SUUID(class_name="Test", name="name", huuid="1234567890abcdef1234567890abcdef")
-        expected_suuid_str = "MTIzNDU2Nzg5MGFiY2RlZjEyMzQ1Njc4OTBhYmNkZWZUZXN0QG5hbWU="
-        assert sid.to_dict() == {
-            "class_name": "Test",
-            "name": "name",
-            "huuid": "1234567890abcdef1234567890abcdef",
-            "suuid": expected_suuid_str
-        }
-
-    def test_sname(self):
-        sid = SUUID(class_name="Test", name="name", huuid="1234567890abcdef1234567890abcdef")
-        assert sid.sname == "Test@name@1234567890abcdef1234567890abcdef"
-
-    def test_suuid_and_suuid_str(self):
-        sid = SUUID(class_name="Test", name="name", huuid="1234567890abcdef1234567890abcdef")
-        expected_s = "1234567890abcdef1234567890abcdefTest@name"
-        expected_bytes = base64.b64encode(expected_s.encode())
-        assert sid.suuid_bytes == expected_bytes
-        assert sid.suuid_str == expected_bytes.decode().strip()
-
-    def test_from_uuid(self):
-        u = uuid.UUID("1234567890abcdef1234567890abcdef")
-        sid = SUUID.from_uuid(class_name="Test", uuid_obj=u)
-        assert sid.class_name == "Test"
-        assert sid.huuid == "1234567890abcdef1234567890abcdef"
-        assert sid.name == "noname"
-
-    def test_get_namespace_from_name(self):
-        ns = SUUID.get_namespace_from_name("project_xy")
-        assert ns == uuid.uuid5(uuid.NAMESPACE_OID, "PROJECT_XY")
-
-    def test_get_uuid_from_name(self):
-        uid = SUUID.get_uuid_from_name(name="DATAotto")
-        assert uid.hex == "96da1780e6225b33b9186e41838d2e2c"
-
-        uid_ns = SUUID.get_uuid_from_name(name="DATAotto", ns_name="project_xy")
-        assert uid_ns.hex == "903649d7c1f9529f9c4ba45eb79751f4"
-
-    def test_from_name(self):
-        sid = SUUID.from_name(class_name="DATA", name="otto")
-        assert sid.huuid == "96da1780e6225b33b9186e41838d2e2c"
-        assert sid.class_name == "DATA"
-        assert sid.name == "otto"
-        assert sid.suuid_str == "OTZkYTE3ODBlNjIyNWIzM2I5MTg2ZTQxODM4ZDJlMmNEQVRBQG90dG8="
+    # --- from_name: deterministisch, huuid-Vertrag erhalten -------------
+    def test_from_name_deterministic(self):
+        sid = SUUID.from_name("DATA", "otto")
+        assert sid.huuid == "96da1780e6225b33b9186e41838d2e2c"   # golden (unverändert)
+        assert sid.class_name == "DATA" and sid.name == "otto"
+        assert sid.sname == f"DATA__otto__{sid.huuid}"
+        assert SUUID.from_name("DATA", "otto") == sid
 
     def test_from_name_with_ns(self):
-        sid = SUUID.from_name(class_name="DATA", name="otto", ns_name="project_xy")
-        assert sid.huuid == "903649d7c1f9529f9c4ba45eb79751f4"
-        assert sid.suuid_str == "OTAzNjQ5ZDdjMWY5NTI5ZjljNGJhNDVlYjc5NzUxZjREQVRBQG90dG8="
+        sid = SUUID.from_name("DATA", "otto", ns_name="project_xy")
+        assert sid.huuid == "903649d7c1f9529f9c4ba45eb79751f4"   # golden (unverändert)
+        assert sid != SUUID.from_name("DATA", "otto")            # Scoping wirkt
 
-    def test_get_suuid_from_name(self):
-        suuid_bytes = SUUID.get_suuid_from_name(class_name="DATA", name="otto")
-        assert suuid_bytes == b'OTZkYTE3ODBlNjIyNWIzM2I5MTg2ZTQxODM4ZDJlMmNEQVRBQG90dG8='
+    # --- Aliasse / Properties -------------------------------------------
+    def test_aliases(self):
+        sid = SUUID.from_name("DATA", "otto")
+        assert sid.suuid_str == sid.compact_token
+        assert sid.suuid_bytes == sid.compact_token.encode()
+        assert sid.uuid == sid.as_uuid() == sid.get_uuid()
+        assert isinstance(sid.uuid, uuid.UUID)
+        assert sid.hex == sid.huuid
 
-    def test_get_sname_from_name(self):
-        sname = SUUID.get_sname_from_name(class_name="DATA", name="otto")
-        assert sname == "DATA@otto@96da1780e6225b33b9186e41838d2e2c"
+    def test_to_list_and_dict(self):
+        sid = SUUID.from_name("DATA", "otto")
+        assert sid.to_list() == [sid.sname, sid.suuid_str, "DATA", "otto", sid.huuid]
+        d = sid.to_dict()
+        assert d["sname"] == sid.sname
+        assert d["suuid"] == sid.suuid_str
+        assert d["huuid"] == sid.huuid
 
-    def test_from_str(self):
-        sid = SUUID.from_str(class_name="Data", s="test text")
-        expected_hash = '_08487142e9585eb2a39f4b8c9f64d4b60dc420af4ee136472d252d0c68d99974'
-        assert sid.name == expected_hash
-        # huuid basierend auf "Data" + hash
-        expected_input = "Data" + expected_hash
-        expected_uid = uuid.uuid5(uuid.NAMESPACE_OID, expected_input.upper())
-        assert sid.huuid == expected_uid.hex
+    # --- Roundtrips -----------------------------------------------------
+    def test_roundtrip_str_bytes_sname(self):
+        sid = SUUID.from_name("DATA", "otto")
+        assert SUUID.from_suuid_str(sid.suuid_str) == sid
+        assert SUUID.from_suuid_bytes(sid.suuid_bytes) == sid
+        assert SUUID.from_suuid_sname(sid.sname) == sid
 
-    # def test_from_file(self, temp_file):
-    #     sid = SUUID.from_file(class_name="File", filepath=temp_file)
-    #     expected_hash = hashlib.sha3_256(b"test content").hexdigest()
-    #     assert sid.name == "temp.txt"  # Da NamedTemporaryFile auf Windows/Linux .txt haben kann, aber anpassen wenn nötig
-    #     expected_input = "File" + expected_hash
-    #     expected_uid = uuid.uuid5(uuid.NAMESPACE_OID, expected_input.upper())
-    #     assert sid.huuid == expected_uid.hex
+    def test_from_suuid_sname_lenient(self):
+        assert SUUID.from_suuid_sname("kaputt") is None          # Default strict=False
+        assert SUUID.from_suuid_sname("a__b", strict=False) is None
+        with pytest.raises(ValueError):
+            SUUID.from_suuid_sname("a__b", strict=True)
 
-    def test_from_suuid_bytes(self):
-        example_bytes = b'OTZkYTE3ODBlNjIyNWIzM2I5MTg2ZTQxODM4ZDJlMmNEQVRBQG90dG8='
-        sid = SUUID.from_suuid_bytes(example_bytes)
-        assert sid.huuid == "96da1780e6225b33b9186e41838d2e2c"
-        assert sid.class_name == "DATA"
-        assert sid.name == "otto"
+    def test_from_uuid(self):
+        sid = SUUID.from_uuid("Test", uuid.UUID(HEX))
+        assert sid.class_name == "Test" and sid.huuid == HEX
 
-    def test_from_suuid_str(self):
-        example_str = "OTZkYTE3ODBlNjIyNWIzM2I5MTg2ZTQxODM4ZDJlMmNEQVRBQG90dG8="
-        sid = SUUID.from_suuid_str(example_str)
-        assert sid.huuid == "96da1780e6225b33b9186e41838d2e2c"
-        assert sid.class_name == "DATA"
-        assert sid.name == "otto"
+    def test_from_obj(self):
+        sid = SUUID.from_name("DATA", "otto")
+        assert SUUID.from_obj(sid) == sid
+        assert SUUID.from_obj(sid.sname) == sid
+        assert SUUID.from_obj(None) is None
 
-    def test_from_suuid_sname(self):
-        sname = "DATA@otto@96da1780e6225b33b9186e41838d2e2c"
-        sid = SUUID.from_suuid_sname(sname)
-        assert sid.class_name == "DATA"
-        assert sid.name == "otto"
-        assert sid.huuid == "96da1780e6225b33b9186e41838d2e2c"
+    # --- content-adressiert ---------------------------------------------
+    def test_from_str_content_addressed(self):
+        a = SUUID.from_str("Data", "test text")
+        b = SUUID.from_str("Data", "test text")
+        assert a == b
+        assert a.content_hash and len(a.content_hash) == 64
 
-    def test_from_suuid_sname_invalid(self):
-        with pytest.raises(ValueError, match="Ungültiger sname-Format"):
-            SUUID.from_suuid_sname("invalid@format")
+    def test_from_file(self, tmp_path):
+        p = tmp_path / "doc.txt"
+        p.write_bytes(b"test content")
+        sid = SUUID.from_file("File", str(p))
+        assert sid.name == "doc_txt"          # Basename, S3-sicher normalisiert
+        assert sid.content_hash
 
-    def test_from_idstr(self):
-        id_string = "96da1780e6225b33b9186e41838d2e2cDATA@otto"
-        sid = SUUID.from_idstr(id_string)
-        assert sid.huuid == "96da1780e6225b33b9186e41838d2e2c"
-        assert sid.class_name == "DATA"
-        assert sid.name == "otto"
+    # --- 100% S3-Sicherheit ---------------------------------------------
+    @pytest.mark.parametrize("cn, n", [
+        ("Data", "name@|;bad"),
+        ("Über", "Größe @ 2026.csv"),
+        ("Run", "2026_digit_start"),
+        ("Path", r"a/b\c:d*e"),
+    ])
+    def test_safe_filename_and_sname_are_s3_safe(self, cn, n):
+        safe = SUUID.generate_safe_filename(n)
+        assert safe == "" or (S3_SAFE.fullmatch(safe) and not safe.startswith("_"))
+        assert "@" not in safe
+        s = SUUID.from_name(cn, n).sname
+        assert S3_SAFE.fullmatch(s) and not s.startswith("_") and "@" not in s
 
-    def test_from_idstr_no_name(self):
-        id_string = "96da1780e6225b33b9186e41838d2e2cDATA"
-        sid = SUUID.from_idstr(id_string)
-        assert sid.class_name == "DATA"
-        assert sid.name == "noname"
+    def test_generate_safe_filename_examples(self):
+        assert SUUID.generate_safe_filename("name@|;bad") == "name_bad"
+        assert SUUID.generate_safe_filename("clean") == "clean"
 
-    def test_from_idstr_short(self):
-        with pytest.raises(ValueError, match="Ungültiger id_string: Zu kurz"):
-            SUUID.from_idstr("short")
+    def test_is_valid_suuid_str(self):
+        sid = SUUID.from_name("DATA", "otto")
+        assert SUUID.is_valid_suuid_str(sid.suuid_str) is True
+        assert SUUID.is_valid_suuid_str("nope") is False


### PR DESCRIPTION
## Überblick

`sdata` nutzt jetzt das eigenständige **`suuid` (>=0.2.0)** als Single Source of Truth für semantische, **100% S3-sichere** IDs (`Class__safe_name__huuid`). `sdata/suuid.py` ist nur noch ein dünner Adapter.

## Änderungen

- **`sdata/suuid.py`** — Adapter (Subclass von `suuid.SUUID`) mit Rückwärtskompatibilitäts-Aliassen:
  `suuid_str`/`suuid_bytes` → `compact_token`, `uuid`/`get_uuid` → `as_uuid`,
  `from_name(ns_name=…)` → `ns=…`, `from_suuid_sname` → `from_sname(strict=False)`,
  `from_suuid_str`/`from_suuid_bytes` → `from_compact_token`,
  `generate_safe_filename` → `suuid.safe_name`, plus `from_uuid`/`from_obj`/`to_list`/`to_dict`/`is_valid_suuid_str`.
  Erbt Immutabilität, Wertgleichheit und die eingefrorene Normalisierung.
- **`sdata/base.py`** — SUUID-Erzeugung vereinheitlicht auf deterministisches `from_name` (ns-gescopt); kein Direkt-Konstruktor mehr.
- **`setup.py`** — `suuid>=0.2.0` als Core-Dependency.
- **Tests** — `test_suuid`/`test_suuid_class` auf den Adapter neu geschrieben (huuid-Goldenwerte bleiben gültig, da gleicher uuid5-Algorithmus); 2 `test_base`-Werte auf das `__`-Format aktualisiert.

## Tests (lokal, `./ci/local-ci.sh`)

- `test_suuid` + `test_suuid_class` + `test_base`: **47/47 grün**.
- Gesamtsuite: **194 passed (+10), 0 Regression**. Die verbleibenden Fehler sind vorbestehend und unabhängig (pytables/sqlalchemy-Imports, `test_metadata`-TypeError, `test_data::test_to_json` Name-Restore).

## Hinweis
Das ist ein bewusster **Re-Mint** des sname-Formats (`@` → `__`, S3-sicher) — bestehende serialisierte `_sdata_suuid`/`sname`-Werte ändern sich entsprechend.
