### PR TITLE
feat(metadata): JSON-LD-Export/Import + Sidecar (PR3/4)

### DIFF
--- a/sdata/base.py
+++ b/sdata/base.py
@@ -230,6 +230,20 @@ class Base:
         module = "sdata" # self.get_sdata_did_method()
         return f"did:suuid:{self.sname}:{module}"
 
+    def to_jsonld(self, context_mode="inline"):
+        """Serialisiere die Metadaten als JSON-LD (siehe :mod:`sdata.semantic`)."""
+        return self.metadata.to_jsonld(context_mode=context_mode)
+
+    def write_sidecar(self, path=None, indent=2):
+        """Schreibe ``<sname>.meta.jsonld`` neben einen Datenblob; gibt den Pfad zurück."""
+        return self.metadata.write_sidecar(path=path, indent=indent)
+
+    @classmethod
+    def read_sidecar(cls, path):
+        """Lade eine ``.meta.jsonld``-Sidecar-Datei zu einer Metadata."""
+        from sdata import semantic
+        return semantic.read_sidecar(path)
+
     def _get_name(self) -> str:
         return self.metadata.get(self.SDATA_NAME).value
 

--- a/sdata/metadata.py
+++ b/sdata/metadata.py
@@ -613,6 +613,29 @@ class Metadata(object):
                              label=alist[5], required=alist[6])
         return metadata
 
+    # --- JSON-LD / Linked Data / Sidecar (siehe sdata.semantic) -------------
+    def to_jsonld(self, context_mode="inline"):
+        """Serialisiere als selbstbeschreibendes JSON-LD-Dokument (dict)."""
+        from sdata import semantic
+        return semantic.to_jsonld(self, context_mode=context_mode)
+
+    @classmethod
+    def from_jsonld(cls, doc):
+        """Rekonstruiere Metadata aus einem JSON-LD-Dokument (dict oder str)."""
+        from sdata import semantic
+        return semantic.from_jsonld(doc)
+
+    def write_sidecar(self, path=None, indent=2):
+        """Schreibe ``<sname>.meta.jsonld`` neben einen Datenblob; gibt den Pfad zurück."""
+        from sdata import semantic
+        return semantic.write_sidecar(self, path=path, indent=indent)
+
+    @classmethod
+    def read_sidecar(cls, path):
+        """Lade eine ``.meta.jsonld``-Sidecar-Datei zu Metadata."""
+        from sdata import semantic
+        return semantic.read_sidecar(path)
+
     def __repr__(self):
         return "(Metadata'%s':%d)" % (self.name, len(self.attributes))
 

--- a/sdata/semantic.py
+++ b/sdata/semantic.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+"""JSON-LD-/Linked-Data-Serialisierung für sdata-Metadaten + Sidecar-Dateien.
+
+Wandelt eine :class:`sdata.metadata.Metadata` in ein selbstbeschreibendes
+JSON-LD-Dokument (und zurück) und schreibt/liest optionale Sidecar-Dateien
+``<sname>.meta.jsonld`` neben einem Datenblob.
+
+Modellierung (siehe Projektentscheidungen):
+
+* ``@id`` = DID des Objekts ``did:suuid:<sname>:sdata``.
+* ``@type`` = ``[sdata:<Klasse>, <BFO-IRI der Topologieklasse>]``.
+* Reservierte ``_sdata_*``-Felder -> schema.org/DCAT/PROV-Terme (name,
+  identifier, generatedAtTime, wasDerivedFrom, isPartOf, …).
+* **Hybrid** für User-Attribute: mit echter Einheit -> ``qudt:Quantity``-Knoten;
+  ohne Einheit aber mit ``ontology`` -> getypter Knoten; sonst einfaches
+  typisiertes Literal. ``ontology`` ist stets ein ``@type``/Klasse des Werts;
+  das Prädikat ist ``sdata:<name>``.
+
+Pure-Python; keine Pflicht-Dependency.
+"""
+import json
+import os
+
+import sdata.dtypes as dtypes
+from sdata import vocab, units
+
+__all__ = [
+    "to_jsonld", "from_jsonld", "write_sidecar", "read_sidecar",
+    "SIDECAR_SUFFIX",
+]
+
+SIDECAR_SUFFIX = ".meta.jsonld"
+
+# reserviertes Feld -> JSON-LD-Term (für Top-Level-Mapping & Rück-Parsing)
+_RESERVED_TERMS = {
+    "_sdata_name": "name",
+    "_sdata_suuid": "identifier",
+    "_sdata_ctime": "generatedAtTime",
+    "_sdata_topology_class": "topologyClass",
+    "_sdata_version": "sdata:version",
+}
+_TERMS_RESERVED = {v: k for k, v in _RESERVED_TERMS.items()}
+
+# XSD-CURIE -> dtype (eindeutige Rückabbildung; list/json kommen über JSON-Typ)
+_DTYPE_FROM_XSD = {
+    "xsd:string": "str", "xsd:integer": "int", "xsd:double": "float",
+    "xsd:boolean": "bool", "xsd:dateTime": "timestamp",
+    "xsd:base64Binary": "bytes", "xsd:anyURI": "uri",
+}
+
+
+def _did(sname):
+    return "did:suuid:{}:sdata".format(sname)
+
+
+def _sname_from_did(ref):
+    """Extrahiere den sname aus ``did:suuid:<sname>:sdata`` (oder aus {'@id':…})."""
+    if isinstance(ref, dict):
+        ref = ref.get("@id", "")
+    parts = str(ref).split(":")
+    if len(parts) >= 4 and parts[0] == "did" and parts[1] == "suuid":
+        return parts[2]
+    return str(ref)
+
+
+def _class_local(class_spec):
+    """``"sdata.sclass.dataframe:DataFrame"`` -> ``"DataFrame"``."""
+    return str(class_spec).split(":")[-1].split(".")[-1]
+
+
+def _value_literal(attr):
+    """Typisiertes JSON-LD-Literal ``{"@value": …, "@type": xsd}`` für ein Attribut."""
+    spec = dtypes.get(attr.dtype) or dtypes.get("str")
+    return {"@value": spec.to_json(attr.value), "@type": vocab.xsd_for_dtype(attr.dtype)}
+
+
+def _attr_node(attr):
+    """Hybrid-Repräsentation eines User-Attributs (Knoten oder Literal)."""
+    has_unit = attr.unit not in (None, "", "-")
+    types = []
+    if has_unit:
+        types.append("qudt:Quantity")
+    type_of = vocab.type_iri(attr.ontology)
+    if type_of:
+        types.append(type_of)
+    # ohne Einheit und ohne ontology -> einfaches Literal
+    if not types:
+        return _value_literal(attr)
+    node = {"@type": types if len(types) > 1 else types[0],
+            "name": attr.name,
+            "value": _value_literal(attr)}
+    if has_unit:
+        node.update(units.unit_node(attr.unit))
+    if attr.description:
+        node["description"] = attr.description
+    if attr.label:
+        node["label"] = attr.label
+    if attr.required:
+        node["required"] = bool(attr.required)
+    return node
+
+
+def to_jsonld(metadata, context_mode="inline"):
+    """Serialisiere ``metadata`` als JSON-LD-Dokument (dict)."""
+    doc = {"@context": vocab.build_context(mode=context_mode)}
+
+    sname = metadata.get("_sdata_sname")
+    if sname is not None and sname.value:
+        doc["@id"] = _did(sname.value)
+
+    types = []
+    cls = metadata.get("_sdata_class")
+    if cls is not None and cls.value:
+        types.append("sdata:" + _class_local(cls.value))
+    topo = metadata.get("_sdata_topology_class")
+    bfo = vocab.bfo_iri(topo.value) if topo is not None else None
+    if bfo:
+        types.append(bfo)
+    if types:
+        doc["@type"] = types if len(types) > 1 else types[0]
+
+    # bekannte reservierte Felder -> Terme
+    for key, term in _RESERVED_TERMS.items():
+        attr = metadata.get(key)
+        if attr is None or attr.value in (None, ""):
+            continue
+        doc[term] = attr.value
+    # Relationen als DID-Referenzen
+    parent = metadata.get("_sdata_parent_sname")
+    if parent is not None and parent.value:
+        doc["wasDerivedFrom"] = {"@id": _did(parent.value)}
+    project = metadata.get("_sdata_project_sname")
+    if project is not None and project.value:
+        doc["isPartOf"] = {"@id": _did(project.value)}
+
+    # User-Attribute -> sdata:<name>
+    for attr in metadata.user_attributes.values():
+        doc[vocab.predicate_for(attr.name)] = _attr_node(attr)
+    return doc
+
+
+def _set_from_node(metadata, name, node):
+    """Rekonstruiere ein User-Attribut aus Knoten/Literal."""
+    unit = "-"
+    ontology = ""
+    if isinstance(node, dict) and "@value" in node:
+        raw, xsd = node.get("@value"), node.get("@type")
+    elif isinstance(node, dict):
+        literal = node.get("value", {})
+        raw = literal.get("@value") if isinstance(literal, dict) else literal
+        xsd = literal.get("@type") if isinstance(literal, dict) else None
+        unit = node.get("symbol", "-") or "-"
+        type_list = node.get("@type", [])
+        if isinstance(type_list, str):
+            type_list = [type_list]
+        ontology = next((t for t in type_list if t != "qudt:Quantity"), "")
+    else:
+        raw, xsd = node, None
+    # dtype bestimmen: JSON-Typ hat Vorrang (list/json), sonst XSD-Rückabbildung
+    if isinstance(raw, list):
+        dtype = "list"
+    elif isinstance(raw, dict):
+        dtype = "json"
+    else:
+        dtype = _DTYPE_FROM_XSD.get(xsd, "str")
+    metadata.set_attr(name, raw, dtype=dtype, unit=unit, ontology=ontology)
+
+
+def from_jsonld(doc):
+    """Rekonstruiere eine :class:`Metadata` aus einem JSON-LD-Dokument (dict oder str)."""
+    from sdata.metadata import Metadata
+    if isinstance(doc, str):
+        doc = json.loads(doc)
+    m = Metadata()
+
+    if "@id" in doc:
+        m.set_attr("_sdata_sname", _sname_from_did(doc["@id"]))
+    type_list = doc.get("@type", [])
+    if isinstance(type_list, str):
+        type_list = [type_list]
+    for t in type_list:
+        if isinstance(t, str) and t.startswith("sdata:"):
+            m.set_attr("_sdata_class", t.split(":", 1)[1])
+    for term, key in _TERMS_RESERVED.items():
+        if term in doc:
+            m.set_attr(key, doc[term])
+    if "wasDerivedFrom" in doc:
+        m.set_attr("_sdata_parent_sname", _sname_from_did(doc["wasDerivedFrom"]))
+    if "isPartOf" in doc:
+        m.set_attr("_sdata_project_sname", _sname_from_did(doc["isPartOf"]))
+
+    reserved_terms = set(_TERMS_RESERVED) | {
+        "@context", "@id", "@type", "wasDerivedFrom", "isPartOf"}
+    for key, val in doc.items():
+        if key in reserved_terms:
+            continue
+        if key.startswith("sdata:"):
+            _set_from_node(m, key.split(":", 1)[1], val)
+    return m
+
+
+def _sidecar_path(path, sname):
+    """Ziel-Dateipfad: Verzeichnis -> ``<dir>/<sname>.meta.jsonld``; sonst ``path``."""
+    if path is None or os.path.isdir(path):
+        directory = path or "."
+        return os.path.join(directory, "{}{}".format(sname, SIDECAR_SUFFIX))
+    return path
+
+
+def write_sidecar(metadata, path=None, indent=2):
+    """Schreibe ``<sname>.meta.jsonld`` (JSON-LD) neben einen Blob; gibt den Pfad zurück."""
+    sname_attr = metadata.get("_sdata_sname")
+    sname = sname_attr.value if sname_attr is not None and sname_attr.value else "metadata"
+    target = _sidecar_path(path, sname)
+    with open(target, "w") as fh:
+        json.dump(to_jsonld(metadata), fh, indent=indent, default=dtypes.json_default)
+    return target
+
+
+def read_sidecar(path):
+    """Lade eine ``.meta.jsonld``-Sidecar-Datei und rekonstruiere die Metadata."""
+    with open(path, "r") as fh:
+        return from_jsonld(json.load(fh))

--- a/tests/test_semantic_jsonld.py
+++ b/tests/test_semantic_jsonld.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Tests für sdata/semantic.py: JSON-LD-Export/Import + Sidecar."""
+import json
+import os
+
+from sdata.base import Base
+from sdata.metadata import Metadata
+from sdata import semantic
+
+
+def _obj():
+    b = Base(name="specimen_01")
+    b.metadata.add("force_x", 12.5, unit="kN", dtype="float", description="fx",
+                   label="Fx", required=True)
+    b.metadata.add("stress", 350.0, unit="MPa", dtype="float", ontology="bfo:Quality")
+    b.metadata.add("material_id", "DP800")                 # Literal
+    b.metadata.add("phase", "martensite", ontology="bfo:Quality")  # getypter Knoten
+    return b
+
+
+def test_to_jsonld_structure():
+    doc = _obj().to_jsonld()
+    assert doc["@id"].startswith("did:suuid:Base__specimen_01__")
+    assert "sdata:Base" in doc["@type"] and "bfo:BFO_0000004" in doc["@type"]
+    assert doc["name"] == "specimen_01"
+    assert "identifier" in doc and "generatedAtTime" in doc
+    # einheitenbehaftet -> qudt:Quantity
+    fx = doc["sdata:force_x"]
+    assert fx["@type"] == "qudt:Quantity"
+    assert fx["value"] == {"@value": 12.5, "@type": "xsd:double"}
+    assert fx["unitRef"] == "unit:KiloN" and fx["symbol"] == "kN"
+    assert fx["description"] == "fx" and fx["label"] == "Fx" and fx["required"] is True
+    # Einheit + ontology -> zwei @type
+    assert doc["sdata:stress"]["@type"] == ["qudt:Quantity", "bfo:Quality"]
+    # unit-los, kein ontology -> Literal
+    assert doc["sdata:material_id"] == {"@value": "DP800", "@type": "xsd:string"}
+    # unit-los + ontology -> getypter Knoten
+    assert doc["sdata:phase"]["@type"] == "bfo:Quality"
+
+
+def test_jsonld_roundtrip():
+    doc = _obj().to_jsonld()
+    m = Metadata.from_jsonld(doc)
+    assert m.name == "specimen_01"
+    assert m.get("force_x").value == 12.5
+    assert m.get("force_x").unit == "kN" and m.get("force_x").dtype == "float"
+    assert m.get("material_id").value == "DP800"
+    assert m.get("phase").ontology == "bfo:Quality"
+    # auch aus JSON-String
+    assert Metadata.from_jsonld(json.dumps(doc)).name == "specimen_01"
+
+
+def test_provenance_links():
+    parent = Base(name="parent")
+    child = Base(name="child", parent=parent, project=parent)
+    doc = child.to_jsonld()
+    assert doc["wasDerivedFrom"]["@id"].startswith("did:suuid:Base__parent__")
+    assert doc["isPartOf"]["@id"].startswith("did:suuid:Base__parent__")
+    m = Metadata.from_jsonld(doc)
+    assert m.get("_sdata_parent_sname").value.startswith("Base__parent__")
+    assert m.get("_sdata_project_sname").value.startswith("Base__parent__")
+
+
+def test_bare_metadata_and_special_dtypes():
+    m = Metadata()
+    m.add("note", "hello")
+    m.add("tags", ["a", "b"], dtype="list")
+    m.add("blob", b"\x00\x01", dtype="bytes")
+    m.add("config", {"k": 1}, dtype="json")
+    doc = m.to_jsonld()
+    assert "@id" not in doc and "@type" not in doc      # keine reservierten Felder
+    rt = Metadata.from_jsonld(doc)
+    assert rt.get("tags").value == ["a", "b"] and rt.get("tags").dtype == "list"
+    assert rt.get("config").value == {"k": 1} and rt.get("config").dtype == "json"
+    assert rt.get("blob").dtype == "bytes"
+
+
+def test_from_jsonld_scalar_predicate():
+    # handgeschriebenes JSON-LD mit blankem Skalar unter einem sdata:-Prädikat
+    m = Metadata.from_jsonld({"@type": "sdata:Thing", "sdata:count": 5})
+    assert m.get("count").value == "5"           # Skalar -> str (kein XSD-Hint)
+    assert m.get("_sdata_class").value == "Thing"
+
+
+def test_sidecar_roundtrip(tmp_path):
+    b = _obj()
+    # Verzeichnis -> <sname>.meta.jsonld
+    written = b.write_sidecar(str(tmp_path))
+    assert written.endswith(".meta.jsonld") and os.path.exists(written)
+    assert os.path.basename(written).startswith("Base__specimen_01__")
+    m = Base.read_sidecar(written)
+    assert m.get("force_x").value == 12.5
+    # voller Dateipfad
+    target = str(tmp_path / "custom.meta.jsonld")
+    assert b.metadata.write_sidecar(target) == target
+    assert Metadata.read_sidecar(target).name == "specimen_01"
+
+
+def test_sidecar_path_helpers():
+    assert semantic._sidecar_path(None, "x") == os.path.join(".", "x.meta.jsonld")
+    assert semantic._sidecar_path("/tmp/a.jsonld", "x") == "/tmp/a.jsonld"
+    assert semantic._sname_from_did("did:suuid:Foo__bar__abc:sdata") == "Foo__bar__abc"
+    assert semantic._sname_from_did("plain") == "plain"
+
+
+def test_sidecar_without_sname(tmp_path):
+    m = Metadata()
+    m.add("x", 1)
+    written = m.write_sidecar(str(tmp_path))
+    assert os.path.basename(written) == "metadata.meta.jsonld"


### PR DESCRIPTION
Kern-PR der Maschinenlesbarkeit: Metadaten als selbstbeschreibendes **JSON-LD** (Linked Data) — und als **Sidecar** neben dem Datenblob ablegbar.

## `sdata/semantic.py` (pure-Python)
- **`to_jsonld(metadata)`**: `@id` = `did:suuid:<sname>:sdata`; `@type` = `[sdata:<Klasse>, <BFO-IRI>]`; reservierte `_sdata_*` → schema.org/DCAT/PROV (`name/identifier/generatedAtTime/wasDerivedFrom/isPartOf/…`).
  **Hybrid-Attributmodell**: einheitenbehaftet → `qudt:Quantity`-Knoten; unit-los + `ontology` → getypter Knoten; sonst typisiertes Literal. `ontology` = `@type`/Klasse; Prädikat = `sdata:<name>`.
- **`from_jsonld()`**: verlustarmer Round-Trip (dtype via XSD bzw. JSON-Typ für list/json; Provenienz-DIDs → snames).
- **`write_sidecar()/read_sidecar()`**: `<sname>.meta.jsonld` (Verzeichnis oder Datei).

## Beispiel
```json
{ "@id": "did:suuid:Base__specimen_01__…:sdata",
  "@type": ["sdata:Base", "bfo:BFO_0000004"], "name": "specimen_01",
  "sdata:force_x": {"@type":"qudt:Quantity","value":{"@value":12.5,"@type":"xsd:double"},
                    "unitRef":"unit:KiloN","symbol":"kN"},
  "sdata:material_id": {"@value":"DP800","@type":"xsd:string"},
  "sdata:phase": {"@type":"bfo:Quality","value":{"@value":"martensite","@type":"xsd:string"}} }
```

## Kompatibilität & Tests
Additive Delegatoren auf `Metadata`/`Base` (lazy import); keine Default-Verhaltensänderung, keine Pflicht-Dependency. **437 passed, 8 skipped, Coverage 100 %**.