### PR TITLE
feat(metadata): MetadataSchema / Templates (PR5)

### DIFF
--- a/sdata/base.py
+++ b/sdata/base.py
@@ -48,6 +48,10 @@ class Base:
         SDATA_PARENT_SNAME, SDATA_PROJECT_SNAME, SDATA_TOPOLOGY_CLASS
     ]
 
+    #: optionales MetadataSchema/Template (Default None); Subklassen/Factory können
+    #: es setzen, dann werden die Metadaten beim Init vervollständigt (vollqualifiziert).
+    SDATA_SCHEMA = None
+
     @classmethod
     def get_sdata_spec(cls: type) -> str:
         """Kanonischer, importierbarer String für eine Klasse: ``modul:Klasse``."""
@@ -130,7 +134,21 @@ class Base:
         self._description = kwargs.get("description", "")
         self._data: Dict[str, Any] = kwargs.get("data", {})
 
+        # Optionales Schema/Template anwenden (vollqualifizieren), falls deklariert
+        if self.SDATA_SCHEMA is not None:
+            self.SDATA_SCHEMA.apply(self.metadata)
+
         # logger.debug(f"Created {self.__class__.__name__} '{suuid.sname}'")
+
+    def validate(self):
+        """Validiere die Metadaten gegen das deklarierte ``SDATA_SCHEMA``.
+
+        Ohne Schema ist das Ergebnis trivial gültig.
+        """
+        from sdata.schema import ValidationReport
+        if self.SDATA_SCHEMA is None:
+            return ValidationReport(ok=True)
+        return self.SDATA_SCHEMA.validate(self.metadata)
 
     def _resolve_relation_sname(self, obj: Any, sname: Optional[str], label: str) -> str:
         """Ermittle den sname-Wert für eine Relation (``project``/``parent``).

--- a/sdata/metadata.py
+++ b/sdata/metadata.py
@@ -625,6 +625,14 @@ class Metadata(object):
         from sdata import semantic
         return semantic.from_jsonld(doc)
 
+    def validate(self, schema):
+        """Validiere diese Metadaten gegen ein :class:`sdata.schema.MetadataSchema`."""
+        return schema.validate(self)
+
+    def apply_schema(self, schema):
+        """Vervollständige diese Metadaten in-place gemäß einem MetadataSchema."""
+        return schema.apply(self)
+
     def to_rdf(self, fmt="turtle"):
         """Serialisiere als RDF (rdflib falls vorhanden, sonst JSON-LD)."""
         from sdata import semantic

--- a/sdata/schema.py
+++ b/sdata/schema.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""Metadaten-Schemata / Templates zum *Vollqualifizieren* von Metadaten.
+
+Ein :class:`MetadataSchema` deklariert die erwarteten Attribute einer Datenklasse
+(Name, dtype, Einheit, required, ontology, …) und kann Metadaten dagegen
+*validieren* sowie *vervollständigen* (Defaults/Einheiten/Ontologie auffüllen).
+
+Reine-Python-Validierung ist immer verfügbar; mit dem optionalen Extra
+``[schema]`` (jsonschema) lässt sich zusätzlich gegen ein generiertes JSON Schema
+prüfen.
+"""
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+import numpy as np
+
+import sdata.dtypes as dtypes
+from sdata import units
+
+try:  # optionales Backend ([schema]=jsonschema)
+    import jsonschema as _jsonschema
+except ImportError:  # pragma: no cover - abhängig vom Environment
+    _jsonschema = None
+
+__all__ = ["AttrSpec", "MetadataSchema", "ValidationReport"]
+
+# sdata-dtype -> JSON-Schema-Typ
+_JSON_TYPE = {
+    "str": "string", "uri": "string", "bytes": "string", "timestamp": "string",
+    "int": "integer", "float": "number", "bool": "boolean",
+    "list": "array", "json": "object",
+}
+
+
+def _is_empty(value):
+    if value is None or value == "":
+        return True
+    try:
+        return bool(np.isnan(value))
+    except (TypeError, ValueError):
+        return False
+
+
+@dataclass
+class AttrSpec:
+    """Spezifikation eines erwarteten Attributs."""
+    name: str
+    dtype: str = "str"
+    unit: str = "-"
+    required: bool = False
+    ontology: str = ""
+    description: str = ""
+    default: Any = None
+    allowed: Optional[List[Any]] = None
+
+    def to_dict(self):
+        return {"name": self.name, "dtype": self.dtype, "unit": self.unit,
+                "required": self.required, "ontology": self.ontology,
+                "description": self.description, "default": self.default,
+                "allowed": self.allowed}
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(**{k: d[k] for k in d if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class ValidationReport:
+    """Ergebnis einer Schema-Validierung (truthy, wenn ``ok``)."""
+    ok: bool
+    missing: List[str] = field(default_factory=list)
+    type_errors: List[tuple] = field(default_factory=list)
+    unit_errors: List[str] = field(default_factory=list)
+    enum_errors: List[str] = field(default_factory=list)
+    extra: List[str] = field(default_factory=list)
+    messages: List[str] = field(default_factory=list)
+
+    def __bool__(self):
+        return self.ok
+
+    def _repr_html_(self):
+        color = "#2e7d32" if self.ok else "#c62828"
+        status = "OK" if self.ok else "INVALID"
+        rows = ""
+        for label, items in [("missing", self.missing), ("type", self.type_errors),
+                             ("unit", self.unit_errors), ("enum", self.enum_errors),
+                             ("extra", self.extra), ("messages", self.messages)]:
+            if items:
+                rows += "<tr><td><b>{}</b></td><td>{}</td></tr>".format(label, items)
+        return ("<div><b style='color:{}'>ValidationReport: {}</b>"
+                "<table>{}</table></div>").format(color, status, rows)
+
+
+class MetadataSchema:
+    """Sammlung von :class:`AttrSpec` für eine Datenklasse."""
+
+    def __init__(self, name, specs, topology_class=None, sdata_class=None):
+        self.name = name
+        self.specs = list(specs)
+        self.topology_class = topology_class
+        self.sdata_class = sdata_class
+
+    @property
+    def _by_name(self):
+        return {s.name: s for s in self.specs}
+
+    def to_dict(self):
+        return {"name": self.name,
+                "topology_class": self.topology_class,
+                "sdata_class": self.sdata_class,
+                "specs": [s.to_dict() for s in self.specs]}
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(name=d.get("name", "N.N."),
+                   specs=[AttrSpec.from_dict(s) for s in d.get("specs", [])],
+                   topology_class=d.get("topology_class"),
+                   sdata_class=d.get("sdata_class"))
+
+    def validate(self, metadata):
+        """Prüfe ``metadata`` gegen das Schema (wirft nie; liefert ValidationReport)."""
+        report = ValidationReport(ok=True)
+        specs = self._by_name
+        for name, spec in specs.items():
+            attr = metadata.get(name)
+            if spec.required and (attr is None or _is_empty(attr.value)):
+                report.missing.append(name)
+            if attr is None:
+                continue
+            if dtypes.resolve(attr.dtype) != dtypes.resolve(spec.dtype):
+                report.type_errors.append((name, spec.dtype))
+            if spec.unit not in ("-", "") and \
+                    units.normalize_symbol(attr.unit) != units.normalize_symbol(spec.unit):
+                report.unit_errors.append(name)
+            if spec.allowed is not None and attr.value not in spec.allowed:
+                report.enum_errors.append(name)
+        for name in metadata.user_attributes.keys():
+            if name not in specs:
+                report.extra.append(name)
+        report.ok = not (report.missing or report.type_errors
+                         or report.unit_errors or report.enum_errors)
+        return report
+
+    def apply(self, metadata):
+        """Vervollständige ``metadata`` in-place: fehlende Attribute aus Defaults
+        anlegen, vorhandene um Einheit/Ontologie/Beschreibung ergänzen. Gibt
+        ``metadata`` zurück (für nicht-destruktiv: ``schema.apply(md.copy())``)."""
+        for spec in self.specs:
+            attr = metadata.get(spec.name)
+            if attr is None:
+                metadata.set_attr(spec.name, spec.default, dtype=spec.dtype,
+                                  unit=spec.unit, ontology=spec.ontology,
+                                  description=spec.description)
+                continue
+            if attr.unit in ("-", "", None) and spec.unit not in ("-", ""):
+                attr.unit = spec.unit
+            if not attr.ontology and spec.ontology:
+                attr.ontology = spec.ontology
+            if not attr.description and spec.description:
+                attr.description = spec.description
+        return metadata
+
+    def to_json_schema(self):
+        """Generiere ein JSON Schema (Draft 2020-12) für ``metadata.get_udict()``."""
+        properties = {}
+        required = []
+        for spec in self.specs:
+            prop = {"type": _JSON_TYPE.get(dtypes.resolve(spec.dtype), "string")}
+            if spec.description:
+                prop["description"] = spec.description
+            if spec.allowed is not None:
+                prop["enum"] = spec.allowed
+            properties[spec.name] = prop
+            if spec.required:
+                required.append(spec.name)
+        schema = {"$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object", "properties": properties}
+        if required:
+            schema["required"] = required
+        return schema
+
+    def validate_jsonschema(self, metadata):
+        """Validiere via ``jsonschema`` (falls installiert), sonst native ``validate``."""
+        if _jsonschema is None:
+            return self.validate(metadata)
+        try:
+            _jsonschema.validate(metadata.get_udict(), self.to_json_schema())
+            return ValidationReport(ok=True)
+        except _jsonschema.ValidationError as exp:
+            return ValidationReport(ok=False, messages=[str(exp).splitlines()[0]])

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ EXTRAS = {
     # Semantische Metadaten-Schicht (alles mit pure-Python-Fallback):
     'units': ['pint'],        # Einheiten-Validierung/-Normalisierung (sonst kuratierte Tabelle)
     'rdf': ['rdflib'],        # RDF/Turtle-Serialisierung (sonst JSON-LD = gültiges RDF)
+    'schema': ['jsonschema'], # JSON-Schema-Validierung (sonst native MetadataSchema-Prüfung)
 }
 
 setup(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""Tests für sdata/schema.py (MetadataSchema/Templates, Validierung)."""
+import numpy as np
+
+from sdata.base import Base, sdata_factory
+from sdata.metadata import Metadata
+from sdata.schema import AttrSpec, MetadataSchema, ValidationReport
+from sdata import schema as schema_mod
+
+
+def _schema():
+    return MetadataSchema("TensileTest", [
+        AttrSpec("force_x", dtype="float", unit="kN", required=True,
+                 ontology="bfo:Quality", description="force x"),
+        AttrSpec("strain", dtype="float", unit="-", default=1.0),
+        AttrSpec("phase", dtype="str", allowed=["ferrite", "martensite"]),
+    ], topology_class="IndependentContinuant", sdata_class="sdata.base:Base")
+
+
+# --- AttrSpec / MetadataSchema (de)serialisierung ---------------------------
+def test_spec_and_schema_roundtrip():
+    s = _schema()
+    d = s.to_dict()
+    s2 = MetadataSchema.from_dict(d)
+    assert s2.name == "TensileTest"
+    assert {sp.name for sp in s2.specs} == {"force_x", "strain", "phase"}
+    assert AttrSpec.from_dict({"name": "x", "dtype": "int", "extra": "ignored"}).dtype == "int"
+
+
+# --- validate ---------------------------------------------------------------
+def test_validate_missing():
+    m = Metadata()                                     # force_x fehlt -> required
+    assert "force_x" in _schema().validate(m).missing
+
+
+def test_validate_type_unit_enum_extra():
+    s = _schema()
+    m = Metadata()
+    m.add("force_x", "abc", dtype="str", unit="MPa")   # type- (str/float) + unit-Fehler (MPa/kN)
+    m.add("phase", "austenite")                        # enum-Fehler
+    m.add("note", "frei")                              # extra
+    rep = s.validate(m)
+    assert not rep and rep.ok is False
+    assert ("force_x", "float") in rep.type_errors
+    assert "force_x" in rep.unit_errors
+    assert "phase" in rep.enum_errors
+    assert "note" in rep.extra
+
+
+def test_validate_ok():
+    s = _schema()
+    m = Metadata()
+    m.add("force_x", 12.5, dtype="float", unit="kN")
+    m.add("phase", "ferrite")
+    rep = s.validate(m)
+    assert rep and bool(rep) is True
+
+
+# --- apply ------------------------------------------------------------------
+def test_apply_fills_defaults_and_blanks():
+    s = _schema()
+    m = Metadata()
+    m.add("force_x", 10.0, dtype="float")              # ohne unit/ontology
+    s.apply(m)
+    assert m.get("force_x").unit == "kN"               # Einheit ergänzt
+    assert m.get("force_x").ontology == "bfo:Quality"  # Ontologie ergänzt
+    assert m.get("force_x").description == "force x"
+    assert m.get("strain").value == 1.0                # Default angelegt
+    assert "phase" in m                                # angelegt (Default None)
+
+
+# --- to_json_schema + validate_jsonschema -----------------------------------
+def test_to_json_schema():
+    js = _schema().to_json_schema()
+    assert js["type"] == "object"
+    assert js["properties"]["force_x"]["type"] == "number"
+    assert js["properties"]["phase"]["enum"] == ["ferrite", "martensite"]
+    assert js["required"] == ["force_x"]
+
+
+def test_validate_jsonschema_native_fallback():
+    # ohne jsonschema -> native validate
+    s = _schema()
+    m = Metadata()
+    m.add("force_x", 1.0, dtype="float", unit="kN")
+    m.add("phase", "ferrite")
+    assert s.validate_jsonschema(m).ok is True
+
+
+def test_validate_jsonschema_with_fake(monkeypatch):
+    class _Err(Exception):
+        pass
+
+    class _FakeJsonschema:
+        ValidationError = _Err
+
+        @staticmethod
+        def validate(instance, schema):
+            if "force_x" not in instance:
+                raise _Err("'force_x' is a required property\nmore")
+
+    monkeypatch.setattr(schema_mod, "_jsonschema", _FakeJsonschema)
+    s = _schema()
+    ok = Metadata()
+    ok.add("force_x", 1.0, dtype="float", unit="kN")
+    assert s.validate_jsonschema(ok).ok is True
+    bad = Metadata()
+    rep = s.validate_jsonschema(bad)
+    assert rep.ok is False and "required property" in rep.messages[0]
+
+
+# --- ValidationReport -------------------------------------------------------
+def test_validation_report_html():
+    rep = ValidationReport(ok=False, missing=["a"], messages=["m"])
+    html = rep._repr_html_()
+    assert "INVALID" in html and "missing" in html
+    assert "OK" in ValidationReport(ok=True)._repr_html_()
+
+
+def test_is_empty_branches():
+    assert schema_mod._is_empty(None) is True
+    assert schema_mod._is_empty("") is True
+    assert schema_mod._is_empty(np.nan) is True
+    assert schema_mod._is_empty("x") is False
+    assert schema_mod._is_empty(0) is False           # 0 ist nicht "leer"
+
+
+# --- Base-Wiring ------------------------------------------------------------
+def test_base_schema_wiring():
+    # Default-Base ohne Schema -> validate trivially ok
+    assert Base(name="x").validate().ok is True
+    # Factory-Klasse mit Schema -> Init qualifiziert voll + validate
+    Material = sdata_factory("Material", name="DP800",
+                             sdata_attrs={"SDATA_SCHEMA": _schema()})
+    assert Material.metadata.get("force_x").unit == "kN"   # apply lief im Init
+    assert "strain" in Material.metadata
+    rep = Material.validate()
+    assert "force_x" in rep.missing                        # force_x leer (nur Default)
+
+
+def test_metadata_validate_delegators():
+    s = _schema()
+    m = Metadata()
+    m.apply_schema(s)
+    assert "strain" in m
+    assert isinstance(m.validate(s), ValidationReport)


### PR DESCRIPTION
Schema/Templates zum **Vollqualifizieren** von Metadaten (deferred PR5 des Rückgrat-Programms).

## `sdata/schema.py` (pure-Python)
- **`AttrSpec`** — erwartetes Attribut (name/dtype/unit/required/ontology/description/default/allowed).
- **`MetadataSchema`**:
  - `validate(metadata) → ValidationReport` (missing/type/unit/enum/extra; wirft nie).
  - `apply(metadata)` — füllt Defaults/Einheit/Ontologie/Beschreibung in-place.
  - `to_json_schema()` (Draft 2020-12), `validate_jsonschema()` (optional `jsonschema`, sonst native Prüfung).
  - `to_dict/from_dict`.
- **`ValidationReport`** — truthy bei `ok`, `_repr_html_` (grün/rot).

## Wiring
- `Base.SDATA_SCHEMA` (Default `None`): falls gesetzt, werden Metadaten beim Init **vervollständigt**; `Base.validate()` prüft dagegen.
- `Metadata.validate(schema)/apply_schema(schema)`.
- `setup.py`: optionales Extra `[schema]=jsonschema`.

## Tests/Coverage
`tests/test_schema.py` (validate/apply/json-schema, jsonschema-Fake, Report-HTML, Base-Wiring via `sdata_factory`). **454 passed, 9 skipped, Coverage 100 %**.