### PR TITLE
feat(metadata): Vokabular + Einheiten (PR2/4)

### DIFF
--- a/sdata/units.py
+++ b/sdata/units.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""Einheiten-Vokabular: kuratierte Abbildung Einheit → QUDT-IRI / UCUM-Code.
+
+Reine-Python-Tabelle (keine Abhängigkeit). Optionales Extra ``[units]`` = pint
+erweitert die Validierung auf beliebige parsebare Einheiten; ohne pint greift
+die kuratierte Tabelle.
+"""
+__all__ = [
+    "UNIT_MAP", "normalize_symbol", "qudt_iri", "ucum_code", "unit_node",
+    "validate_unit", "has_pint",
+]
+
+try:  # optionales Backend
+    import pint as _pint
+except ImportError:  # pragma: no cover - abhängig vom Environment
+    _pint = None
+
+#: gespeichertes Einheiten-Symbol -> (QUDT-IRI-CURIE | None, UCUM-Code)
+UNIT_MAP = {
+    "mm":   ("unit:MilliM",  "mm"),
+    "cm":   ("unit:CentiM",  "cm"),
+    "m":    ("unit:M",       "m"),
+    "kN":   ("unit:KiloN",   "kN"),
+    "N":    ("unit:N",       "N"),
+    "MPa":  ("unit:MegaPA",  "MPa"),
+    "GPa":  ("unit:GigaPA",  "GPa"),
+    "Pa":   ("unit:PA",      "Pa"),
+    "degC": ("unit:DEG_C",   "Cel"),
+    "K":    ("unit:K",       "K"),
+    "s":    ("unit:SEC",     "s"),
+    "1/s":  ("unit:PER-SEC", "/s"),
+    "kg":   ("unit:KiloGM",  "kg"),
+    "g":    ("unit:GM",      "g"),
+    "%":    ("unit:PERCENT", "%"),
+    "-":    (None,           "1"),     # dimensionslos
+    "":     (None,           "1"),
+}
+
+#: Symbol-Aliasse -> kanonisches UNIT_MAP-Symbol
+_ALIASES = {
+    "°C": "degC", "celsius": "degC", "C": "degC",
+    "µm": "mm", "um": "mm", "mpa": "MPa", "gpa": "GPa", "kn": "kN",
+}
+
+
+def has_pint():
+    """True, falls das optionale pint-Backend verfügbar ist."""
+    return _pint is not None
+
+
+def normalize_symbol(symbol):
+    """Trimme/normalisiere ein Einheiten-Symbol auf einen kanonischen Schlüssel."""
+    if symbol is None:
+        return "-"
+    text = str(symbol).strip()
+    if text in UNIT_MAP:
+        return text
+    return _ALIASES.get(text, _ALIASES.get(text.lower(), text))
+
+
+def qudt_iri(symbol):
+    """QUDT-Einheiten-IRI-CURIE für ein Symbol oder ``None`` (unbekannt/dimensionslos)."""
+    entry = UNIT_MAP.get(normalize_symbol(symbol))
+    return entry[0] if entry else None
+
+
+def ucum_code(symbol):
+    """UCUM-Code für ein Symbol; Fallback ist das (getrimmte) Symbol selbst."""
+    entry = UNIT_MAP.get(normalize_symbol(symbol))
+    if entry:
+        return entry[1]
+    return str(symbol).strip() if symbol is not None else "1"
+
+
+def unit_node(symbol):
+    """JSON-LD-Fragment für eine Einheit: ``{"unitRef": <iri>, "symbol": <sym>}``.
+
+    ``unitRef`` entfällt, wenn keine QUDT-IRI bekannt ist (z.B. ``"-"`` oder
+    unbekannte Einheit) – das rohe ``symbol`` bleibt stets erhalten.
+    """
+    node = {}
+    iri = qudt_iri(symbol)
+    if iri is not None:
+        node["unitRef"] = iri
+    raw = "" if symbol is None else str(symbol).strip()
+    node["symbol"] = raw
+    return node
+
+
+def validate_unit(symbol):
+    """True, wenn die Einheit bekannt (kuratierte Tabelle) oder – mit pint – parsebar ist."""
+    if normalize_symbol(symbol) in UNIT_MAP:
+        return True
+    if _pint is not None:
+        try:
+            _pint.Unit(str(symbol))
+            return True
+        except Exception:
+            return False
+    return False

--- a/sdata/vocab.py
+++ b/sdata/vocab.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+"""Vokabular & JSON-LD-``@context`` für die semantische Metadaten-Schicht.
+
+Reine-Python-Tabellen (keine Abhängigkeit): Namespace-Präfixe, ein
+``@context``-Builder, das XSD-Typ-Mapping (aus :mod:`sdata.dtypes`) und die
+Auflösung von BFO-Topologieklassen sowie von Attribut-``ontology``-Annotationen.
+
+Designentscheidungen (siehe Projektplan):
+
+* **Identität**: ``@id`` eines Objekts ist seine DID ``did:suuid:<sname>:sdata``.
+* **``ontology`` = immer ``@type``/Klasse** des Werts (z.B. ``bfo:Quality``); das
+  Subjekt→Wert-**Prädikat** kommt NICHT aus ``ontology``, sondern ist
+  ``sdata:<name>`` (bzw. ein gemappter schema.org/qudt-Term).
+"""
+import re
+
+import sdata.dtypes as dtypes
+
+__all__ = [
+    "SDATA_NS", "NAMESPACES", "CONTEXT_TERMS", "CONTEXT_URL", "BFO_IRIS",
+    "build_context", "xsd_for_dtype", "expand_curie", "bfo_iri",
+    "safe_term", "predicate_for", "type_iri",
+]
+
+#: Default-Namespace-IRI des sdata-Vokabulars (Platzhalter – bei Bedarf anpassen).
+SDATA_NS = "https://sdata.tools/ns#"
+CONTEXT_URL = "https://sdata.tools/ns/context.jsonld"
+
+NAMESPACES = {
+    "sdata":   SDATA_NS,
+    "schema":  "https://schema.org/",
+    "dcterms": "http://purl.org/dc/terms/",
+    "dcat":    "http://www.w3.org/ns/dcat#",
+    "prov":    "http://www.w3.org/ns/prov#",
+    "qudt":    "http://qudt.org/schema/qudt/",
+    "unit":    "http://qudt.org/vocab/unit/",
+    "xsd":     "http://www.w3.org/2001/XMLSchema#",
+    "bfo":     "http://purl.obolibrary.org/obo/",
+    "rdfs":    "http://www.w3.org/2000/01/rdf-schema#",
+    "did":     "https://www.w3.org/ns/did#",
+}
+
+#: JSON-LD-Term-Definitionen (ergänzen die Präfixe im ``@context``).
+CONTEXT_TERMS = {
+    "name":            "schema:name",
+    "description":     "schema:description",
+    "generatedAtTime": {"@id": "prov:generatedAtTime", "@type": "xsd:dateTime"},
+    "wasDerivedFrom":  {"@id": "prov:wasDerivedFrom", "@type": "@id"},
+    "isPartOf":        {"@id": "dcterms:isPartOf", "@type": "@id"},
+    "identifier":      "dcterms:identifier",
+    "topologyClass":   {"@id": "sdata:topologyClass", "@type": "@id"},
+    "value":           "qudt:value",
+    "unitRef":         {"@id": "qudt:unit", "@type": "@id"},
+    "symbol":          "qudt:symbol",
+    "label":           "rdfs:label",
+    "required":        {"@id": "sdata:required", "@type": "xsd:boolean"},
+}
+
+#: BFO-2.0-Klassenname -> OBO-CURIE (für ``_sdata_topology_class``).
+BFO_IRIS = {
+    "Entity": "bfo:BFO_0000001",
+    "Continuant": "bfo:BFO_0000002",
+    "Occurrent": "bfo:BFO_0000003",
+    "IndependentContinuant": "bfo:BFO_0000004",
+    "SpatialRegion": "bfo:BFO_0000006",
+    "Process": "bfo:BFO_0000015",
+    "Disposition": "bfo:BFO_0000016",
+    "RealizableEntity": "bfo:BFO_0000017",
+    "Quality": "bfo:BFO_0000019",
+    "SpecificallyDependentContinuant": "bfo:BFO_0000020",
+    "Role": "bfo:BFO_0000023",
+    "Site": "bfo:BFO_0000029",
+    "GenericallyDependentContinuant": "bfo:BFO_0000031",
+    "Function": "bfo:BFO_0000034",
+    "MaterialEntity": "bfo:BFO_0000040",
+    "ImmaterialEntity": "bfo:BFO_0000141",
+    "RelationalQuality": "bfo:BFO_0000145",
+}
+
+
+def build_context(mode="inline", extra=None):
+    """Liefere das JSON-LD-``@context`` (``inline`` = vollständige Term-Map) oder
+    – bei ``mode="url"`` – die gehostete Context-URL.
+
+    :param mode: ``"inline"`` (default) oder ``"url"``
+    :param extra: optionale zusätzliche Term-Definitionen
+    """
+    if mode == "url":
+        return CONTEXT_URL
+    ctx = dict(NAMESPACES)
+    ctx.update(CONTEXT_TERMS)
+    if extra:
+        ctx.update(extra)
+    return ctx
+
+
+def xsd_for_dtype(dtype):
+    """XSD-Typ-CURIE für einen sdata-dtype (String oder Klasse)."""
+    return dtypes.XSD.get(dtypes.resolve(dtype) or "str", "xsd:string")
+
+
+def expand_curie(curie):
+    """Expandiere eine CURIE (``schema:name``) zur vollen IRI; IRIs/Unbekanntes
+    werden unverändert zurückgegeben."""
+    if not isinstance(curie, str) or ":" not in curie:
+        return curie
+    prefix, _, local = curie.partition(":")
+    if curie.startswith("http://") or curie.startswith("https://"):
+        return curie
+    base = NAMESPACES.get(prefix)
+    return base + local if base else curie
+
+
+def bfo_iri(topology_class):
+    """Mappe einen Topologieklassen-String (``"sdata.sclass:IndependentContinuant"``)
+    auf die BFO-CURIE oder ``None``, falls unbekannt/leer."""
+    if not topology_class:
+        return None
+    local = str(topology_class).rsplit(":", 1)[-1]
+    return BFO_IRIS.get(local)
+
+
+def safe_term(name):
+    """Normalisiere einen Attributnamen zu einem CURIE-tauglichen lokalen Teil."""
+    local = re.sub(r"[^0-9A-Za-z_]", "_", str(name)).strip("_")
+    return local or "attribute"
+
+
+def predicate_for(attr_name):
+    """Subjekt→Wert-Prädikat für ein User-Attribut: Default ``sdata:<safe_name>``."""
+    return "sdata:" + safe_term(attr_name)
+
+
+def type_iri(ontology):
+    """``@type``/Klasse eines Werts aus dem ``ontology``-Feld (CURIE/IRI) oder
+    ``None``. (``ontology`` ist per Projektentscheidung stets eine Klasse.)"""
+    if not ontology:
+        return None
+    return str(ontology)

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ EXTRAS = {
     'sql': ['sqlalchemy'],
     'parquet': ['pyarrow'],   # sdata.sclass.DataFrame (Parquet-Serialisierung)
     'blob': ['fsspec'],       # sdata.sclass.Blob (URI-Content: file/S3/Zip)
+    # Semantische Metadaten-Schicht (alles mit pure-Python-Fallback):
+    'units': ['pint'],        # Einheiten-Validierung/-Normalisierung (sonst kuratierte Tabelle)
 }
 
 setup(

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Tests für sdata/units.py (Einheiten→QUDT/UCUM, unit_node, pint-Validierung)."""
+from sdata import units
+
+
+def test_normalize_symbol():
+    assert units.normalize_symbol(None) == "-"
+    assert units.normalize_symbol(" mm ") == "mm"
+    assert units.normalize_symbol("°C") == "degC"
+    assert units.normalize_symbol("mpa") == "MPa"        # lower-Alias
+    assert units.normalize_symbol("furlong") == "furlong"  # unbekannt -> passthrough
+
+
+def test_qudt_and_ucum():
+    assert units.qudt_iri("kN") == "unit:KiloN"
+    assert units.qudt_iri("-") is None
+    assert units.qudt_iri("furlong") is None
+    assert units.ucum_code("degC") == "Cel"
+    assert units.ucum_code("furlong") == "furlong"
+    assert units.ucum_code(None) == "1"
+
+
+def test_unit_node():
+    n = units.unit_node("kN")
+    assert n == {"unitRef": "unit:KiloN", "symbol": "kN"}
+    assert units.unit_node("-") == {"symbol": "-"}         # keine IRI
+    assert units.unit_node(None) == {"symbol": ""}
+
+
+def test_validate_unit_pure():
+    assert units.validate_unit("mm") is True
+    assert units.validate_unit("furlong") is False         # ohne pint
+
+
+def test_validate_unit_with_pint(monkeypatch):
+    class _FakePint:
+        @staticmethod
+        def Unit(symbol):
+            if symbol == "furlong":
+                return object()
+            raise ValueError("bad unit")
+
+    monkeypatch.setattr(units, "_pint", _FakePint)
+    assert units.has_pint() is True
+    assert units.validate_unit("furlong") is True          # via pint
+    assert units.validate_unit("zonk") is False            # pint wirft
+
+
+def test_has_pint_is_bool():
+    assert isinstance(units.has_pint(), bool)

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Tests für sdata/vocab.py (Namespaces, @context, XSD/BFO, CURIE/Prädikat/Typ)."""
+from sdata import vocab
+
+
+def test_build_context_inline_and_url():
+    ctx = vocab.build_context()
+    assert ctx["sdata"] == vocab.SDATA_NS
+    assert ctx["name"] == "schema:name"
+    assert ctx["generatedAtTime"]["@type"] == "xsd:dateTime"
+    # extra-Terme
+    ctx2 = vocab.build_context(extra={"foo": "sdata:foo"})
+    assert ctx2["foo"] == "sdata:foo"
+    # url-Modus
+    assert vocab.build_context(mode="url") == vocab.CONTEXT_URL
+
+
+def test_xsd_for_dtype():
+    assert vocab.xsd_for_dtype("int") == "xsd:integer"
+    assert vocab.xsd_for_dtype(float) == "xsd:double"
+    assert vocab.xsd_for_dtype("timestamp") == "xsd:dateTime"
+    assert vocab.xsd_for_dtype("bytes") == "xsd:base64Binary"
+    assert vocab.xsd_for_dtype("unknown") == "xsd:string"
+
+
+def test_expand_curie():
+    assert vocab.expand_curie("schema:name") == "https://schema.org/name"
+    assert vocab.expand_curie("http://x.org/a") == "http://x.org/a"
+    assert vocab.expand_curie("https://x.org/a") == "https://x.org/a"
+    assert vocab.expand_curie("plainstring") == "plainstring"      # kein ':'
+    assert vocab.expand_curie("nope:term") == "nope:term"          # unbek. Präfix
+    assert vocab.expand_curie(123) == 123                          # nicht-str
+
+
+def test_bfo_iri():
+    assert vocab.bfo_iri("sdata.sclass:IndependentContinuant") == "bfo:BFO_0000004"
+    assert vocab.bfo_iri("MaterialEntity") == "bfo:BFO_0000040"
+    assert vocab.bfo_iri("sdata.sclass:Unknown") is None
+    assert vocab.bfo_iri(None) is None
+    assert vocab.bfo_iri("") is None
+
+
+def test_safe_term_predicate_type():
+    assert vocab.safe_term("force_x") == "force_x"
+    assert vocab.safe_term("Gauge Length (mm)") == "Gauge_Length__mm"
+    assert vocab.safe_term("!!!") == "attribute"
+    assert vocab.predicate_for("force_x") == "sdata:force_x"
+    assert vocab.type_iri("bfo:Quality") == "bfo:Quality"
+    assert vocab.type_iri("") is None
+    assert vocab.type_iri(None) is None


### PR DESCRIPTION
Zweiter PR des Metadaten-Rückgrats: die **reine-Python-Vokabular-Grundlage** für die JSON-LD-Schicht (PR3). Keine Pflicht-Dependency; keine Änderung an `metadata.py`/`base.py`.

## `sdata/vocab.py`
- Namespace-Präfixe (schema.org/DCAT/PROV/QUDT/BFO/xsd/did/…).
- `build_context(mode="inline"|"url")` — JSON-LD-`@context`.
- `xsd_for_dtype()` — XSD-Typ aus `sdata.dtypes` (Single Source of Truth).
- `bfo_iri()` — Topologieklasse → echte OBO-BFO-2.0-IRI (`IndependentContinuant`→`bfo:BFO_0000004`).
- `expand_curie`, `safe_term`, `predicate_for`, `type_iri`.
- **Entscheidungen umgesetzt**: `ontology` = `@type`/Klasse des Werts; Prädikat = `sdata:<name>`.

## `sdata/units.py`
- Kuratierte Einheit→QUDT-IRI/UCUM-Tabelle (mm/cm/m/kN/N/MPa/GPa/Pa/degC/K/s/1/s/kg/g/%/–).
- `unit_node()` JSON-LD-Fragment (`unitRef`+`symbol`; IRI entfällt bei unbekannt/dimensionslos).
- Optionale `pint`-Validierung (`[units]`-Extra) mit Tabellen-Fallback.

## Tests/Coverage
`tests/test_vocab.py`, `tests/test_units.py` (pint-Pfad via injiziertem Fake). **429 passed, 8 skipped, Coverage 100 %**.