### PR TITLE
chore(coverage): Coverage-Konfiguration (vendored contrib ausschliessen)

### DIFF
--- a/ci/local-ci.sh
+++ b/ci/local-ci.sh
@@ -42,7 +42,7 @@ echo "[ci] führe Tests aus: ${TARGETS[*]}"
 "$PYBIN" -m coverage run -m pytest --continue-on-collection-errors "${TARGETS[@]}"
 
 echo
-echo "[ci] Coverage (sdata/did):"
-"$PYBIN" -m coverage report -m --include="sdata/did/*" || true
+echo "[ci] Coverage (Produktcode, ohne vendored contrib — siehe pyproject.toml):"
+"$PYBIN" -m coverage report || true
 
 echo "[ci] OK"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,24 @@
 [build-system]
 requires = ["setuptools>=64.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.coverage.run]
+source = ["sdata"]
+omit = [
+    # Vendored Third-Party-Libs (nicht Teil der eigenen Coverage)
+    "sdata/contrib/*",
+    # Test-/Hilfsdateien
+    "*/tests/*",
+    "sdata/test/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+exclude_also = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "@(abc\\.)?abstractmethod",
+    "\\.\\.\\.",
+]


### PR DESCRIPTION
Macht die Coverage-Metrik aussagekräftig: `sdata/contrib/*` (vendored Third-Party-Libs, ~12k von 19.5k Statements) werden ausgeschlossen. Realer Produktcode: ~7.187 Statements, aktuell **39%**. Basis für die schrittweise Erhöhung auf 100%.