### PR TITLE
feat(metadata): dtype-Registry + Robustheit (PR1/4)

### DIFF
--- a/sdata/dtypes.py
+++ b/sdata/dtypes.py
@@ -1,0 +1,271 @@
+# -*- coding: utf-8 -*-
+"""Reine-stdlib dtype-Registry für :class:`sdata.metadata.Attribute`.
+
+Single Source of Truth für Wert-Coercion, JSON-(De)Serialisierung, die zu einem
+dtype gehörige Python-Klasse und das XSD-Typ-Mapping (das die JSON-LD-Schicht
+konsumiert).
+
+Designziele:
+
+* **Rückwärtskompatibel** – im *lenienten* Default-Modus (``strict=False``)
+  verhält sich die Coercion byte-genau wie der bisherige
+  ``Attribute._set_value``: leere/falsy Werte werden je dtype zu ``np.nan`` /
+  ``None`` / ``""`` / ``False``; nicht-castbare Werte lösen ``DtypeError`` aus
+  (vom Setter geloggt, Wert bleibt unverändert).
+* **Strikt opt-in** – ``strict=True`` wirft ``DtypeError`` statt still zu
+  degradieren.
+* **Erweiterbar** – neben den 6 Alt-dtypes (str/int/float/bool/timestamp/list)
+  zusätzlich ``bytes`` (base64), ``json`` (dict/list) und ``uri``.
+"""
+import base64
+import binascii
+import datetime
+import json as _json
+from urllib.parse import urlsplit
+
+import numpy as np
+import pandas as pd
+
+from sdata.timestamp import TimeStamp
+
+__all__ = [
+    "DtypeError", "DtypeSpec", "register", "get", "names", "resolve",
+    "coerce", "xsd_map", "json_default", "XSD", "DTYPES", "DTYPES_INV",
+]
+
+
+class DtypeError(ValueError):
+    """Wert kann nicht in den Ziel-dtype überführt werden (v.a. im strict-Modus)."""
+
+
+def _isna(value):
+    """``pd.isna`` skalar; Array-Eingaben (Liste o.ä.) gelten als nicht-NA."""
+    result = pd.isna(value)
+    return bool(result) if isinstance(result, (bool, np.bool_)) else False
+
+
+# --- Coercion-Funktionen (value, strict) -> python value --------------------
+def _c_str(value, strict):
+    if value == "":
+        return ""
+    if not value:
+        return None
+    return str(value)
+
+
+def _c_int(value, strict):
+    if not value:                 # 0/None/""/False/[]  -> nan (Altverhalten)
+        return np.nan
+    if _isna(value):
+        return np.nan
+    try:
+        return int(value)
+    except (ValueError, TypeError) as exp:
+        raise DtypeError("int: {!r}".format(value)) from exp
+
+
+def _c_float(value, strict):
+    if not value:
+        return np.nan
+    if _isna(value):
+        return np.nan
+    try:
+        return float(value)
+    except (ValueError, TypeError) as exp:
+        raise DtypeError("float: {!r}".format(value)) from exp
+
+
+# leniente bool-Abbildung = exakt das bisherige Verhalten
+_LEGACY_BOOL_TRUE = [1, "1", "true", "True"]
+# strenge, case-insensitive Erweiterung
+_STRICT_TRUE = {"1", "true", "yes", "y", "on", "t", "wahr"}
+_STRICT_FALSE = {"0", "false", "no", "n", "off", "f", "falsch", ""}
+
+
+def _c_bool(value, strict):
+    if isinstance(value, bool):
+        return value
+    if not strict:
+        # Altverhalten: True genau dann, wenn value in {1,"1","true","True"}
+        return value in _LEGACY_BOOL_TRUE
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(value)
+    token = str(value).strip().lower()
+    if token in _STRICT_TRUE:
+        return True
+    if token in _STRICT_FALSE:
+        return False
+    raise DtypeError("bool: {!r}".format(value))
+
+
+def _c_timestamp(value, strict):
+    if value is None or value == "":
+        return None
+    if isinstance(value, TimeStamp):
+        return value
+    if isinstance(value, datetime.datetime):
+        return TimeStamp(value.isoformat())
+    try:
+        return TimeStamp(str(value))
+    except Exception as exp:                       # ParseError u.ä.
+        raise DtypeError("timestamp: {!r}".format(value)) from exp
+
+
+def _c_list(value, strict):
+    if value is None or value == "":
+        return []
+    if isinstance(value, str):
+        return [v.strip() for v in value.split(",") if v.strip()]
+    if isinstance(value, (list, tuple)):
+        return [str(v) for v in value]
+    raise DtypeError("list[str]: {!r}".format(value))
+
+
+def _c_bytes(value, strict):
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, (bytearray, memoryview)):
+        return bytes(value)
+    if isinstance(value, str):
+        try:
+            return base64.b64decode(value, validate=True)
+        except (binascii.Error, ValueError):
+            return value.encode("utf-8")
+    raise DtypeError("bytes: {!r}".format(value))
+
+
+def _c_json(value, strict):
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, str):
+        try:
+            return _json.loads(value)
+        except (ValueError, TypeError) as exp:
+            raise DtypeError("json: {!r}".format(value)) from exp
+    raise DtypeError("json: {!r}".format(value))
+
+
+def _c_uri(value, strict):
+    if value is None or value == "":
+        return None if value is None else ""
+    text = str(value).strip()
+    if strict and not (urlsplit(text).scheme or urlsplit(text).path):
+        raise DtypeError("uri: {!r}".format(value))
+    return text
+
+
+# --- JSON-Serialisierung je dtype -------------------------------------------
+def _ts_to_json(value):
+    return str(value.utc) if isinstance(value, TimeStamp) else value
+
+
+def _bytes_to_json(value):
+    return base64.b64encode(value).decode("ascii") if isinstance(value, bytes) else value
+
+
+class DtypeSpec:
+    """Beschreibt einen dtype: Coercion, JSON-Repräsentation, Klasse, XSD-Typ."""
+
+    def __init__(self, name, pytype, coerce, xsd, to_json=None):
+        self.name = name
+        self.pytype = pytype
+        self._coerce = coerce
+        self.xsd = xsd
+        self._to_json = to_json or (lambda v: v)
+
+    def coerce(self, value, strict=False):
+        return self._coerce(value, strict)
+
+    def to_json(self, value):
+        return self._to_json(value)
+
+
+_REGISTRY = {}
+
+
+def register(spec):
+    _REGISTRY[spec.name] = spec
+
+
+for _spec in [
+    DtypeSpec("str", str, _c_str, "xsd:string"),
+    DtypeSpec("int", int, _c_int, "xsd:integer"),
+    DtypeSpec("float", float, _c_float, "xsd:double"),
+    DtypeSpec("bool", bool, _c_bool, "xsd:boolean"),
+    DtypeSpec("timestamp", datetime.datetime, _c_timestamp, "xsd:dateTime", _ts_to_json),
+    DtypeSpec("list", list, _c_list, "xsd:string"),
+    DtypeSpec("bytes", bytes, _c_bytes, "xsd:base64Binary", _bytes_to_json),
+    DtypeSpec("json", dict, _c_json, "xsd:string"),
+    DtypeSpec("uri", str, _c_uri, "xsd:anyURI"),
+]:
+    register(_spec)
+
+
+def get(name):
+    """DtypeSpec zum kanonischen Namen oder ``None``."""
+    return _REGISTRY.get(name)
+
+
+def names():
+    """Liste aller kanonischen dtype-Namen."""
+    return list(_REGISTRY.keys())
+
+
+# Kompat-Aliasse (entsprechen exakt den bisherigen Attribute.DTYPES/_INV
+# für die 6 Alt-dtypes; neue dtypes hängen hinten an, str bleibt -> 'str').
+DTYPES = {name: spec.pytype for name, spec in _REGISTRY.items()}
+DTYPES_INV = {
+    float: "float", int: "int", str: "str",
+    datetime.datetime: "timestamp", bool: "bool", list: "list",
+    bytes: "bytes", dict: "json",
+}
+XSD = {name: spec.xsd for name, spec in _REGISTRY.items()}
+
+
+def xsd_map():
+    """Kopie der ``{dtype_name: xsd_iri}``-Tabelle (für die JSON-LD-Schicht)."""
+    return dict(XSD)
+
+
+def resolve(dtype):
+    """Normalisiere einen dtype-Input (String ODER Klasse) auf einen Registry-Key.
+
+    Spiegelt die bisherigen ``_set_dtype``-Regeln: Klassen via ``DTYPES_INV``,
+    ``'float64'``/``'int32'`` -> ``'float'``/``'int'``, Unbekanntes -> ``'str'``.
+    ``None`` -> ``None`` (kein dtype-Wechsel).
+    """
+    if dtype is None:
+        return None
+    if isinstance(dtype, type):
+        return DTYPES_INV.get(dtype, "str")
+    token = str(dtype).strip().lower()
+    if token in _REGISTRY:
+        return token
+    if "float" in token:
+        return "float"
+    if "int" in token:
+        return "int"
+    if "bool" in token:
+        return "bool"
+    if "list" in token:
+        return "list"
+    return "str"
+
+
+def coerce(value, dtype, strict=False):
+    """Überführe ``value`` in ``dtype`` (String oder Klasse)."""
+    spec = _REGISTRY[resolve(dtype) or "str"]
+    return spec.coerce(value, strict=strict)
+
+
+def json_default(obj):
+    """``default=`` für ``json.dumps``: serialisiert TimeStamp/bytes JSON-sicher."""
+    if isinstance(obj, TimeStamp):
+        return str(obj.utc)
+    if isinstance(obj, (bytes, bytearray)):
+        return base64.b64encode(bytes(obj)).decode("ascii")
+    raise TypeError("not JSON serializable: {!r}".format(type(obj)))

--- a/sdata/metadata.py
+++ b/sdata/metadata.py
@@ -5,6 +5,7 @@ from sdata import __version__
 import pandas as pd
 import numpy as np
 from sdata.timestamp import TimeStamp
+import sdata.dtypes as dtypes
 import pytz
 import datetime
 from dateutil.parser import parse as parse_date
@@ -65,27 +66,26 @@ def _to_utc(dt: datetime.datetime) -> datetime.datetime:
 class Attribute(object):
     """Attribute class"""
 
-    DTYPES = {'float': float,
-              'int': int,
-              'str': str,
-              'timestamp': datetime.datetime,
-              "bool": bool,
-              'list': list, # list of strings!
-              }
-    DTYPES_INV = {v: k for k, v in DTYPES.items()}
+    # Kompat-Aliasse: identische Inhalte für die 6 Alt-dtypes; die Registry in
+    # :mod:`sdata.dtypes` ist die Single Source of Truth (+ bytes/json/uri).
+    DTYPES = dtypes.DTYPES
+    DTYPES_INV = dtypes.DTYPES_INV
 
-    def __init__(self, name, value, **kwargs):
+    def __init__(self, name, value, *, strict=False, **kwargs):
         """Attribute(name, value, dtype=str, unit="-", description="", label="", required=False,
-            ontology:"BFO:quality")
+            ontology:"BFO:quality", strict=False)
         :param name
         :param value
-        :param dtype ['float', 'int', 'str', 'timestamp', 'bool', 'list']
+        :param dtype ['float', 'int', 'str', 'timestamp', 'bool', 'list', 'bytes', 'json', 'uri']
         :param description
         :param unit
         :param label
         :param required
         :param ontology
+        :param strict: bei True wirft fehlgeschlagene Coercion ``dtypes.DtypeError``
+            statt still zu degradieren (Default False = bisheriges Verhalten)
         """
+        self._strict: bool = bool(strict)
         self._name: str = None
         self._value: Any = None
         self._unit:str = "-"
@@ -126,36 +126,13 @@ class Attribute(object):
         return self._value
 
     def _set_value(self, value):
+        spec = dtypes.get(self._dtype) or dtypes.get("str")
         try:
-            dtype = self.DTYPES.get(self.dtype, self.guess_dtype(value))
-            # ---- Listen-Sonderfälle ----
-            if self.dtype == "list":
-                if value is None or value == "":
-                    self._value = []
-                elif isinstance(value, str):
-                    self._value = [v.strip() for v in value.split(",") if v.strip()]
-                elif isinstance(value, list):
-                    self._value = [str(v) for v in value]
-                else:
-                    raise ValueError(f"Cannot cast {value} to list[str]")
-
-            # ---- normale Dtypen ----
-            elif self.dtype == "str" and value == "":
-                self._value = ""
-            elif not value and self.dtype not in ["int", "float", "bool"]:
-                self._value = None
-            elif not value and self.dtype in ["int", "float"]:
-                self._value = np.nan
-            elif pd.isna(value) and self.dtype in ["int", "float"]:
-                self._value = np.nan
-            elif dtype.__name__ == "bool" and value not in [1, "1", "true", "True"]:
-                self._value = False
-            elif dtype.__name__ == "bool" and value in [1, "1", "true", "True"]:
-                self._value = True
-            else:
-                self._value = dtype(value)
-
-        except ValueError as exp:
+            self._value = spec.coerce(value, strict=self._strict)
+        except dtypes.DtypeError as exp:
+            if self._strict:
+                raise
+            # lenient: loggen und vorhandenen Wert unverändert lassen (Altverhalten)
             logger.error("error Attribute.value: {}".format(exp))
 
     value = property(fget=_get_value, fset=_set_value, doc="Attribute value")
@@ -183,26 +160,20 @@ class Attribute(object):
 
     def _set_dtype(self, value):
         """set dtype str
-s
-        :param value:
+
+        Akzeptiert dtype-String ('float', 'float64', ...) ODER Klasse (float, int).
+        Ist bereits ein Wert gesetzt, wird er in den neuen dtype umgecastet.
+
+        :param value: dtype-String oder -Klasse
         :return:
         """
-        if value is None:
+        name = dtypes.resolve(value)
+        if name is None:
             return None
-        if value in self.DTYPES_INV.keys():
-            value = self.DTYPES_INV.get(value, "str")
-        elif "float" in value:
-            value = "float"
-        elif "int" in value:
-            value = "int"
-        if value in self.DTYPES.keys():
-            self._dtype = value
-        # todo: cast self.value to new dtype
-        # if self._value is not None:
-        #     try:
-        #         self._value = self.DTYPES[self.dtype](self.value)
-        #     except Exception as exp:
-        #         logger.error("_set_dtype:{}:{}-{}".format(self.dtype, exp, exp.__class__.__name__))
+        self._dtype = name
+        # Re-Cast eines bereits gesetzten Werts (während __init__ ist _value noch None)
+        if getattr(self, "_value", None) is not None:
+            self._set_value(self._value)
 
     dtype = property(fget=_get_dtype, fset=_set_dtype, doc="Attribute type str")
 
@@ -304,6 +275,8 @@ class Metadata(object):
         """
 
     ATTRIBUTEKEYS = ["name", "value", "unit", "dtype", "description", "label", "required", "ontology"]
+    #: reservierte Attribut-Schlüssel, der den Objektnamen autoritativ hält
+    RESERVED_NAME_KEY = "_sdata_name"
 
     def __init__(self, **kwargs):
         """Metadata class
@@ -314,10 +287,18 @@ class Metadata(object):
         self._name = kwargs.get("name") or "N.N."
 
     def _get_name(self):
+        # Single Source of Truth: das reservierte _sdata_name-Attribut ist
+        # autoritativ, sobald gesetzt; sonst der einfache _name-Fallback.
+        attr = self._attributes.get(self.RESERVED_NAME_KEY)
+        if attr is not None and attr.value:
+            return attr.value
         return self._name
 
     def _set_name(self, value):
         self._name = str(value)
+        attr = self._attributes.get(self.RESERVED_NAME_KEY)
+        if attr is not None:
+            attr.value = str(value)
 
     name = property(fget=_get_name, fset=_set_name, doc="Name of the Metadata")
 
@@ -586,8 +567,8 @@ class Metadata(object):
         d = self.to_dict()
         if filepath:
             with open(filepath, "w") as fh:
-                json.dump(d, fh)
-        return json.dumps(d)
+                json.dump(d, fh, default=dtypes.json_default)
+        return json.dumps(d, default=dtypes.json_default)
 
     @classmethod
     def from_json(cls, jsonstr=None, filepath=None):
@@ -655,13 +636,14 @@ class Metadata(object):
         :param newname: new attribute name
         :return: None
         """
-        attr = self.get(name)
-        if not attr:
+        attr = self._attributes.get(name)
+        if attr is None:
             logger.warning("{0}: no Attribute {1} to relabel.".format(self.__class__, name))
-        else:
-            attr.name = newname
-            self.attributes.pop(name)
-            self.add(attr)
+            return
+        # explizit umschlüsseln (kein Präfix-Raten -> robust auch bei prefixed keys)
+        self._attributes.pop(name)
+        attr.name = newname
+        self._attributes[newname] = attr
 
     def get(self, name, default=None):
         #default = default or Attribute(name=name, value=None)
@@ -760,7 +742,7 @@ class Metadata(object):
 
         metadatastr = self.to_json().encode(errors="replace")
         hashobject.update(metadatastr)
-        return hash
+        return hashobject
 
     def set_unit_from_name(self, add_description=True, fix_name=True):
         """try to extract unit from attribute name

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+"""Tests für die dtype-Registry (sdata/dtypes.py) und die Attribute-Anbindung."""
+import datetime
+
+import numpy as np
+import pytest
+
+from sdata import dtypes
+from sdata.dtypes import DtypeError
+from sdata.metadata import Attribute, Metadata
+from sdata.timestamp import TimeStamp
+
+
+# --- resolve ----------------------------------------------------------------
+def test_resolve_class_string_and_unknown():
+    assert dtypes.resolve(float) == "float"
+    assert dtypes.resolve(int) == "int"
+    assert dtypes.resolve(datetime.datetime) == "timestamp"
+    assert dtypes.resolve(bytes) == "bytes"
+    assert dtypes.resolve(dict) == "json"
+    assert dtypes.resolve("float64") == "float"
+    assert dtypes.resolve("int32") == "int"
+    assert dtypes.resolve("boolean") == "bool"
+    assert dtypes.resolve("mylist") == "list"
+    assert dtypes.resolve("timestamp") == "timestamp"
+    assert dtypes.resolve("banana") == "str"
+    assert dtypes.resolve(None) is None
+
+
+def test_xsd_map_and_names():
+    xsd = dtypes.xsd_map()
+    for name, iri in {
+        "str": "xsd:string", "int": "xsd:integer", "float": "xsd:double",
+        "bool": "xsd:boolean", "timestamp": "xsd:dateTime",
+        "bytes": "xsd:base64Binary", "uri": "xsd:anyURI",
+    }.items():
+        assert xsd[name] == iri
+    assert set(["str", "int", "float", "bool", "timestamp", "list",
+                "bytes", "json", "uri"]).issubset(set(dtypes.names()))
+    assert dtypes.get("nope") is None
+
+
+# --- str / int / float (lenient = Altverhalten) -----------------------------
+def test_str_coercion():
+    assert Attribute("a", "", dtype="str").value == ""
+    assert Attribute("a", None, dtype="str").value is None
+    assert Attribute("a", 0, dtype="str").value is None
+    assert Attribute("a", "x", dtype="str").value == "x"
+    assert Attribute("a", float("nan"), dtype="str").value == "nan"
+
+
+def test_int_float_empty_and_cast():
+    assert np.isnan(Attribute("a", 0, dtype="int").value)
+    assert np.isnan(Attribute("a", None, dtype="int").value)
+    assert np.isnan(Attribute("a", float("nan"), dtype="int").value)    # truthy NaN -> _isna
+    assert np.isnan(Attribute("a", 0.0, dtype="float").value)           # falsy float
+    assert np.isnan(Attribute("a", float("nan"), dtype="float").value)
+    assert Attribute("a", "5", dtype="int").value == 5
+    assert Attribute("a", "1.5", dtype="float").value == 1.5
+
+
+def test_int_uncastable_lenient_vs_strict():
+    # lenient: Wert bleibt unverändert (None aus init), nur geloggt
+    assert Attribute("a", "abc", dtype="int").value is None
+    # list -> int trifft _isna(array)-Zweig, dann DtypeError (lenient -> None)
+    assert Attribute("a", [1, 2], dtype="int").value is None
+    with pytest.raises(DtypeError):
+        Attribute("a", "abc", dtype="int", strict=True)
+    with pytest.raises(DtypeError):
+        Attribute("a", "x", dtype="float", strict=True)
+
+
+# --- bool -------------------------------------------------------------------
+@pytest.mark.parametrize("value,expected", [
+    (True, True), (1, True), ("1", True), ("true", True), ("True", True),
+    (False, False), (0, False), ("0", False), ("false", False), ("x", False),
+])
+def test_bool_lenient_matrix(value, expected):
+    assert Attribute("b", value, dtype="bool").value is expected
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("yes", True), ("on", True), ("t", True), (1, True),
+    ("no", False), ("off", False), ("", False), (0, False),
+])
+def test_bool_strict_recognized(value, expected):
+    assert Attribute("b", value, dtype="bool", strict=True).value is expected
+
+
+def test_bool_strict_ambiguous_raises():
+    with pytest.raises(DtypeError):
+        Attribute("b", "maybe", dtype="bool", strict=True)
+    with pytest.raises(DtypeError):
+        Attribute("b", 2, dtype="bool", strict=True)
+
+
+# --- timestamp --------------------------------------------------------------
+def test_timestamp_coercion():
+    attr = Attribute("create", "2017-04-27", dtype="timestamp")
+    assert isinstance(attr.value, TimeStamp)
+    assert attr.value.utc == "2017-04-27T00:00:00+00:00"
+    assert Attribute("t", None, dtype="timestamp").value is None
+    # datetime-Eingang
+    dt = datetime.datetime(2020, 1, 2, 3, 4, 5)
+    assert isinstance(Attribute("t", dt, dtype="timestamp").value, TimeStamp)
+    # idempotent
+    ts = TimeStamp("2017-04-27")
+    assert Attribute("t", ts, dtype="timestamp").value is ts
+
+
+def test_timestamp_invalid():
+    assert Attribute("t", "not-a-date", dtype="timestamp").value is None  # lenient
+    with pytest.raises(DtypeError):
+        Attribute("t", "not-a-date", dtype="timestamp", strict=True)
+
+
+# --- list -------------------------------------------------------------------
+def test_list_coercion():
+    assert Attribute("l", None, dtype="list").value == []
+    assert Attribute("l", "a, b ,c", dtype="list").value == ["a", "b", "c"]
+    assert Attribute("l", [1, 2], dtype="list").value == ["1", "2"]
+    with pytest.raises(DtypeError):
+        Attribute("l", 5, dtype="list", strict=True)
+
+
+# --- bytes / json / uri (neu) ----------------------------------------------
+def test_bytes_dtype():
+    assert Attribute("b", b"\x00\x01", dtype="bytes").value == b"\x00\x01"
+    assert Attribute("b", "AAE=", dtype="bytes").value == b"\x00\x01"   # base64
+    assert Attribute("b", "nothex!!", dtype="bytes").value == b"nothex!!"  # utf-8
+    assert Attribute("b", bytearray(b"xy"), dtype="bytes").value == b"xy"
+    assert Attribute("b", None, dtype="bytes").value is None
+    with pytest.raises(DtypeError):
+        Attribute("b", 5, dtype="bytes", strict=True)
+
+
+def test_json_dtype():
+    assert Attribute("j", {"a": 1}, dtype="json").value == {"a": 1}
+    assert Attribute("j", '{"a": 1}', dtype="json").value == {"a": 1}
+    assert Attribute("j", None, dtype="json").value is None
+    with pytest.raises(DtypeError):
+        Attribute("j", "{bad", dtype="json", strict=True)
+    with pytest.raises(DtypeError):
+        Attribute("j", 5, dtype="json", strict=True)
+
+
+def test_uri_dtype():
+    assert Attribute("u", "https://x.org/a", dtype="uri").value == "https://x.org/a"
+    assert Attribute("u", None, dtype="uri").value is None
+    assert Attribute("u", "", dtype="uri").value == ""
+    assert Attribute("u", "rel/path", dtype="uri", strict=True).value == "rel/path"
+    with pytest.raises(DtypeError):
+        Attribute("u", "   ", dtype="uri", strict=True)
+
+
+# --- dtype=class & Re-Cast --------------------------------------------------
+def test_dtype_class_accepted():
+    assert Attribute("a", 1, dtype=int).dtype == "int"
+    assert Attribute("f", "1.5", dtype=float).value == 1.5
+
+
+def test_dtype_recast_on_change():
+    a = Attribute("a", "3")            # dtype geraten -> str
+    a.dtype = "int"
+    assert a.value == 3 and isinstance(a.value, int)
+    a.dtype = "float"
+    assert a.value == 3.0
+
+
+# --- DtypeSpec.to_json / json_default --------------------------------------
+def test_spec_to_json_and_default():
+    assert dtypes.get("timestamp").to_json(TimeStamp("2017-04-27")) == "2017-04-27T00:00:00+00:00"
+    assert dtypes.get("bytes").to_json(b"\x00\x01") == "AAE="
+    assert dtypes.get("str").to_json("x") == "x"          # passthrough
+    assert dtypes.json_default(TimeStamp("2017-04-27")) == "2017-04-27T00:00:00+00:00"
+    assert dtypes.json_default(b"\x00\x01") == "AAE="
+    with pytest.raises(TypeError):
+        dtypes.json_default(object())
+
+
+def test_coerce_convenience_and_register():
+    assert dtypes.coerce("5", "int") == 5
+    assert dtypes.coerce(b"x", bytes) == b"x"
+    spec = dtypes.DtypeSpec("dummy", str, lambda v, s: "D", "xsd:string")
+    dtypes.register(spec)
+    assert dtypes.get("dummy").coerce("anything") == "D"
+
+
+# --- Metadata-Bugfix-Regressionen ------------------------------------------
+def test_name_sdata_name_single_source():
+    m = Metadata(name="x")
+    assert m.name == "x"                       # Fallback _name
+    m.set_attr("_sdata_name", "y")
+    assert m.name == "y"                        # _sdata_name autoritativ
+    m.name = "z"
+    assert m.get("_sdata_name").value == "z"    # Setter spiegelt zurück
+
+
+def test_relabel_explicit_rekey():
+    m = Metadata()
+    m.add("foo", 1)
+    m.relabel("foo", "bar")
+    assert "bar" in m and "foo" not in m
+    assert m.get("bar").value == 1
+    m.relabel("missing", "x")                   # no-op + warning
+
+
+def test_update_hash_returns_object():
+    import hashlib
+    m = Metadata()
+    m.add("a", 1)
+    h = hashlib.sha3_256()
+    assert m.update_hash(h) is h
+
+
+def test_strict_via_set_attr():
+    m = Metadata()
+    with pytest.raises(DtypeError):
+        m.set_attr("i", "abc", dtype="int", strict=True)
+
+
+def test_timestamp_json_roundtrip():
+    m = Metadata()
+    m.add("create", "2017-04-27", dtype="timestamp")
+    restored = Metadata.from_json(m.to_json())
+    assert restored.get("create").value.utc == "2017-04-27T00:00:00+00:00"


### PR DESCRIPTION
Erster PR des Metadaten-Rückgrat-Programms (Scope: Robustheit + Maschinenlesbarkeit, PR1–PR4). **Robustheit & Korrektheit** — strikt additiv, lenient-Verhalten byte-genau erhalten.

## Neu: `sdata/dtypes.py` (pure stdlib)
Single Source of Truth für Coercion, JSON-(De)Serialisierung, Python-Klasse und **XSD-Typ-Mapping** (Grundlage der JSON-LD-Schicht in PR2/PR3).

## Verbesserungen
- **timestamp** dtype implementiert (via `TimeStamp`, ISO-8601/UTC) — war bisher kaputt.
- **bool** robuster: lenient unverändert; `strict=True` case-insensitiv (`yes/no/on/off…`), wirft bei Mehrdeutigkeit.
- **dtype = Klasse ODER String** (`resolve`); dtype-Wechsel **castet den Wert um** (bisheriger TODO).
- neue dtypes **`bytes`** (base64), **`json`** (dict/list), **`uri`** (+ XSD `base64Binary`/`anyURI`).
- opt-in **`strict=`** wirft `DtypeError` statt still zu degradieren.

## Bugfixes
- `Metadata.name` ↔ `_sdata_name` als Single Source of Truth (keine Desync).
- `relabel()` schlüsselt explizit um (kein Präfix-Verlust).
- `update_hash()` gibt das Hash-Objekt zurück (statt der builtin-`hash`-Klasse).
- `to_json()` serialisiert timestamp/bytes JSON-sicher.

## Kompatibilität & Tests
Keine neuen Dependencies. `Attribute`/`Metadata`-Public-API unverändert; `base.py` unberührt. Die bestehenden `test_metadata*/test_attribute/test_base*`-Tests laufen **unverändert grün**. Neu: `tests/test_dtypes.py`. **418 passed, 8 skipped, Coverage 100 %**.