### PR TITLE
chore(tests): optionale Backends graceful skippen + Extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,14 @@ with open('README.md', 'rb') as f:
 
 REQUIRES = ['numpy', 'pandas', 'tabulate', 'xlrd', 'openpyxl', 'xlsxwriter', 'pytz', 'requests', 'Pillow', 'suuid>=0.2.0']
 
-# Optionale Abhängigkeiten für das DID-/VC-Subpackage (sdata.did):
-#   pip install "sdata[did]"
+# Optionale Abhängigkeiten:
+#   pip install "sdata[did]"   DID-/VC-Subpackage (sdata.did)
+#   pip install "sdata[hdf]"   HDF5-I/O (PyTables-Backend)
+#   pip install "sdata[sql]"   to_sqlite / pandas.to_sql (SQLAlchemy)
 EXTRAS = {
     'did': ['ecdsa>=0.18', 'base58>=2.1'],
+    'hdf': ['tables'],
+    'sql': ['sqlalchemy'],
 }
 
 setup(

--- a/tests/iolib/test_hdf.py
+++ b/tests/iolib/test_hdf.py
@@ -1,6 +1,10 @@
 import sys
 import os
 import pandas as pd
+import pytest
+
+# HDF5-I/O benötigt das optionale Backend PyTables (pip install "sdata[hdf]").
+pytest.importorskip("tables")
 
 modulepath = os.path.dirname(__file__)
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import pandas as pd
+import pytest
 
 modulepath = os.path.dirname(__file__)
 
@@ -164,6 +165,7 @@ def test_asciiname():
     assert sdata.Data(name="ö-ü-ä-Ö-Ü-Ä-?- -\\-/").asciiname == 'oe-ue-ae-Oe-Ue-Ae-?-_-_-_'
 
 def test_to_sqlite():
+    pytest.importorskip("sqlalchemy")  # to_sqlite nutzt pandas.to_sql -> SQLAlchemy (sdata[sql])
     df = pd.DataFrame({'a': ['x', 'y', '', 'z'], 'b': [1, 2, 2, 3.2]})
     data = sdata.Data(name="data", uuid="48b26864e7794f5182d38459bab8584d", table=df, description="abc")
     sq = data.to_sqlite("/tmp/sq.sqlite")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -5,6 +5,7 @@ logger = logging.getLogger("sdata")
 import sys
 import os
 import pandas as pd
+import pytest
 
 modulepath = os.path.dirname(__file__)
 
@@ -27,6 +28,7 @@ def test_data_to_html():
     # assert data.sha3_256 == data2.sha3_256
 
 def test_hdf5():
+    pytest.importorskip("tables")  # HDF5 benötigt PyTables (sdata[hdf])
     df = pd.DataFrame({"a": [1.1, 2.1, 3.5],
                        "b": [2.4, 1.2, 2.2]})
     d = sdata.Data(name="basic example", uuid="38b26864e7794f5182d38459bab85842", table=df, description="hallo")

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -6,6 +6,7 @@ import numpy as np
 import sdata
 import shutil
 import os
+import pytest
 
 
 def test_sqlitevault():
@@ -42,6 +43,7 @@ def test_sqlitevault():
     assert len(all_m) == 0
 
 def test_filesystemvault():
+    pytest.importorskip("tables")  # Blob-Storage nutzt HDF5 (sdata[hdf])
     rootpath = "/tmp/test_filesystemvault/"
 
     shutil.rmtree(rootpath, ignore_errors=True)
@@ -92,6 +94,7 @@ def test_filesystemvault():
     # assert isinstance(o, list)
 
 def test_hdf5vault():
+    pytest.importorskip("tables")  # HDF5-Vault benötigt PyTables (sdata[hdf])
 
     rootpath = "/tmp/test_hdf5vault.h5"
 


### PR DESCRIPTION
## Aufräumen der Testsuite

Tests, die optionale IO-Backends benötigen, **überspringen sich jetzt sauber** (`pytest.importorskip`) statt mit `ImportError` zu **fehlen**:

- **HDF5 / PyTables**: `test_hdf`, `test_io::test_hdf5`, `test_vault::test_filesystemvault`, `test_vault::test_hdf5vault`
- **SQLAlchemy**: `test_data::test_to_sqlite`

`setup.py`: neue Extras `hdf` (`tables`) und `sql` (`sqlalchemy`) — `pip install "sdata[hdf]"` / `"sdata[sql]"`.

## Stand der Suite

**194 passed, 5 skipped** (vorher 4 von diesen als ImportError-Fehler). Verbleiben **4 echte, vorbestehende Bugs** (in eigenen Subsystemen, bewusst NICHT in diesem PR):

1. `iolib/test_jsonsqlitestore::test_compression_and_type_parsing` — Compression-Pfad erzeugt malformed JSON.
2. `test_data::test_to_json` — `Data.from_json` restauriert den Namen nicht (`'N.N.'`).
3. `test_metadata::test_metadata` — `DataFrame.set_index` TypeError (pandas-Compat).
4. `test_vault::test_sqlitevault` — `TypeError: object of type 'NoneType'`.
