### PR TITLE
refactor(did): ecdsa- und base58-Abhängigkeit durch pure-Python ersetzen

### DIFF
--- a/sdata/did/__init__.py
+++ b/sdata/did/__init__.py
@@ -24,18 +24,22 @@ JWK-Thumbprint (RFC 7638).
 
 Installation
 ------------
-Die DID-Funktionen benötigen die Extra-Abhängigkeiten ``ecdsa`` und ``base58``::
+Krypto (Ed25519) und base58btc sind **abhängigkeitsfrei** (reine
+Standardbibliothek) – siehe :mod:`~sdata.did.eddsa` und
+:mod:`~sdata.did.base58btc`. Lediglich die HTTP-Auflösung von ``did:web`` /
+``did:github`` benötigt ``requests``::
 
     pip install "sdata[did]"
 
 .. warning::
-   **Sicherheit / SOTA-Hinweis.** Der produktive Krypto-Pfad nutzt
-   ``python-ecdsa`` (reine Python-Implementierung von Ed25519). Diese ist
-   bewusst dependency-arm, aber **nicht garantiert constant-time** und damit
-   potenziell anfällig für Timing-Seitenkanäle. Für hochsensible Umgebungen ein
-   libsodium-Backend (PyNaCl) oder ``cryptography`` (OpenSSL) erwägen.
-   Das Modul :mod:`sdata.did.ed25519` ist eine reine **Lern-Referenz** und
-   wird vom Funktionspfad nicht verwendet.
+   **Sicherheit / SOTA-Hinweis.** Der produktive Krypto-Pfad nutzt die
+   pure-Python-Ed25519-Implementierung in :mod:`sdata.did.ed25519` (über den
+   Adapter :mod:`sdata.did.eddsa`). Sie ist abhängigkeitsfrei, aber **nicht
+   garantiert constant-time** und damit potenziell anfällig für
+   Timing-Seitenkanäle – genau wie das zuvor genutzte ``python-ecdsa``
+   (ebenfalls pure Python). Für hochsensible Umgebungen ein libsodium-Backend
+   (PyNaCl) oder ``cryptography`` (OpenSSL) erwägen. Korrektheit ist gegen die
+   offiziellen RFC-8032-Testvektoren abgesichert.
 
 Beispiel
 --------
@@ -56,9 +60,9 @@ import importlib
 
 # Lazy-Loading (PEP 562): Submodule werden erst beim Zugriff importiert. Vorteile:
 #   * ``python -m sdata.did.<modul>`` löst keine runpy-Doppelimport-Warnung aus,
-#   * ``import sdata.did`` ist leichtgewichtig – die optionalen Krypto-Deps
-#     (ecdsa/base58) werden erst geladen, wenn eine sie nutzende Funktion
-#     tatsächlich angefasst wird.
+#   * ``import sdata.did`` ist leichtgewichtig – schwerere Submodule (z. B.
+#     ``did_web`` mit ``requests``) werden erst geladen, wenn eine sie nutzende
+#     Funktion tatsächlich angefasst wird.
 # Mapping: exportierter Name -> "submodul"  oder  ("submodul", "originalname").
 _EXPORTS = {
     # Fehler

--- a/sdata/did/base58btc.py
+++ b/sdata/did/base58btc.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""base58btc-Kodierung (Bitcoin-Alphabet) – reine Standardbibliothek.
+
+Ersetzt die externe ``base58``-Abhängigkeit im ``did``-Subpackage. Die
+Funktionen sind bewusst klein und an die multibase-/``did:key``-Nutzung
+angepasst (führende Nullbytes bleiben als ``1`` erhalten).
+
+Referenz: https://datatracker.ietf.org/doc/html/draft-msporny-base58
+"""
+from __future__ import annotations
+
+__all__ = ["b58encode", "b58decode"]
+
+# Bitcoin-/IPFS-Alphabet (ohne 0, O, I, l)
+_B58_ALPHABET = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+_B58_INDEX = {ch: i for i, ch in enumerate(_B58_ALPHABET)}
+
+
+def b58encode(b: bytes) -> str:
+    """Kodiere Bytes als base58btc (führende Nullbytes bleiben als ``1`` erhalten)."""
+    n = int.from_bytes(b, "big", signed=False)
+    out = bytearray()
+    while n > 0:
+        n, r = divmod(n, 58)
+        out.append(_B58_ALPHABET[r])
+    pad = 0
+    for byte in b:
+        if byte == 0:
+            pad += 1
+        else:
+            break
+    return ("1" * pad) + out[::-1].decode()
+
+
+def b58decode(s: str) -> bytes:
+    """Dekodiere einen base58btc-String zurück zu Bytes.
+
+    Raises:
+        ValueError: bei Zeichen ausserhalb des base58-Alphabets.
+    """
+    n = 0
+    for ch in s.encode():
+        try:
+            n = n * 58 + _B58_INDEX[ch]
+        except KeyError:
+            raise ValueError("ungültiges base58-Zeichen: {!r}".format(chr(ch)))
+    pad = len(s) - len(s.lstrip("1"))
+    full = n.to_bytes((n.bit_length() + 7) // 8, "big") if n else b""
+    return b"\x00" * pad + full

--- a/sdata/did/did_peer4.py
+++ b/sdata/did/did_peer4.py
@@ -25,37 +25,11 @@ import hashlib
 from typing import Dict, Tuple
 
 from .errors import EncodingError, VerificationError
+# base58btc liegt jetzt zentral im eigenen Modul (frühere Inline-Variante);
+# Re-Export aus Kompatibilitätsgründen.
+from .base58btc import b58encode, b58decode
 
 __all__ = ["did_peer4_from_payload", "resolve_long_form", "b58encode", "b58decode"]
-
-# --- Base58 (Bitcoin-Alphabet) --------------------------------------------
-_B58_ALPHABET = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-
-
-def b58encode(b: bytes) -> str:
-    """Kodiere Bytes als base58btc (führende Nullbytes bleiben als ``1`` erhalten)."""
-    n = int.from_bytes(b, "big", signed=False)
-    out = bytearray()
-    while n > 0:
-        n, r = divmod(n, 58)
-        out.append(_B58_ALPHABET[r])
-    pad = 0
-    for byte in b:
-        if byte == 0:
-            pad += 1
-        else:
-            break
-    return ("1" * pad) + out[::-1].decode()
-
-
-def b58decode(s: str) -> bytes:
-    """Dekodiere einen base58btc-String zurück zu Bytes."""
-    n = 0
-    for ch in s.encode():
-        n = n * 58 + _B58_ALPHABET.index(ch)
-    pad = len(s) - len(s.lstrip("1"))
-    full = n.to_bytes((n.bit_length() + 7) // 8, "big") if n else b""
-    return b"\x00" * pad + full
 
 
 # --- Varint (LEB128, wie in multicodec) -----------------------------------

--- a/sdata/did/did_web.py
+++ b/sdata/did/did_web.py
@@ -29,8 +29,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import requests
-import base58
 
+from .base58btc import b58encode
 from .errors import EncodingError, ResolutionError
 from .utils_didkey import pub_jwk_from_did_key, b64url_decode
 
@@ -122,7 +122,7 @@ def build_did_document(domain: str, public_input_path: str,
     else:
         if kind == "jwk":
             raw = b64url_decode(data["x"])
-            mb = "z" + base58.b58encode(bytes([0xED, 0x01]) + raw).decode()
+            mb = "z" + b58encode(bytes([0xED, 0x01]) + raw)
         else:
             mb = data["mb"]
         vm = {"id": vm_id, "type": "Ed25519VerificationKey2020", "controller": did,

--- a/sdata/did/eddsa.py
+++ b/sdata/did/eddsa.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Ed25519-Schlüsselobjekte – drop-in-Teilmenge der ``python-ecdsa``-API.
+
+Dieses Modul stellt genau die ``SigningKey``/``VerifyingKey``-Operationen
+bereit, die ``jose`` und ``keys`` zuvor aus dem externen Paket ``ecdsa``
+bezogen haben – jetzt jedoch ohne externe Abhängigkeit, gestützt auf die
+RFC-8032-Primitive in :mod:`sdata.did.ed25519`.
+
+.. warning::
+   Die zugrunde liegende Ed25519-Implementierung ist **pure Python und nicht
+   constant-time** (siehe Sicherheitshinweis in :mod:`sdata.did.ed25519`).
+   Sie verhält sich darin wie ``python-ecdsa`` (ebenfalls pure Python, nicht
+   seitenkanalresistent). Für Umgebungen mit Seitenkanal-Anforderungen ein
+   libsodium-basiertes Backend (PyNaCl) oder ``cryptography`` verwenden.
+
+Korrektheit wird gegen die offiziellen RFC-8032-Testvektoren abgesichert
+(siehe ``tests/test_eddsa.py``).
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from . import ed25519 as _ed
+
+__all__ = ["Ed25519", "SigningKey", "VerifyingKey", "BadSignatureError"]
+
+
+class BadSignatureError(Exception):
+    """Signatur konnte nicht verifiziert werden (API-kompatibel zu ``ecdsa``)."""
+
+
+class _Ed25519Curve:
+    """Sentinel für den Kurvenparameter ``curve=Ed25519`` (API-Kompatibilität)."""
+
+    name = "Ed25519"
+
+    def __repr__(self) -> str:  # pragma: no cover - rein kosmetisch
+        return "Ed25519"
+
+
+#: Kurven-Sentinel, analog zu ``ecdsa.Ed25519``.
+Ed25519 = _Ed25519Curve()
+
+
+def _check_len(raw: bytes, expected: int, what: str) -> bytes:
+    if not isinstance(raw, (bytes, bytearray)) or len(raw) != expected:
+        raise ValueError("{} muss {} Bytes sein".format(what, expected))
+    return bytes(raw)
+
+
+class VerifyingKey:
+    """Öffentlicher Ed25519-Schlüssel (32-Byte, komprimiert)."""
+
+    def __init__(self, pub: bytes):
+        self._pub = pub
+
+    @classmethod
+    def from_string(cls, raw: bytes, curve=Ed25519) -> "VerifyingKey":
+        """Erzeuge einen ``VerifyingKey`` aus 32 rohen Public-Key-Bytes."""
+        return cls(_check_len(raw, 32, "Public Key"))
+
+    def to_string(self) -> bytes:
+        """Liefere den rohen 32-Byte Public Key."""
+        return self._pub
+
+    def verify(self, signature: bytes, data: bytes) -> bool:
+        """Verifiziere ``signature`` über ``data``.
+
+        Returns:
+            ``True`` bei gültiger Signatur.
+        Raises:
+            BadSignatureError: wenn die Signatur ungültig ist.
+        """
+        if not _ed.verify(bytes(signature), bytes(data), self._pub):
+            raise BadSignatureError("Signatur ungültig")
+        return True
+
+
+class SigningKey:
+    """Privater Ed25519-Schlüssel (32-Byte-Seed)."""
+
+    def __init__(self, seed: bytes):
+        self._seed = seed
+        self._pub = _ed.publickey(seed)
+
+    @classmethod
+    def generate(cls, curve=Ed25519) -> "SigningKey":
+        """Erzeuge einen frischen Schlüssel aus 32 zufälligen Bytes (``os.urandom``)."""
+        return cls(os.urandom(32))
+
+    @classmethod
+    def from_string(cls, raw: bytes, curve=Ed25519) -> "SigningKey":
+        """Erzeuge einen ``SigningKey`` aus einem 32-Byte-Seed."""
+        return cls(_check_len(raw, 32, "Seed"))
+
+    def to_string(self) -> bytes:
+        """Liefere den rohen 32-Byte-Seed (geheim halten!)."""
+        return self._seed
+
+    def get_verifying_key(self) -> VerifyingKey:
+        """Leite den zugehörigen öffentlichen Schlüssel ab."""
+        return VerifyingKey(self._pub)
+
+    def sign(self, data: bytes) -> bytes:
+        """Signiere ``data`` und gib die 64-Byte-Signatur zurück."""
+        return _ed.sign(bytes(data), self._seed, self._pub)

--- a/sdata/did/jose.py
+++ b/sdata/did/jose.py
@@ -5,10 +5,11 @@ Diese Modul bündelt das Signieren/Verifizieren von **Compact-JWS**
 (``header.payload.signature``, base64url), das zuvor doppelt in
 ``issue_vc`` und ``verify_vp`` implementiert war.
 
-Krypto-Backend: ``python-ecdsa`` (reine Python-Implementierung von Ed25519).
+Krypto-Backend: :mod:`sdata.did.eddsa` (reine Python-Ed25519-Implementierung,
+abhängigkeitsfrei).
 
 .. warning::
-   ``python-ecdsa`` ist nicht garantiert constant-time. Für hochsensible
+   Das Ed25519-Backend ist nicht garantiert constant-time. Für hochsensible
    Produktivumgebungen mit Seitenkanal-Anforderungen sollte ein
    libsodium-basiertes Backend (PyNaCl) oder ``cryptography`` erwogen werden.
    Siehe auch das Paket-Docstring von :mod:`sdata.did`.
@@ -22,7 +23,7 @@ from __future__ import annotations
 import json
 from typing import Any, Dict
 
-from ecdsa import SigningKey, VerifyingKey, Ed25519, BadSignatureError
+from .eddsa import SigningKey, VerifyingKey, Ed25519, BadSignatureError
 
 from .errors import EncodingError, VerificationError
 from .utils_didkey import b64url, b64url_decode

--- a/sdata/did/keys.py
+++ b/sdata/did/keys.py
@@ -23,7 +23,7 @@ import logging
 import argparse
 from typing import Dict
 
-from ecdsa import SigningKey, Ed25519
+from .eddsa import SigningKey, Ed25519
 
 from .utils_didkey import b64url, jwk_thumbprint_rfc7638, did_key_from_jwk_ed25519
 

--- a/sdata/did/utils_didkey.py
+++ b/sdata/did/utils_didkey.py
@@ -10,7 +10,8 @@ Funktionsumfang:
 * konventionelle ``kid``-Bildung für ``did:web`` und ``did:key``.
 
 Es werden ausschließlich **öffentliche** Schlüssel verarbeitet; private Schlüssel
-tauchen hier nicht auf. Einzige externe Abhängigkeit: ``base58``.
+tauchen hier nicht auf. Abhängigkeitsfrei (nur Standardbibliothek + die eigene
+base58btc-Kodierung in :mod:`sdata.did.base58btc`).
 
 Referenzen:
     * `RFC 7638 <https://www.rfc-editor.org/rfc/rfc7638>`_ – JWK Thumbprint
@@ -24,8 +25,7 @@ import base64
 import hashlib
 from typing import Dict
 
-import base58
-
+from .base58btc import b58encode, b58decode
 from .errors import EncodingError
 
 __all__ = [
@@ -113,7 +113,7 @@ def did_key_from_jwk_ed25519(jwk_pub: Dict) -> str:
     """Erzeuge eine ``did:key``-DID aus einem öffentlichen Ed25519-JWK."""
     _assert_ed25519_jwk_pub(jwk_pub)
     raw = b64url_decode(jwk_pub["x"])  # 32 Byte
-    mb = "z" + base58.b58encode(_ED25519_PUB_PREFIX + raw).decode()
+    mb = "z" + b58encode(_ED25519_PUB_PREFIX + raw)
     return "did:key:{}".format(mb)
 
 
@@ -121,7 +121,7 @@ def did_key_fragment_from_jwk(jwk_pub: Dict) -> str:
     """Liefere den Multibase-Teil (``z…``) – praktisch als ``kid``-Fragment."""
     _assert_ed25519_jwk_pub(jwk_pub)
     raw = b64url_decode(jwk_pub["x"])
-    return "z" + base58.b58encode(_ED25519_PUB_PREFIX + raw).decode()
+    return "z" + b58encode(_ED25519_PUB_PREFIX + raw)
 
 
 def pub_jwk_from_did_key(did_key_or_mb: str) -> Dict[str, str]:
@@ -135,7 +135,7 @@ def pub_jwk_from_did_key(did_key_or_mb: str) -> Dict[str, str]:
     mb = _strip_didkey_multibase(did_key_or_mb)
     if not mb.startswith("z"):
         raise EncodingError("did:key erwartet base58btc (z-Codec)")
-    raw = base58.b58decode(mb[1:])  # 'z' entfernen
+    raw = b58decode(mb[1:])  # 'z' entfernen
     if not (len(raw) >= 34 and raw[0] == 0xED and raw[1] == 0x01):
         raise EncodingError("unerwartetes multicodec-Präfix für ed25519-pub")
     pubkey = raw[2:34]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ REQUIRES = ['numpy', 'pandas', 'tabulate', 'xlrd', 'openpyxl', 'xlsxwriter', 'py
 #   pip install "sdata[hdf]"   HDF5-I/O (PyTables-Backend)
 #   pip install "sdata[sql]"   to_sqlite / pandas.to_sql (SQLAlchemy)
 EXTRAS = {
-    'did': ['ecdsa>=0.18', 'base58>=2.1'],
+    # sdata.did ist abhängigkeitsfrei (Ed25519 + base58btc als pure Python);
+    # die HTTP-Auflösung von did:web/did:github nutzt 'requests' (in REQUIRES).
+    # Extra bleibt als no-op erhalten, damit 'pip install sdata[did]' weiter funktioniert.
+    'did': [],
     'hdf': ['tables'],
     'sql': ['sqlalchemy'],
     'parquet': ['pyarrow'],   # sdata.sclass.DataFrame (Parquet-Serialisierung)
@@ -61,7 +64,7 @@ setup(
 
     install_requires=REQUIRES,
     extras_require=EXTRAS,
-    tests_require=['coverage', 'pytest', 'ecdsa', 'base58'],
+    tests_require=['coverage', 'pytest'],
     test_suite = 'tests',
     packages=find_packages(),
 )

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -2,9 +2,8 @@
 """Tests für das DID-/VC-Subpackage :mod:`sdata.did`.
 
 Importiert über die öffentliche Paket-API. Die Tests laufen ohne Netzwerk
-(HTTP wird via ``monkeypatch`` gemockt) und überspringen sich sauber, falls die
-optionalen Abhängigkeiten (``ecdsa``/``base58``, via ``pip install sdata[did]``)
-nicht installiert sind.
+(HTTP wird via ``monkeypatch`` gemockt). Das Subpackage ist abhängigkeitsfrei
+(Ed25519 + base58btc als pure Python), daher sind keine Krypto-Extras nötig.
 """
 import json
 import base64
@@ -12,12 +11,7 @@ import hashlib
 
 import pytest
 
-# Optionale Abhängigkeiten / Paket – sonst die gesamte Datei überspringen.
-pytest.importorskip("ecdsa")
-pytest.importorskip("base58")
-pytest.importorskip("sdata.did")
-
-from sdata.did import (                                              # noqa: E402
+from sdata.did import (
     gen_ed25519_jwk, pub_from_priv_jwk, did_key_from_jwk_ed25519,
     pub_jwk_from_did_key, jwk_thumbprint_rfc7638,
     sign_compact, verify_compact, jws_header, jws_verify,

--- a/tests/test_eddsa.py
+++ b/tests/test_eddsa.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""Korrektheits- und API-Tests für das abhängigkeitsfreie Ed25519-Backend.
+
+Die offiziellen RFC-8032-Testvektoren (§7.1) sichern ab, dass die pure-Python-
+Implementierung bitgenau das gleiche Ergebnis liefert wie eine etablierte
+Bibliothek – Grundlage dafür, ``python-ecdsa`` als Abhängigkeit abzulösen.
+"""
+import pytest
+
+from sdata.did import ed25519
+from sdata.did.eddsa import (
+    Ed25519, SigningKey, VerifyingKey, BadSignatureError,
+)
+from sdata.did.base58btc import b58encode, b58decode
+
+
+def _h(s):
+    return bytes.fromhex(s)
+
+
+# RFC 8032 §7.1 – (secret, public, message, signature)
+RFC8032_VECTORS = [
+    (  # TEST 1 – leere Nachricht
+        "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+        "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "",
+        "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e0652249015"
+        "55fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b",
+    ),
+    (  # TEST 2 – 1 Byte
+        "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb",
+        "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "72",
+        "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da"
+        "085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00",
+    ),
+    (  # TEST 3 – 2 Byte
+        "c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7",
+        "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "af82",
+        "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac"
+        "18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a",
+    ),
+    (  # TEST – SHA-512("abc") als Nachricht
+        "833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42",
+        "ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf",
+        "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a"
+        "2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+        "dc2a4459e7369633a52b1bf277839a00201009a3efbf3ecb69bea2186c26b589"
+        "09351fc9ac90b3ecfdfbc7c66431e0303dca179c138ac17ad9bef1177331a704",
+    ),
+]
+
+
+@pytest.mark.parametrize("sk_hex,pk_hex,msg_hex,sig_hex", RFC8032_VECTORS)
+def test_rfc8032_primitives(sk_hex, pk_hex, msg_hex, sig_hex):
+    sk, pk, msg, sig = _h(sk_hex), _h(pk_hex), _h(msg_hex), _h(sig_hex)
+    assert ed25519.publickey(sk) == pk
+    assert ed25519.sign(msg, sk, pk) == sig
+    assert ed25519.verify(sig, msg, pk) is True
+    # manipulierte Nachricht -> ungültig
+    assert ed25519.verify(sig, msg + b"\x00", pk) is False
+
+
+@pytest.mark.parametrize("sk_hex,pk_hex,msg_hex,sig_hex", RFC8032_VECTORS)
+def test_rfc8032_adapter(sk_hex, pk_hex, msg_hex, sig_hex):
+    sk, pk, msg, sig = _h(sk_hex), _h(pk_hex), _h(msg_hex), _h(sig_hex)
+    signer = SigningKey.from_string(sk, curve=Ed25519)
+    assert signer.to_string() == sk
+    assert signer.get_verifying_key().to_string() == pk
+    assert signer.sign(msg) == sig
+    verifier = VerifyingKey.from_string(pk, curve=Ed25519)
+    assert verifier.verify(sig, msg) is True
+
+
+def test_adapter_bad_signature_raises():
+    sk = _h(RFC8032_VECTORS[0][0])
+    pk = _h(RFC8032_VECTORS[0][1])
+    sig = _h(RFC8032_VECTORS[0][3])
+    vk = VerifyingKey.from_string(pk)
+    with pytest.raises(BadSignatureError):
+        vk.verify(sig, b"andere nachricht")
+
+
+def test_adapter_generate_roundtrip():
+    sk = SigningKey.generate(curve=Ed25519)
+    vk = sk.get_verifying_key()
+    msg = b"hallo welt"
+    sig = sk.sign(msg)
+    assert vk.verify(sig, msg) is True
+    # zwei frische Schlüssel unterscheiden sich
+    assert sk.to_string() != SigningKey.generate().to_string()
+
+
+def test_adapter_wrong_length():
+    with pytest.raises(ValueError):
+        SigningKey.from_string(b"\x00" * 31)
+    with pytest.raises(ValueError):
+        VerifyingKey.from_string(b"\x00" * 33)
+
+
+def test_ed25519_sentinel():
+    assert Ed25519.name == "Ed25519"
+
+
+# --- base58btc --------------------------------------------------------------
+def test_base58_roundtrip_and_prefix():
+    # multicodec ed25519-pub Präfix + 32 Byte
+    raw = bytes([0xED, 0x01]) + b"\x11" * 32
+    enc = b58encode(raw)
+    assert isinstance(enc, str)
+    assert b58decode(enc) == raw
+
+
+def test_base58_leading_zero_and_empty():
+    assert b58encode(b"\x00\x00\x05") == "11" + b58encode(b"\x05")
+    assert b58encode(b"") == ""
+    assert b58decode("") == b""
+    assert b58decode("11") == b"\x00\x00"
+
+
+def test_base58_invalid_char():
+    with pytest.raises(ValueError):
+        b58decode("0OIl")  # nicht im Alphabet


### PR DESCRIPTION
Macht `sdata.did` krypto-/encoding-seitig **abhängigkeitsfrei**. Beide bisherigen `[did]`-Extra-Dependencies (`ecdsa`, `base58`) entfallen — nur noch `requests` (Core-Dependency) für die HTTP-Auflösung von `did:web`/`did:github`.

## Motivation
Es wurde **nur Ed25519** aus `python-ecdsa` genutzt (kein echtes ECDSA/NIST). Eine geprüfte pure-Python-RFC-8032-Implementierung lag bereits im Repo (`ed25519.py`, von `diddoc.py` schon genutzt) — und `did_peer4.py` brachte bereits eine eigene base58btc-Kodierung mit. Die Abhängigkeiten waren also redundant.

## Änderungen
**Neu**
- `eddsa.py` — drop-in-Teilmenge der `ecdsa`-API (`SigningKey`/`VerifyingKey`/`Ed25519`/`BadSignatureError`) über die RFC-8032-Primitive; Schlüsselerzeugung via `os.urandom(32)`.
- `base58btc.py` — konsolidierte base58btc-Kodierung (vorher inline), zentral + saubere Fehlerbehandlung.

**Umstellungen**
- `jose.py`, `keys.py`: `from .eddsa import …` statt `ecdsa`.
- `did_web.py`, `utils_didkey.py`: `from .base58btc import …`; `did_peer4.py` re-exportiert `b58encode`/`b58decode`.
- `setup.py`: `[did]`-Extra ohne `ecdsa`/`base58` (no-op, bleibt installierbar). Docstrings aktualisiert.

## Sicherheit
Kein Constant-time-Regress: `python-ecdsa` war ebenfalls pure-Python/nicht seitenkanalresistent. Der ehrliche Sicherheitshinweis bleibt; für Hochsicherheit weiterhin PyNaCl/`cryptography` empfohlen. **Korrektheit ist gegen die offiziellen RFC-8032-Testvektoren (§7.1) abgesichert** (`tests/test_eddsa.py`).

## Verifikation
Mit **deinstalliertem** `ecdsa`/`base58`: `377 passed, 5 skipped`, **Coverage 100 %** (inkl. neuer Module). `did:key` + JWS sign/verify-Roundtrip pure-Python bestätigt.