### PR TITLE
test(sclass): dependency_graph/__init__/lazy_namespace auf 100%

### DIFF
--- a/tests/test_sclass_lazy_namespace_coverage.py
+++ b/tests/test_sclass_lazy_namespace_coverage.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""Vollständige Abdeckung von sdata/sclass/lazy_namespace.py."""
+import sys
+import types
+
+import pytest
+
+from sdata.base import Base
+from sdata.sclass.lazy_namespace import (
+    LazyRegistry, ExportItem, _split_spec, _resolve_attr,
+    resolve_by_string, to_json, from_json, TYPE_FIELD, SPEC_FIELD,
+)
+
+
+def test_split_spec_and_resolve_attr():
+    assert _split_spec("a.b:C.D") == ("a.b", "C.D")
+    with pytest.raises(ValueError):
+        _split_spec("nocolon")
+    with pytest.raises(ValueError):
+        _split_spec(":x")
+    import sdata.base as m
+    assert _resolve_attr(m, "Base") is Base
+
+
+def test_export_item():
+    assert ExportItem(name="X", spec="m:X").name == "X"
+
+
+def _temp_pkg(name):
+    pkg = types.ModuleType(name)
+    sys.modules[name] = pkg
+    return pkg
+
+
+def test_registry_lifecycle():
+    name = "sdata._test_lazy_pkg"
+    pkg = _temp_pkg(name)
+    try:
+        reg = LazyRegistry(name)
+        reg.register("Base", "sdata.base:Base")
+        reg.register_many({"SUUID": "sdata.suuid:SUUID"})
+        assert "Base" in reg.exports()
+        reg.attach()
+        reg.attach()                          # idempotent
+        assert pkg.__getattr__("Base") is Base
+        with pytest.raises(AttributeError):
+            pkg.__getattr__("Missing")
+        assert "Base" in pkg.__dir__()
+        reg.register("X", "sdata.base:Base")          # nach attach -> __all__ update
+        reg.register_many({"Y": "sdata.base:Base"})
+        assert "X" in pkg.__all__ and "Y" in pkg.__all__
+        assert resolve_by_string("Base", reg) is Base  # Kurzname via Registry
+    finally:
+        del sys.modules[name]
+
+
+def test_get_pkg_missing():
+    with pytest.raises(RuntimeError):
+        LazyRegistry("nonexistent.package.xyz")._get_pkg()
+
+
+def test_resolve_by_string_requires_registry():
+    assert resolve_by_string("sdata.base:Base") is Base
+    with pytest.raises(ValueError):
+        resolve_by_string("Base")             # Kurzname ohne Registry
+
+
+def test_to_json_and_from_json():
+    b = Base(name="x")
+    d = to_json(b, include_spec=True)
+    assert SPEC_FIELD in d and TYPE_FIELD in d
+    assert isinstance(from_json(d), Base)     # via __spec__ + from_dict
+
+    # via __type__ + Registry
+    name = "sdata._test_lazy_pkg3"
+    _temp_pkg(name)
+    try:
+        reg = LazyRegistry(name)
+        reg.register("Base", "sdata.base:Base")
+        reg.attach()
+        assert isinstance(from_json(to_json(b, type_name="Base"), reg), Base)
+    finally:
+        del sys.modules[name]
+
+    # Klasse ohne from_dict -> init-Pfad
+    obj = from_json({SPEC_FIELD: "builtins:dict", "a": 1})
+    assert obj == {"a": 1}
+
+    # weder __type__ noch __spec__ -> ValueError
+    with pytest.raises(ValueError):
+        from_json({"foo": 1})

--- a/tests/test_sclass_misc_coverage.py
+++ b/tests/test_sclass_misc_coverage.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Abdeckung von sdata/sclass/dependency_graph.py und sdata/sclass/__init__.py."""
+import pytest
+
+from sdata.base import Base
+from sdata.sclass.dependency_graph import (
+    toposort, toposort_flatten, CircularDependencyError,
+)
+from sdata.sclass import (
+    register, register_many, get_specs, class_to_spec, obj_to_spec,
+    spec_to_class, is_importable_by_spec, make_module_alias,
+)
+
+
+# --- dependency_graph ---------------------------------------------------
+def test_toposort_empty():
+    assert list(toposort({})) == []
+
+
+def test_toposort_dag_and_flatten():
+    g = {"a": {"b"}, "b": set(), "c": {"a"}}
+    levels = list(toposort(g))
+    assert levels[0] == {"b"}
+    flat = toposort_flatten(g)
+    assert flat.index("b") < flat.index("a") < flat.index("c")
+    assert "y" in toposort_flatten({"x": {"y"}})   # extra_nodes
+    assert isinstance(toposort_flatten(g, sort=False), list)
+
+
+def test_toposort_cycle():
+    with pytest.raises(CircularDependencyError):
+        list(toposort({"a": {"b"}, "b": {"a"}}))
+
+
+# --- sclass/__init__ ----------------------------------------------------
+def test_registry_and_specs():
+    register("MyAlias", "sdata.base:Base")
+    register_many({"MyAlias2": "sdata.base:Base"})
+    assert "MyAlias" in get_specs()
+    assert class_to_spec(Base) == "sdata.base:Base"
+    assert obj_to_spec(Base(name="x")) == "sdata.base:Base"
+    assert spec_to_class("sdata.base:Base") is Base
+    assert spec_to_class("nope.mod:Thing", on_error="ignore") is Base
+    with pytest.raises(ModuleNotFoundError):
+        spec_to_class("nope.mod:Thing", on_error="strict")
+
+
+def test_is_importable_and_make_module_alias():
+    assert is_importable_by_spec(Base) is True
+
+    class Local:           # lokal/nested -> nicht per Spec importierbar
+        pass
+    assert is_importable_by_spec(Local) is False
+    spec = make_module_alias(Local, alias="LocalAlias_xyz")
+    assert spec.endswith(":LocalAlias_xyz")
+    assert spec_to_class(spec) is Local


### PR DESCRIPTION
Hebt 3 weitere sclass-Module auf **100%** (dependency_graph, __init__, lazy_namespace).