### PR TITLE
refactor(deps): Core-Abhängigkeiten verschlanken (9 → 4)

### DIFF
--- a/sdata/deprecated/data.py
+++ b/sdata/deprecated/data.py
@@ -24,7 +24,6 @@ import json
 import hashlib
 import base64
 import re
-from tabulate import tabulate
 from sdata.contrib.sqlitedict import SqliteDict
 
 if sys.version_info < (3, 0):
@@ -1340,6 +1339,7 @@ class Data(object):
         else:
             xlsx_tag = ""
 
+        from tabulate import tabulate  # optional; nur für HTML-Repr benötigt
         param = {"title":"{0} [{1}]".format(self.osname,
                                             self.uuid),
                  "description":self.description,

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,15 @@ with open('sdata/__init__.py', 'r') as f:
 with open('README.md', 'rb') as f:
     readme = f.read().decode('utf-8')
 
-REQUIRES = ['numpy', 'pandas', 'tabulate', 'xlrd', 'openpyxl', 'xlsxwriter', 'pytz', 'Pillow', 'suuid>=0.2.0']
+# Schlanker Kern: nur numpy/pandas (Datenmodell), pytz (Zeitzonen) und suuid.
+REQUIRES = ['numpy', 'pandas', 'pytz', 'suuid>=0.2.0']
 
 # Optionale Abhängigkeiten:
-#   pip install "sdata[did]"   DID-/VC-Subpackage (sdata.did)
-#   pip install "sdata[hdf]"   HDF5-I/O (PyTables-Backend)
-#   pip install "sdata[sql]"   to_sqlite / pandas.to_sql (SQLAlchemy)
+#   pip install "sdata[did]"     DID-/VC-Subpackage (sdata.did, pure Python)
+#   pip install "sdata[http]"    requests als HTTP-Backend (sonst urllib-Fallback)
+#   pip install "sdata[excel]"   Excel-I/O (openpyxl/xlsxwriter via pandas)
+#   pip install "sdata[hdf]"     HDF5-I/O (PyTables-Backend)
+#   pip install "sdata[sql]"     to_sqlite / pandas.to_sql (SQLAlchemy)
 EXTRAS = {
     # sdata.did ist abhängigkeitsfrei (Ed25519 + base58btc als pure Python).
     # Extra bleibt als no-op erhalten, damit 'pip install sdata[did]' weiter funktioniert.
@@ -24,6 +27,8 @@ EXTRAS = {
     # Optionales HTTP-Backend: ohne 'requests' nutzt sdata einen urllib-Fallback
     # (Standardbibliothek). 'requests' bietet certifi-CA-Bundle/Connection-Pooling.
     'http': ['requests'],
+    # Excel-I/O (z. B. deprecated Data.to_xlsx); 'tabulate' für das HTML-Repr.
+    'excel': ['openpyxl', 'xlsxwriter', 'tabulate'],
     'hdf': ['tables'],
     'sql': ['sqlalchemy'],
     'parquet': ['pyarrow'],   # sdata.sclass.DataFrame (Parquet-Serialisierung)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,6 +1,10 @@
 import sys
 import os
 import pandas as pd
+import pytest
+
+pytest.importorskip("PIL")  # Bild-Funktionen optional (Pillow)
+
 from sdata.sclass.image import Image
 modulepath = os.path.dirname(__file__)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -15,6 +15,7 @@ import sdata
 import uuid
 
 def test_data_to_html():
+    pytest.importorskip("xlsxwriter")  # to_html bettet xlsx ein (sdata[excel])
     df = pd.DataFrame({'a': ['x', 'y', '', 'z'], 'b': [1, 2, 2, 3.2]})
     data = sdata.Data(name="data", uuid="38b26864e7794f5182d38459bab8584d", table=df, description="abc")
     data.to_html("/tmp/data.html")

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.join(modulepath, "..", "..", "src"))
 import sdata
 import pandas as pd
 import numpy as np
+import pytest
 
 
 def test_table():
@@ -30,6 +31,7 @@ def test_table():
 
     ts.to_folder("/tmp/sdata_table")
 
+    pytest.importorskip("xlsxwriter")  # Excel-Export optional (sdata[excel])
     table.to_xlsx("/tmp/sdata_table.xlsx")
     print(table.metadata.to_dataframe())
 


### PR DESCRIPTION
Verschlankt `REQUIRES` von 9 auf 4 Pakete. Kern ist jetzt nur noch `numpy, pandas, pytz, suuid`; Excel-/Bild-/Legacy-Abhängigkeiten werden optional.

## Audit (aktiver, gemessener Code)
| Dep | Nutzung | Aktion |
|---|---|---|
| `xlrd` | **nirgends** | ersatzlos entfernt |
| `Pillow` | nur transitiv via openpyxl (das PIL `try/except`-guarded) | entfernt |
| `openpyxl` | guarded Import in `__init__` + pandas-Excel-Engine | → `[excel]` |
| `xlsxwriter` | nur deprecated `Data.to_xlsx` (Laufzeit) | → `[excel]` |
| `tabulate` | nur deprecated HTML-Repr (war Modulebene-Import!) | lazy + `[excel]` |
| `pytz` | echt im Kern (Zeitzonen) | bleibt |

## Änderungen
- `setup.py`: `REQUIRES = [numpy, pandas, pytz, suuid]`; neues Extra `[excel] = [openpyxl, xlsxwriter, tabulate]`.
- `deprecated/data.py`: `from tabulate import tabulate` von Modulebene in die nutzende Methode → `import sdata` läuft ohne tabulate.
- Tests mit optionalem Backend überspringen sich sauber via `importorskip`: `test_image` (PIL), `test_io::test_data_to_html` & `test_table::to_xlsx` (xlsxwriter) — analog zu den bestehenden HDF5/sql-Skips.

## Installationsmodell
```
pip install sdata           # schlanker Kern
pip install sdata[excel]    # Excel-I/O + HTML-Repr
```

## Verifikation
Mit **nur** den Kern-Deps (ohne `tabulate/xlrd/openpyxl/xlsxwriter/Pillow`): `import sdata` OK, `379 passed, 8 skipped`, **Coverage 100 %**.