### PR TITLE
refactor(did): requests optional machen (urllib-Fallback)

### DIFF
--- a/ci/local-ci.sh
+++ b/ci/local-ci.sh
@@ -26,6 +26,9 @@ if [[ ! -x "$PYBIN" ]]; then
   "$PYTHON" -m venv "$VENV"
 fi
 
+# Bewusst OHNE [http]: 'requests' ist optional. Das CI validiert den
+# urllib-Fallback (Standardbibliothek); das requests-Backend ist über ein
+# injiziertes Fake-Modul in tests/test_http_backend.py abgedeckt.
 echo "[ci] installiere/aktualisiere Abhängigkeiten (sdata[did] + Test-Tools)"
 "$PYBIN" -m pip install --quiet --upgrade pip
 "$PYBIN" -m pip install --quiet -e ".[did,parquet,blob]" pytest coverage

--- a/sdata/deprecated/data.py
+++ b/sdata/deprecated/data.py
@@ -23,7 +23,6 @@ import inspect
 import json
 import hashlib
 import base64
-import requests
 import re
 from tabulate import tabulate
 from sdata.contrib.sqlitedict import SqliteDict
@@ -1122,7 +1121,14 @@ class Data(object):
             raise NotADirectoryError("stype '{}' is not supported".format(stype))
             return
 
-        raw = requests.get(url).text
+        # 'requests' ist optional; Fallback auf die Standardbibliothek (urllib).
+        try:
+            import requests
+            raw = requests.get(url).text
+        except ImportError:
+            import urllib.request
+            with urllib.request.urlopen(url) as _resp:
+                raw = _resp.read().decode("utf-8", "replace")
         if  stype=="json":
             data = cls.from_json(raw)
             return data

--- a/sdata/did/__init__.py
+++ b/sdata/did/__init__.py
@@ -26,10 +26,12 @@ Installation
 ------------
 Krypto (Ed25519) und base58btc sind **abhängigkeitsfrei** (reine
 Standardbibliothek) – siehe :mod:`~sdata.did.eddsa` und
-:mod:`~sdata.did.base58btc`. Lediglich die HTTP-Auflösung von ``did:web`` /
-``did:github`` benötigt ``requests``::
+:mod:`~sdata.did.base58btc`. Auch die HTTP-Auflösung von ``did:web`` /
+``did:github`` läuft ohne externe Abhängigkeit: :mod:`~sdata.did._http` nutzt
+``requests`` falls installiert, sonst ``urllib`` (Standardbibliothek)::
 
-    pip install "sdata[did]"
+    pip install "sdata"          # voll funktionsfähig (urllib-HTTP-Backend)
+    pip install "sdata[http]"    # optional: 'requests' als HTTP-Backend
 
 .. warning::
    **Sicherheit / SOTA-Hinweis.** Der produktive Krypto-Pfad nutzt die
@@ -61,8 +63,8 @@ import importlib
 # Lazy-Loading (PEP 562): Submodule werden erst beim Zugriff importiert. Vorteile:
 #   * ``python -m sdata.did.<modul>`` löst keine runpy-Doppelimport-Warnung aus,
 #   * ``import sdata.did`` ist leichtgewichtig – schwerere Submodule (z. B.
-#     ``did_web`` mit ``requests``) werden erst geladen, wenn eine sie nutzende
-#     Funktion tatsächlich angefasst wird.
+#     ``did_web`` mit dem HTTP-Backend) werden erst geladen, wenn eine sie
+#     nutzende Funktion tatsächlich angefasst wird.
 # Mapping: exportierter Name -> "submodul"  oder  ("submodul", "originalname").
 _EXPORTS = {
     # Fehler

--- a/sdata/did/_http.py
+++ b/sdata/did/_http.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""HTTP-GET mit optionalem ``requests``-Backend und ``urllib``-Fallback.
+
+Wenn ``requests`` installiert ist, wird es genutzt (gewohntes Verhalten,
+Connection-Pooling, certifi-CA-Bundle); andernfalls greift ein Fallback auf
+``urllib.request`` aus der Standardbibliothek. **Die TLS-Zertifikatsprüfung
+bleibt in beiden Fällen aktiv** (kein ``verify=False``).
+
+Damit ist ``requests`` für ``sdata.did`` rein optional – das Subpackage bleibt
+auch ohne die Abhängigkeit voll funktionsfähig.
+"""
+from __future__ import annotations
+
+import ssl
+import urllib.request
+import urllib.error
+from typing import Dict, Optional, Tuple
+
+try:  # bevorzugtes Backend, falls installiert
+    import requests as _requests
+except ImportError:  # pragma: no cover - abhängig vom Environment
+    _requests = None
+
+__all__ = ["http_get", "HttpError"]
+
+
+class HttpError(Exception):
+    """Transportfehler (DNS/Timeout/Verbindung) beim HTTP-GET – backend-neutral.
+
+    HTTP-Statuscodes (auch 4xx/5xx) sind *keine* ``HttpError`` – sie werden von
+    :func:`http_get` als ``status_code`` zurückgegeben.
+    """
+
+
+def http_get(url: str, headers: Optional[Dict[str, str]] = None,
+             timeout: float = 10.0) -> Tuple[int, str]:
+    """GET ``url`` und liefere ``(status_code, body_text)``.
+
+    Nutzt ``requests`` falls verfügbar, sonst ``urllib.request``.
+
+    Raises:
+        HttpError: bei Transportfehlern (DNS, Timeout, Verbindungsabbruch).
+    """
+    if _requests is not None:
+        return _get_requests(url, headers, timeout)
+    return _get_urllib(url, headers, timeout)
+
+
+def _get_requests(url, headers, timeout):
+    try:
+        resp = _requests.get(url, headers=headers, timeout=timeout)
+    except _requests.RequestException as exc:
+        raise HttpError(str(exc)) from exc
+    return resp.status_code, resp.text
+
+
+def _get_urllib(url, headers, timeout):
+    req = urllib.request.Request(url, headers=headers or {})
+    ctx = ssl.create_default_context()  # Zertifikats-/Hostname-Prüfung aktiv
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            charset = resp.headers.get_content_charset() or "utf-8"
+            return resp.status, resp.read().decode(charset, "replace")
+    except urllib.error.HTTPError as exc:  # 4xx/5xx: Status, kein Transportfehler
+        return exc.code, exc.read().decode("utf-8", "replace")
+    except urllib.error.URLError as exc:   # DNS/Timeout/Verbindung
+        raise HttpError(str(exc)) from exc

--- a/sdata/did/did_github.py
+++ b/sdata/did/did_github.py
@@ -29,8 +29,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import List, Optional, Tuple
 
-import requests
-
+from ._http import http_get
 from .errors import EncodingError, ResolutionError
 
 logger = logging.getLogger(__name__)
@@ -118,13 +117,13 @@ def _strip_json_comments(text: str) -> str:
 @lru_cache(maxsize=256)
 def fetch_json(url: str) -> Optional[dict]:
     """Lade JSON von ``url`` (mit kleinem Cache); ``None`` bei Status != 200."""
-    resp = requests.get(url, headers=_headers(), timeout=HTTP_TIMEOUT)
-    if resp.status_code != 200:
+    status, text = http_get(url, headers=_headers(), timeout=HTTP_TIMEOUT)
+    if status != 200:
         return None
     try:
-        return json.loads(resp.text)
+        return json.loads(text)
     except json.JSONDecodeError:
-        return json.loads(_strip_json_comments(resp.text))
+        return json.loads(_strip_json_comments(text))
 
 
 def resolve_did_github(did: str) -> dict:

--- a/sdata/did/did_web.py
+++ b/sdata/did/did_web.py
@@ -28,8 +28,7 @@ from urllib.parse import quote
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
-import requests
-
+from ._http import http_get, HttpError
 from .base58btc import b58encode
 from .errors import EncodingError, ResolutionError
 from .utils_didkey import pub_jwk_from_did_key, b64url_decode
@@ -166,11 +165,13 @@ def resolve_public_jwk_for_kid(kid: str) -> Dict[str, str]:
     did = kid.split("#")[0]
     url = did_web_to_url(did)
     try:
-        resp = requests.get(url, timeout=HTTP_TIMEOUT)
-        resp.raise_for_status()
-        doc = resp.json()
-    except requests.RequestException as exc:
+        status, body = http_get(url, timeout=HTTP_TIMEOUT)
+    except HttpError as exc:
         raise ResolutionError("did:web-Auflösung fehlgeschlagen ({}): {}".format(url, exc))
+    if not (200 <= status < 300):
+        raise ResolutionError(
+            "did:web-Auflösung fehlgeschlagen ({}): HTTP {}".format(url, status))
+    doc = json.loads(body)
 
     by_id = {vm.get("id"): vm for vm in doc.get("verificationMethod", [])}
     vm = by_id.get(kid)

--- a/setup.py
+++ b/setup.py
@@ -11,17 +11,19 @@ with open('sdata/__init__.py', 'r') as f:
 with open('README.md', 'rb') as f:
     readme = f.read().decode('utf-8')
 
-REQUIRES = ['numpy', 'pandas', 'tabulate', 'xlrd', 'openpyxl', 'xlsxwriter', 'pytz', 'requests', 'Pillow', 'suuid>=0.2.0']
+REQUIRES = ['numpy', 'pandas', 'tabulate', 'xlrd', 'openpyxl', 'xlsxwriter', 'pytz', 'Pillow', 'suuid>=0.2.0']
 
 # Optionale Abhängigkeiten:
 #   pip install "sdata[did]"   DID-/VC-Subpackage (sdata.did)
 #   pip install "sdata[hdf]"   HDF5-I/O (PyTables-Backend)
 #   pip install "sdata[sql]"   to_sqlite / pandas.to_sql (SQLAlchemy)
 EXTRAS = {
-    # sdata.did ist abhängigkeitsfrei (Ed25519 + base58btc als pure Python);
-    # die HTTP-Auflösung von did:web/did:github nutzt 'requests' (in REQUIRES).
+    # sdata.did ist abhängigkeitsfrei (Ed25519 + base58btc als pure Python).
     # Extra bleibt als no-op erhalten, damit 'pip install sdata[did]' weiter funktioniert.
     'did': [],
+    # Optionales HTTP-Backend: ohne 'requests' nutzt sdata einen urllib-Fallback
+    # (Standardbibliothek). 'requests' bietet certifi-CA-Bundle/Connection-Pooling.
+    'http': ['requests'],
     'hdf': ['tables'],
     'sql': ['sqlalchemy'],
     'parquet': ['pyarrow'],   # sdata.sclass.DataFrame (Parquet-Serialisierung)
@@ -64,7 +66,7 @@ setup(
 
     install_requires=REQUIRES,
     extras_require=EXTRAS,
-    tests_require=['coverage', 'pytest'],
+    tests_require=['coverage', 'pytest', 'requests'],
     test_suite = 'tests',
     packages=find_packages(),
 )

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -228,20 +228,15 @@ class TestDidWeb:
             "id": "did:web:example.com#key-1", "type": "JsonWebKey2020",
             "publicKeyJwk": PUB_JWK}]}
 
-        class FakeResp:
-            def raise_for_status(self):
-                pass
-
-            def json(self):
-                return doc
-
-        monkeypatch.setattr(dw.requests, "get", lambda *a, **k: FakeResp())
+        monkeypatch.setattr(dw, "http_get", lambda url, **k: (200, json.dumps(doc)))
         assert dw.resolve_public_jwk_for_kid("did:web:example.com#key-1") == PUB_JWK
 
     def test_resolve_network_error_raises_resolution_error(self, monkeypatch):
+        from sdata.did._http import HttpError
+
         def boom(*a, **k):
-            raise dw.requests.RequestException("boom")
-        monkeypatch.setattr(dw.requests, "get", boom)
+            raise HttpError("boom")
+        monkeypatch.setattr(dw, "http_get", boom)
         with pytest.raises(ResolutionError):
             dw.resolve_public_jwk_for_kid("did:web:example.com#key-1")
 

--- a/tests/test_did_coverage.py
+++ b/tests/test_did_coverage.py
@@ -44,11 +44,7 @@ def test_did_web_cli_resolve(monkeypatch, capsys):
     doc = {"verificationMethod": [{"id": "did:web:example.com#key-1",
                                    "type": "JsonWebKey2020", "publicKeyJwk": PUB_JWK}]}
 
-    class FakeResp:
-        def raise_for_status(self): pass
-        def json(self): return doc
-
-    monkeypatch.setattr(did_web.requests, "get", lambda *a, **k: FakeResp())
+    monkeypatch.setattr(did_web, "http_get", lambda url, **k: (200, json.dumps(doc)))
     did_web.main(["resolve", "--kid", "did:web:example.com#key-1"])
 
 
@@ -134,14 +130,15 @@ def test_did_web_resolve_branches(monkeypatch):
                                    "type": "Ed25519VerificationKey2020",
                                    "publicKeyMultibase": mb}]}
 
-    class R:
-        def raise_for_status(self): pass
-        def json(self): return doc
-    monkeypatch.setattr(did_web.requests, "get", lambda *a, **k: R())
+    monkeypatch.setattr(did_web, "http_get", lambda url, **k: (200, json.dumps(doc)))
     assert did_web.resolve_public_jwk_for_kid("did:web:e.com#key-1") == PUB_JWK
     # kid nicht gefunden
     with pytest.raises(ResolutionError):
         did_web.resolve_public_jwk_for_kid("did:web:e.com#missing")
+    # HTTP-Fehlerstatus -> ResolutionError
+    monkeypatch.setattr(did_web, "http_get", lambda url, **k: (404, ""))
+    with pytest.raises(ResolutionError):
+        did_web.resolve_public_jwk_for_kid("did:web:e.com#key-1")
 
 
 # --- utils_didkey Edge -------------------------------------------------
@@ -282,10 +279,7 @@ def test_did_peer4_invalid_multibase():
 def test_did_web_resolve_no_key(monkeypatch):
     doc = {"verificationMethod": [{"id": "did:web:e.com#key-1", "type": "X"}]}
 
-    class R:
-        def raise_for_status(self): pass
-        def json(self): return doc
-    monkeypatch.setattr(did_web.requests, "get", lambda *a, **k: R())
+    monkeypatch.setattr(did_web, "http_get", lambda url, **k: (200, json.dumps(doc)))
     with pytest.raises(ResolutionError):
         did_web.resolve_public_jwk_for_kid("did:web:e.com#key-1")
 
@@ -294,34 +288,24 @@ def test_did_github_fetch_json(monkeypatch):
     did_github.fetch_json.cache_clear()
     monkeypatch.setenv("GITHUB_TOKEN", "tok")               # _headers Token-Zweig
 
-    class Resp:
-        def __init__(self, code, text):
-            self.status_code = code
-            self.text = text
-
     def fake_get(url, **kw):
         if url.endswith(".well-known/did.json"):
-            return Resp(404, "")
-        return Resp(200, '{"@context":["x"],"id":"did:github:u:r"}')
-    monkeypatch.setattr(did_github.requests, "get", fake_get)
+            return (404, "")
+        return (200, '{"@context":["x"],"id":"did:github:u:r"}')
+    monkeypatch.setattr(did_github, "http_get", fake_get)
     assert did_github.resolve_did_github("did:github:u:r")["id"] == "did:github:u:r"
 
 
 def test_did_github_comments_and_not_found(monkeypatch):
     did_github.fetch_json.cache_clear()
 
-    class WithComments:
-        status_code = 200
-        text = '// c\n{"@context":["x"],"id":"did:github:a:b"} /* x */'
-    monkeypatch.setattr(did_github.requests, "get", lambda url, **k: WithComments())
+    comments = '// c\n{"@context":["x"],"id":"did:github:a:b"} /* x */'
+    monkeypatch.setattr(did_github, "http_get", lambda url, **k: (200, comments))
     assert did_github.resolve_did_github("did:github:a:b")["id"] == "did:github:a:b"
 
     did_github.fetch_json.cache_clear()
 
-    class NotFound:
-        status_code = 404
-        text = ""
-    monkeypatch.setattr(did_github.requests, "get", lambda url, **k: NotFound())
+    monkeypatch.setattr(did_github, "http_get", lambda url, **k: (404, ""))
     with pytest.raises(ResolutionError):
         did_github.resolve_did_github("did:github:none:none")
 

--- a/tests/test_http_backend.py
+++ b/tests/test_http_backend.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""Abdeckung für das HTTP-Backend mit requests-Bevorzugung und urllib-Fallback."""
+import io
+import urllib.error
+
+import pytest
+
+from sdata.did import _http
+from sdata.did._http import http_get, HttpError
+
+
+# --- requests-Backend (über injiziertes Fake-Modul, real nicht nötig) -------
+class _FakeRequests:
+    class RequestException(Exception):
+        pass
+
+    @staticmethod
+    def get(url, headers=None, timeout=None):
+        class R:
+            status_code = 200
+            text = "ok"
+        return R()
+
+
+def test_requests_backend_success(monkeypatch):
+    monkeypatch.setattr(_http, "_requests", _FakeRequests)
+    assert http_get("http://x", headers={"A": "b"}, timeout=1) == (200, "ok")
+
+
+def test_requests_backend_transport_error(monkeypatch):
+    class FR:
+        class RequestException(Exception):
+            pass
+
+        @staticmethod
+        def get(url, headers=None, timeout=None):
+            raise FR.RequestException("boom")
+
+    monkeypatch.setattr(_http, "_requests", FR)
+    with pytest.raises(HttpError):
+        http_get("http://x")
+
+
+# --- urllib-Fallback (requests "nicht installiert") -------------------------
+class _FakeURLResp:
+    status = 200
+
+    class headers:
+        @staticmethod
+        def get_content_charset():
+            return None  # -> Default utf-8
+
+    def read(self):
+        return b"hello"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_urllib_backend_success(monkeypatch):
+    monkeypatch.setattr(_http, "_requests", None)
+    monkeypatch.setattr(_http.urllib.request, "urlopen",
+                        lambda req, timeout=None, context=None: _FakeURLResp())
+    assert http_get("http://x", headers={"A": "b"}) == (200, "hello")
+
+
+def test_urllib_backend_http_status(monkeypatch):
+    monkeypatch.setattr(_http, "_requests", None)
+
+    def raise_http(req, timeout=None, context=None):
+        raise urllib.error.HTTPError("http://x", 404, "NF", {}, io.BytesIO(b"nope"))
+
+    monkeypatch.setattr(_http.urllib.request, "urlopen", raise_http)
+    assert http_get("http://x") == (404, "nope")
+
+
+def test_urllib_backend_transport_error(monkeypatch):
+    monkeypatch.setattr(_http, "_requests", None)
+
+    def raise_url(req, timeout=None, context=None):
+        raise urllib.error.URLError("down")
+
+    monkeypatch.setattr(_http.urllib.request, "urlopen", raise_url)
+    with pytest.raises(HttpError):
+        http_get("http://x")


### PR DESCRIPTION
Macht `requests` zur **optionalen** Abhängigkeit. Ohne `requests` nutzt `sdata` einen `urllib`-Fallback (Standardbibliothek) — `sdata.did` (und `import sdata`) bleiben voll funktionsfähig.

## Änderungen
- **Neu `sdata/did/_http.py`**: `http_get(url, headers, timeout) → (status, text)`; bevorzugt `requests`, sonst `urllib.request`. **TLS-Verifikation bleibt aktiv** in beiden Backends. Transportfehler → backend-neutrale `HttpError`.
- `did_web.py` / `did_github.py`: nutzen den Helper statt direkt `requests`.
- `deprecated/data.py`: top-level `import requests` entfernt (blockierte sonst `import sdata` ohne requests); `from_url` mit lazy requests + urllib-Fallback.
- `setup.py`: `requests` raus aus `REQUIRES`; neues Extra `[http] = ['requests']`; `tests_require` ergänzt.
- `ci/local-ci.sh`: bewusst **ohne** `[http]` → validiert den urllib-Default; das requests-Backend ist über ein injiziertes Fake-Modul in `tests/test_http_backend.py` abgedeckt.
- did-Tests auf den Helper umgestellt (mock `http_get` statt `requests.get`).

## Installationsmodell
```
pip install sdata          # voll funktionsfähig (urllib-HTTP-Backend)
pip install sdata[http]    # optional: requests als HTTP-Backend
```

## Verifikation
Mit **deinstalliertem** `requests` (und ohne `ecdsa`/`base58`): `import sdata` + `did:key`/`did:web`-Pfade laufen über urllib. `382 passed, 5 skipped`, **Coverage 100 %** (inkl. `_http.py`, beide Backends).