### PR TITLE
feat(metadata): Interaktivität (_repr_html_, .a, get_prefixed) (PR6)

### DIFF
--- a/sdata/base.py
+++ b/sdata/base.py
@@ -256,6 +256,10 @@ class Base:
         """Serialisiere die Metadaten als RDF/Turtle (siehe :mod:`sdata.semantic`)."""
         return self.metadata.to_turtle()
 
+    def _repr_html_(self):
+        """Jupyter-Darstellung der Metadaten (siehe :mod:`sdata.interactive`)."""
+        return self.metadata._repr_html_()
+
     def write_sidecar(self, path=None, indent=2):
         """Schreibe ``<sname>.meta.jsonld`` neben einen Datenblob; gibt den Pfad zurück."""
         return self.metadata.write_sidecar(path=path, indent=indent)

--- a/sdata/interactive.py
+++ b/sdata/interactive.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Interaktive Ergonomie für Metadaten: Jupyter-``_repr_html_``, Attribut-
+Autocomplete (``m.a.force_x``) und Prefix-Filterung.
+
+Reine Standardbibliothek; die Renderer bauen HTML manuell (keine pandas-Styler-/
+tabulate-Abhängigkeit).
+"""
+import html as _html
+
+__all__ = ["attribute_html", "metadata_html", "AttrAccessor"]
+
+
+def _esc(value):
+    return _html.escape("" if value is None else str(value))
+
+
+def attribute_html(attr):
+    """Einzeilige HTML-Tabelle für ein :class:`Attribute`."""
+    return (
+        "<table><tr><th>name</th><th>value</th><th>unit</th><th>dtype</th>"
+        "<th>ontology</th></tr>"
+        "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr></table>"
+    ).format(_esc(attr.name), _esc(attr.value), _esc(attr.unit),
+             _esc(attr.dtype), _esc(attr.ontology))
+
+
+def metadata_html(metadata):
+    """HTML-Darstellung einer :class:`Metadata` (Kopf + User-Attribut-Tabelle)."""
+    sname_attr = metadata.get("_sdata_sname")
+    sname = sname_attr.value if sname_attr is not None and sname_attr.value else ""
+    cls_attr = metadata.get("_sdata_class")
+    cls = cls_attr.value if cls_attr is not None and cls_attr.value else ""
+
+    header = "<b>{}</b>".format(_esc(metadata.name))
+    if cls:
+        header += " <code>{}</code>".format(_esc(cls))
+    if sname:
+        header += " <small>did:suuid:{}:sdata</small>".format(_esc(sname))
+
+    rows = ""
+    for attr in metadata.user_attributes.values():
+        rows += ("<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td>"
+                 "<td>{}</td><td>{}</td></tr>").format(
+            _esc(attr.name), _esc(attr.value), _esc(attr.unit),
+            _esc(attr.dtype), _esc(attr.ontology), _esc(attr.description))
+    table = ("<table><tr><th>name</th><th>value</th><th>unit</th><th>dtype</th>"
+             "<th>ontology</th><th>description</th></tr>{}</table>".format(rows))
+    return "<div>{}{}</div>".format(header, table)
+
+
+class AttrAccessor:
+    """Attribut-Autocomplete-Helfer: ``m.a.force_x`` liefert/setzt ein Attribut.
+
+    Liegt bewusst auf einem eigenen Objekt (nicht auf :class:`Metadata`), damit
+    Tab-Completion nur Attributnamen zeigt und keine Methoden überschattet.
+    """
+
+    def __init__(self, metadata):
+        object.__setattr__(self, "_md", metadata)
+
+    def __getattr__(self, name):
+        attr = self._md.get(name)
+        if attr is None:
+            raise AttributeError(name)
+        return attr
+
+    def __setattr__(self, name, value):
+        self._md.set_attr(name, value)
+
+    def __dir__(self):
+        return [a.name for a in self._md.user_attributes.values()
+                if a.name.isidentifier()]
+
+    def __repr__(self):
+        return "AttrAccessor({})".format(self.__dir__())

--- a/sdata/metadata.py
+++ b/sdata/metadata.py
@@ -262,6 +262,10 @@ class Attribute(object):
 
     __repr__ = __str__
 
+    def _repr_html_(self):
+        from sdata import interactive
+        return interactive.attribute_html(self)
+
 
 class Metadata(object):
     """Metadata container class
@@ -624,6 +628,24 @@ class Metadata(object):
         """Rekonstruiere Metadata aus einem JSON-LD-Dokument (dict oder str)."""
         from sdata import semantic
         return semantic.from_jsonld(doc)
+
+    def get_prefixed(self, prefix):
+        """Neue Metadata nur mit Attributen, deren Schlüssel mit ``prefix`` beginnt."""
+        sub = Metadata()
+        for key, attr in self._attributes.items():
+            if key.startswith(prefix):
+                sub._attributes[key] = attr
+        return sub
+
+    @property
+    def a(self):
+        """Attribut-Autocomplete-Accessor für die interaktive Nutzung (``m.a.force_x``)."""
+        from sdata import interactive
+        return interactive.AttrAccessor(self)
+
+    def _repr_html_(self):
+        from sdata import interactive
+        return interactive.metadata_html(self)
 
     def validate(self, schema):
         """Validiere diese Metadaten gegen ein :class:`sdata.schema.MetadataSchema`."""

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Tests für die interaktive Schicht: _repr_html_, .a-Accessor, get_prefixed."""
+import pytest
+
+from sdata.base import Base
+from sdata.metadata import Attribute, Metadata
+
+
+def test_attribute_repr_html():
+    a = Attribute("force_x", 12.5, unit="kN", dtype="float", ontology="bfo:Quality")
+    html = a._repr_html_()
+    assert "force_x" in html and "kN" in html and "bfo:Quality" in html
+
+
+def test_metadata_repr_html_bare_and_base():
+    # bare Metadata: kein did/class
+    m = Metadata()
+    m.add("note", "<b>hi</b>")
+    html = m._repr_html_()
+    assert "note" in html
+    assert "&lt;b&gt;hi&lt;/b&gt;" in html          # HTML-escaped
+    assert "did:suuid" not in html
+    # Base: mit did + class
+    b = Base(name="specimen")
+    b.metadata.add("force_x", 1.0, unit="kN", dtype="float")
+    bh = b._repr_html_()
+    assert "did:suuid:Base__specimen__" in bh
+    assert "sdata.base:Base" in bh and "force_x" in bh
+
+
+def test_attr_accessor():
+    m = Metadata()
+    m.add("force_x", 12.5, unit="kN", dtype="float")
+    m.add("with space", 1)                          # kein Identifier -> nicht in dir()
+    # get
+    assert m.a.force_x.value == 12.5
+    # set
+    m.a.stress = 350.0
+    assert m.get("stress").value == 350.0
+    # dir -> nur identifier-fähige User-Attribute
+    names = dir(m.a)
+    assert "force_x" in names and "stress" in names and "with space" not in names
+    # unbekannt -> AttributeError
+    with pytest.raises(AttributeError):
+        _ = m.a.does_not_exist
+    # repr
+    assert "AttrAccessor(" in repr(m.a)
+
+
+def test_get_prefixed():
+    m = Metadata()
+    m.add("Load/Fx", 1.0, prefix="")                # key "Load/Fx"
+    m.set_attr("Fy", 2.0, prefix="Load/")
+    m.add("temp", 25.0)
+    sub = m.get_prefixed("Load/")
+    assert set(sub.keys()) == {"Load/Fx", "Load/Fy"}
+    assert "temp" not in sub
+    # reservierte via Prefix
+    b = Base(name="x")
+    assert all(k.startswith("_sdata") for k in b.metadata.get_prefixed("_sdata").keys())


### PR DESCRIPTION
Interaktive Ergonomie (deferred PR6). Pure stdlib, keine neue Dependency.

## `sdata/interactive.py`
- **`_repr_html_`** (Jupyter) für `Metadata`/`Base`/`Attribute` — manuell gebautes HTML (kein pandas-Styler/tabulate), Kopf mit `name`/`class`/DID + Attribut-Tabelle, escaped.
- **`AttrAccessor`** — `m.a.force_x` liest/setzt Attribute; `__dir__` liefert nur identifier-fähige User-Attributnamen → Tab-Completion **ohne** Method-Shadowing (liegt auf eigenem Helfer, nicht auf `Metadata`).

## Wiring (additiv)
`Attribute._repr_html_`, `Metadata._repr_html_/a/get_prefixed`, `Base._repr_html_`.

## Tests/Coverage
`tests/test_interactive.py`. **458 passed, 9 skipped, Coverage 100 %**.