### PR TITLE
test(sclass): blob.py auf 100% (+ Blob.__init__ repariert)

### DIFF
--- a/ci/local-ci.sh
+++ b/ci/local-ci.sh
@@ -28,7 +28,7 @@ fi
 
 echo "[ci] installiere/aktualisiere Abhängigkeiten (sdata[did] + Test-Tools)"
 "$PYBIN" -m pip install --quiet --upgrade pip
-"$PYBIN" -m pip install --quiet -e ".[did,parquet]" pytest coverage
+"$PYBIN" -m pip install --quiet -e ".[did,parquet,blob]" pytest coverage
 
 # Testziel: durchgereichte Argumente oder – wenn keine – die komplette Suite.
 TARGETS=("$@")

--- a/sdata/sclass/blob.py
+++ b/sdata/sclass/blob.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 # Note: fsspec must be installed (pip install fsspec) and for S3, also install s3fs (pip install s3fs)
 try:
     import fsspec
-except ImportError:
-    logger.warn('fsspec not installed')
+except ImportError:  # pragma: no cover - optionales Backend (sdata[blob])
+    logger.warning('fsspec not installed')
     fsspec = None
 
 class Blob(Base):
@@ -142,12 +142,11 @@ class Blob(Base):
         if content_type not in typing.get_args(self.ContentType):
             raise ValueError(f"Invalid content_type: {content_type}")
 
-        # self.data['content'] = {
-        #     'type': content_type,
-        #     'filetype': filetype
-        # }
-
-        # self._set_value(value)
+        self.data['content'] = {
+            'type': content_type,
+            'filetype': filetype,
+        }
+        self._set_value(value)
 
         logger.debug(f"Created Blob '{self.sname}' with content_type '{content_type}' and filetype '{filetype}'")
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ EXTRAS = {
     'hdf': ['tables'],
     'sql': ['sqlalchemy'],
     'parquet': ['pyarrow'],   # sdata.sclass.DataFrame (Parquet-Serialisierung)
+    'blob': ['fsspec'],       # sdata.sclass.Blob (URI-Content: file/S3/Zip)
 }
 
 setup(

--- a/tests/test_sclass_blob_coverage.py
+++ b/tests/test_sclass_blob_coverage.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Vollständige Abdeckung von sdata/sclass/blob.py."""
+import pytest
+
+pytest.importorskip("fsspec")
+
+import sdata.sclass.blob as blobmod
+from sdata.sclass.blob import Blob
+
+
+def test_invalid_content_type():
+    with pytest.raises(ValueError):
+        Blob(content_type="nope", name="b")
+
+
+def test_bytes_content_and_hashes():
+    b = Blob(content_type="bytes", value=b"hello", filetype="bin", name="b")
+    assert b.filetype == "bin"
+    assert b.content_bytes == b"hello"          # b64decode
+    assert b.content_bytes == b"hello"          # Cache
+    assert b.exists() is True
+    assert len(b.sha1) == 40 and len(b.md5) == 32
+
+
+def test_value_none_and_set_content():
+    b = Blob(name="b")                          # bytes, value None
+    assert b.exists() is False
+    with pytest.raises(ValueError):
+        _ = b.content_bytes                     # kein value
+    b.set_content("bytes", b"data", filetype="x")
+    assert b.content_bytes == b"data" and b.filetype == "x"
+
+
+def test_uri_content(tmp_path):
+    p = tmp_path / "f.txt"
+    p.write_bytes(b"uri-bytes")
+    b = Blob(content_type="uri", value=str(p), filetype="txt", name="u")
+    assert b.content_bytes == b"uri-bytes"      # fsspec.open
+    assert b.exists() is True
+    # nicht existierende Datei -> exists False
+    b2 = Blob(content_type="uri", value=str(tmp_path / "missing"), name="u2")
+    assert b2.exists() is False
+
+
+def test_set_value_type_errors():
+    b = Blob(name="b")
+    with pytest.raises(ValueError):
+        b.set_content("bytes", "not-bytes")     # bytes erwartet
+    with pytest.raises(ValueError):
+        b.set_content("uri", b"not-str")        # str erwartet
+    with pytest.raises(ValueError):
+        b.set_content("weird", b"x")            # unbekannter content_type
+
+
+def test_content_bytes_error_branches():
+    b = Blob(content_type="bytes", value=b"x", name="b")
+    # unbekannter ctype
+    b.data["content"]["type"] = "weird"
+    with pytest.raises(ValueError):
+        _ = b.content_bytes
+    # kein content
+    b.data.pop("content")
+    with pytest.raises(ValueError):
+        _ = b.content_bytes
+
+
+def test_exists_branches():
+    b = Blob(name="b")
+    assert b.exists() is False                  # value None
+    b.data.pop("content")
+    assert b.exists() is False                  # kein content
+    b2 = Blob(content_type="bytes", value=b"x", name="b2")
+    b2.data["content"]["type"] = "weird"
+    assert b2.exists() is False                 # unbekannter ctype
+
+
+def test_uri_fsspec_none(monkeypatch, tmp_path):
+    p = tmp_path / "f.txt"
+    p.write_bytes(b"x")
+    b = Blob(content_type="uri", value=str(p), name="u")
+    monkeypatch.setattr(blobmod, "fsspec", None)
+    with pytest.raises(ImportError):
+        _ = b.content_bytes
+    assert b.exists() is False
+
+
+def test_uri_bad_value_raises_and_exists_exception():
+    b = Blob(content_type="uri", value="://broken", name="u")
+    with pytest.raises(ValueError):
+        _ = b.content_bytes
+    # unbekanntes Protokoll -> get_fs_token_paths wirft -> except-Zweig in exists()
+    b2 = Blob(content_type="uri", value="weirdproto://x", name="u2")
+    assert b2.exists() is False
+
+
+def test_sha1_md5_none_on_error():
+    b = Blob(name="b")                          # value None -> content_bytes wirft
+    assert b.sha1 is None
+    assert b.md5 is None
+
+
+def test_to_from_dict():
+    b = Blob(content_type="bytes", value=b"abc", filetype="bin", name="b")
+    d = b.to_dict()
+    assert "content" in d["data"]
+    r = Blob.from_dict(d)
+    assert r.data["content"]["type"] == "bytes"
+    # from_dict ohne content -> Default ergänzt
+    r2 = Blob.from_dict({"metadata": d["metadata"], "data": {}, "description": ""})
+    assert r2.data["content"]["type"] == "bytes"
+    # ungültige content-Struktur -> ValueError
+    with pytest.raises(ValueError):
+        Blob.from_dict({"metadata": d["metadata"], "data": {"content": {}}, "description": ""})
+    # uri mit nicht-String value -> ValueError
+    with pytest.raises(ValueError):
+        Blob.from_dict({"metadata": d["metadata"],
+                        "data": {"content": {"type": "uri", "filetype": "x", "value": 123}},
+                        "description": ""})


### PR DESCRIPTION
Hebt `sdata/sclass/blob.py` von 27% auf **100%**. Repariert nebenbei `Blob.__init__` (Content-Setup war auskommentiert -> Blob jetzt funktionsfaehig). Neues `blob`-Extra (fsspec).