### PR TITLE
feat(metadata): Sidecar-Verdrahtung + RDF/Turtle (PR4/4)

### DIFF
--- a/sdata/base.py
+++ b/sdata/base.py
@@ -234,6 +234,10 @@ class Base:
         """Serialisiere die Metadaten als JSON-LD (siehe :mod:`sdata.semantic`)."""
         return self.metadata.to_jsonld(context_mode=context_mode)
 
+    def to_turtle(self):
+        """Serialisiere die Metadaten als RDF/Turtle (siehe :mod:`sdata.semantic`)."""
+        return self.metadata.to_turtle()
+
     def write_sidecar(self, path=None, indent=2):
         """Schreibe ``<sname>.meta.jsonld`` neben einen Datenblob; gibt den Pfad zurück."""
         return self.metadata.write_sidecar(path=path, indent=indent)
@@ -389,17 +393,21 @@ class Base:
         b.description = d.get("description", "")
         return b
 
-    def to_json(self, filepath: Optional[str] = None) -> Optional[str]:
+    def to_json(self, filepath: Optional[str] = None, sidecar: bool = False) -> Optional[str]:
         """
         Export the object to JSON format, either as a string or to a file.
 
         :param filepath: Optional file path to write JSON (default: None).
+        :param sidecar: bei True zusätzlich ``<dir>/<sname>.meta.jsonld`` schreiben
+            (nur wirksam mit ``filepath``; Default False = unverändertes Verhalten).
         :return: JSON string if filepath is None, else None.
         """
         data_dict = self.to_dict()
         if filepath:
             with open(filepath, "w") as fh:
                 json.dump(data_dict, fh, indent=4)
+            if sidecar:
+                self.write_sidecar(os.path.dirname(filepath) or ".")
             return None
         else:
             return json.dumps(data_dict, indent=4)

--- a/sdata/metadata.py
+++ b/sdata/metadata.py
@@ -625,6 +625,16 @@ class Metadata(object):
         from sdata import semantic
         return semantic.from_jsonld(doc)
 
+    def to_rdf(self, fmt="turtle"):
+        """Serialisiere als RDF (rdflib falls vorhanden, sonst JSON-LD)."""
+        from sdata import semantic
+        return semantic.to_rdf(self, fmt=fmt)
+
+    def to_turtle(self):
+        """Convenience: RDF im Turtle-Format."""
+        from sdata import semantic
+        return semantic.to_turtle(self)
+
     def write_sidecar(self, path=None, indent=2):
         """Schreibe ``<sname>.meta.jsonld`` neben einen Datenblob; gibt den Pfad zurück."""
         from sdata import semantic

--- a/sdata/sclass/dataframe.py
+++ b/sdata/sclass/dataframe.py
@@ -166,6 +166,7 @@ class DataFrame(Base):
         """
         engine = kwargs.get("engine", "pyarrow")
         compression = kwargs.get("compression", "zstd")
+        sidecar = kwargs.get("sidecar", False)
 
         df = self.df.copy()
         df.attrs["_sdata"] = {"metadata": self.metadata.to_dict(),
@@ -177,6 +178,8 @@ class DataFrame(Base):
             filepath = os.path.join(path, filename)
             df.to_parquet(filepath, engine=engine, compression=compression)
             logger.info(f"DataFrame Parquet saved to {filepath}")
+            if sidecar:
+                self.write_sidecar(path)
             return filepath
         else:
             return df.to_parquet(engine=engine, compression=compression)

--- a/sdata/semantic.py
+++ b/sdata/semantic.py
@@ -24,9 +24,14 @@ import os
 import sdata.dtypes as dtypes
 from sdata import vocab, units
 
+try:  # optionales RDF-Backend ([rdf]=rdflib)
+    import rdflib as _rdflib
+except ImportError:  # pragma: no cover - abhängig vom Environment
+    _rdflib = None
+
 __all__ = [
-    "to_jsonld", "from_jsonld", "write_sidecar", "read_sidecar",
-    "SIDECAR_SUFFIX",
+    "to_jsonld", "from_jsonld", "to_rdf", "to_turtle",
+    "write_sidecar", "read_sidecar", "SIDECAR_SUFFIX",
 ]
 
 SIDECAR_SUFFIX = ".meta.jsonld"
@@ -197,6 +202,27 @@ def from_jsonld(doc):
         if key.startswith("sdata:"):
             _set_from_node(m, key.split(":", 1)[1], val)
     return m
+
+
+def to_rdf(metadata, fmt="turtle"):
+    """Serialisiere die Metadaten als RDF.
+
+    Mit installiertem ``rdflib`` (``[rdf]``) wird das JSON-LD nach ``fmt``
+    (turtle/nt/xml/…) serialisiert. Ohne rdflib wird das JSON-LD selbst
+    zurückgegeben – ``application/ld+json`` ist bereits gültiges RDF.
+    """
+    doc = to_jsonld(metadata)
+    data = json.dumps(doc, default=dtypes.json_default)
+    if _rdflib is not None:
+        graph = _rdflib.Graph()
+        graph.parse(data=data, format="json-ld")
+        return graph.serialize(format=fmt)
+    return json.dumps(doc, indent=2, default=dtypes.json_default)
+
+
+def to_turtle(metadata):
+    """Convenience: RDF im Turtle-Format (siehe :func:`to_rdf`)."""
+    return to_rdf(metadata, fmt="turtle")
 
 
 def _sidecar_path(path, sname):

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ EXTRAS = {
     'blob': ['fsspec'],       # sdata.sclass.Blob (URI-Content: file/S3/Zip)
     # Semantische Metadaten-Schicht (alles mit pure-Python-Fallback):
     'units': ['pint'],        # Einheiten-Validierung/-Normalisierung (sonst kuratierte Tabelle)
+    'rdf': ['rdflib'],        # RDF/Turtle-Serialisierung (sonst JSON-LD = gültiges RDF)
 }
 
 setup(

--- a/tests/test_semantic_rdf.py
+++ b/tests/test_semantic_rdf.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Tests für die RDF/Turtle-Serialisierung (rdflib optional, JSON-LD-Fallback)."""
+import json
+
+import pytest
+
+from sdata.base import Base
+from sdata import semantic
+
+
+def _md():
+    b = Base(name="specimen_rdf")
+    b.metadata.add("force_x", 12.5, unit="kN", dtype="float")
+    return b.metadata
+
+
+def test_to_rdf_fallback_is_jsonld(monkeypatch):
+    monkeypatch.setattr(semantic, "_rdflib", None)
+    out = _md().to_rdf()
+    doc = json.loads(out)                      # Fallback = gültiges JSON-LD
+    assert "@context" in doc and doc["name"] == "specimen_rdf"
+    # Base-Delegator liefert dasselbe (Fallback-JSON-LD)
+    b = Base(name="specimen_rdf")
+    b.metadata.add("force_x", 12.5, unit="kN", dtype="float")
+    assert json.loads(b.to_turtle())["name"] == "specimen_rdf"
+
+
+def test_to_rdf_with_fake_rdflib(monkeypatch):
+    class _FakeGraph:
+        def parse(self, data=None, format=None):
+            self.data = data
+            return self
+        def serialize(self, format=None):
+            return "@FAKE-RDF@ format={}".format(format)
+
+    class _FakeRdflib:
+        Graph = _FakeGraph
+
+    monkeypatch.setattr(semantic, "_rdflib", _FakeRdflib)
+    assert "@FAKE-RDF@ format=turtle" in _md().to_turtle()
+    assert "format=nt" in _md().to_rdf(fmt="nt")
+
+
+def test_to_turtle_real_rdflib():
+    rdflib = pytest.importorskip("rdflib")
+    ttl = _md().to_turtle()
+    graph = rdflib.Graph()
+    graph.parse(data=ttl, format="turtle")
+    assert len(graph) > 0                       # Tripel wurden erzeugt

--- a/tests/test_sidecar_wiring.py
+++ b/tests/test_sidecar_wiring.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Opt-in Sidecar-Verdrahtung in die Speicherpfade (to_json / to_parquet)."""
+import pandas as pd
+import pytest
+
+from sdata.base import Base
+
+
+def test_to_json_sidecar(tmp_path):
+    b = Base(name="x")
+    b.metadata.add("a", 1)
+    fp = str(tmp_path / "x.sjson")
+    assert b.to_json(fp, sidecar=True) is None
+    side = tmp_path / (b.sname + ".meta.jsonld")
+    assert side.exists()
+    # Default: kein Sidecar
+    Base(name="y").to_json(str(tmp_path / "y.sjson"))
+    assert not list(tmp_path.glob("Base__y*.meta.jsonld"))
+    # String-Modus unverändert
+    assert isinstance(Base(name="z").to_json(), str)
+
+
+def test_to_json_sidecar_no_dir(tmp_path, monkeypatch):
+    # filepath ohne Verzeichnis -> dirname("") -> "." (cwd = tmp_path)
+    monkeypatch.chdir(tmp_path)
+    b = Base(name="here")
+    b.to_json("here.sjson", sidecar=True)
+    assert (tmp_path / (b.sname + ".meta.jsonld")).exists()
+
+
+def test_to_parquet_sidecar(tmp_path):
+    pytest.importorskip("pyarrow")
+    from sdata.sclass.dataframe import DataFrame
+    sdf = DataFrame(df=pd.DataFrame({"a": [1, 2, 3]}), name="d")
+    sdf.metadata.add("temperature", 23.0, unit="degC", dtype="float")
+    fp = sdf.to_parquet(path=str(tmp_path), sidecar=True)
+    assert fp.endswith(".spq")
+    assert (tmp_path / (sdf.sname + ".meta.jsonld")).exists()
+    # Default: kein Sidecar
+    sdf2 = DataFrame(df=pd.DataFrame({"a": [1]}), name="e")
+    sdf2.to_parquet(path=str(tmp_path))
+    assert not list(tmp_path.glob("*__e__*.meta.jsonld"))


### PR DESCRIPTION
Letzter PR des Scopes (Robustheit + Maschinenlesbarkeit). Schließt **Co-Location** + **RDF** ab.

## Sidecar-Verdrahtung (opt-in, Default unverändert)
- `Base.to_json(filepath, sidecar=True)` → zusätzlich `<dir>/<sname>.meta.jsonld`.
- `DataFrame.to_parquet(path, sidecar=True)` → Sidecar neben der `.spq`.
→ Die maschinenlesbare Beschreibung liegt damit **direkt neben jedem Datenblob**.

## RDF/Turtle
- `semantic.to_rdf(fmt)` / `to_turtle()`: mit `rdflib` (`[rdf]`) echte Turtle/NT/XML-Serialisierung; ohne rdflib **Fallback = das JSON-LD selbst** (gültiges RDF) — kein fragiler eigener Tripel-Writer.
- Delegatoren `Metadata.to_rdf/to_turtle`, `Base.to_turtle`. Extra `[rdf]=rdflib`.

## Tests/Coverage
`test_semantic_rdf` (Fallback, Fake-rdflib, echtes rdflib via `importorskip`), `test_sidecar_wiring`. **442 passed, 9 skipped, Coverage 100 %**.