### PR TITLE
fix(metadata,vault): pandas-Compat + None-Guards

### DIFF
--- a/sdata/iolib/vault.py
+++ b/sdata/iolib/vault.py
@@ -119,7 +119,7 @@ class VaultSqliteIndex:
         logger.debug(f"add '{uid}' to vault index")
         self.db.upsert_node(identifier=uid, data=d)
         puid = d.get("!sdata_parent")
-        if len(puid) > 0:
+        if puid:  # None (kein Parent) oder leerer String -> kein Parent-Knoten
             if len(self.db.find_node(puid)) == 0:
                 self.db.upsert_node(identifier=puid, data={"!sdata_uuid": puid, '!sdata_name': "?"})
             self.db.connect_nodes(puid, uid, {"con_type": "parent"})

--- a/sdata/metadata.py
+++ b/sdata/metadata.py
@@ -411,7 +411,6 @@ class Metadata(object):
         :return:
         """
         for k, v in d.items():
-            k = k.replace("!sdata_", "_sdata_")
             if guess_dtype is False:
                 value = v
                 dtype = None
@@ -571,7 +570,10 @@ class Metadata(object):
         """create metadata from dataframe"""
         df = pd.read_csv(filepath, header=None)
         df.columns = cls.ATTRIBUTEKEYS
-        df.set_index(df.name.values, inplace=True)
+        # Index nach Spalte "name" (Spalte behalten). Kein df.name.values, da das
+        # in neueren pandas-Versionen ein StringArray ist, den set_index als
+        # unhashbaren Key behandelt (TypeError).
+        df.set_index("name", drop=False, inplace=True)
         metadata = cls.from_dataframe(df)
         return metadata
 


### PR DESCRIPTION
Behebt 2 vorbestehende Bugs: Metadata.from_csv set_index (pandas StringArray, test_metadata) und Data.from_json Name-Restore (update_from_dict-Rename, test_data::test_to_json); plus None-Guard im SqliteVault-Index. Suite: 196 passed (+2). Offen bleiben test_sqlitevault (Data popt !sdata_uuid aus Metadata, Vault erwartet es) und jsonsqlitestore-Compression.