### PR TITLE
feat(metadata): Verifiable Credentials (PR7)

### DIFF
--- a/sdata/metadata.py
+++ b/sdata/metadata.py
@@ -660,6 +660,19 @@ class Metadata(object):
         from sdata import semantic
         return semantic.to_rdf(self, fmt=fmt)
 
+    def to_verifiable_credential(self, issuer_did, issuer_priv_jwk, kid=None,
+                                 extra_claims=None):
+        """Signiere die Metadaten als W3C Verifiable Credential (Compact-JWS)."""
+        from sdata import semantic
+        return semantic.to_verifiable_credential(
+            self, issuer_did, issuer_priv_jwk, kid=kid, extra_claims=extra_claims)
+
+    @classmethod
+    def from_verifiable_credential(cls, vc_jws, pub_jwk):
+        """Verifiziere ein VC und rekonstruiere die Metadata aus dem credentialSubject."""
+        from sdata import semantic
+        return cls.from_jsonld(semantic.verify_credential(vc_jws, pub_jwk))
+
     def to_turtle(self):
         """Convenience: RDF im Turtle-Format."""
         from sdata import semantic

--- a/sdata/semantic.py
+++ b/sdata/semantic.py
@@ -31,7 +31,8 @@ except ImportError:  # pragma: no cover - abhängig vom Environment
 
 __all__ = [
     "to_jsonld", "from_jsonld", "to_rdf", "to_turtle",
-    "write_sidecar", "read_sidecar", "SIDECAR_SUFFIX",
+    "write_sidecar", "read_sidecar", "to_verifiable_credential",
+    "verify_credential", "SIDECAR_SUFFIX",
 ]
 
 SIDECAR_SUFFIX = ".meta.jsonld"
@@ -223,6 +224,43 @@ def to_rdf(metadata, fmt="turtle"):
 def to_turtle(metadata):
     """Convenience: RDF im Turtle-Format (siehe :func:`to_rdf`)."""
     return to_rdf(metadata, fmt="turtle")
+
+
+def to_verifiable_credential(metadata, issuer_did, issuer_priv_jwk,
+                             kid=None, extra_claims=None):
+    """Signiere die Metadaten als W3C Verifiable Credential (Compact-JWS, EdDSA).
+
+    Wickelt :func:`to_jsonld` als ``credentialSubject`` und signiert über den
+    pure-Python-EdDSA-Stack (:mod:`sdata.did.jose`) – keine externe Krypto.
+
+    :return: Compact-JWS-String (``header.payload.signature``)
+    """
+    from sdata.did import jose
+    subject = to_jsonld(metadata)
+    payload = {
+        "iss": issuer_did,
+        "vc": {
+            "@context": ["https://www.w3.org/2018/credentials/v1"],
+            "type": ["VerifiableCredential", "SdataMetadataCredential"],
+            "credentialSubject": subject,
+        },
+    }
+    if subject.get("@id"):
+        payload["sub"] = subject["@id"]
+    if extra_claims:
+        payload.update(extra_claims)
+    return jose.sign_compact(payload, issuer_priv_jwk,
+                             kid=kid or (issuer_did + "#key-1"), typ="vc+ld+jwt")
+
+
+def verify_credential(vc_jws, pub_jwk):
+    """Verifiziere ein VC (Compact-JWS) und gib das ``credentialSubject`` (JSON-LD) zurück.
+
+    :raises sdata.did.errors.VerificationError: bei ungültiger Signatur.
+    """
+    from sdata.did import jose
+    payload = jose.verify_compact(vc_jws, pub_jwk)
+    return payload["vc"]["credentialSubject"]
 
 
 def _sidecar_path(path, sname):

--- a/tests/test_semantic_vc.py
+++ b/tests/test_semantic_vc.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Tests für signierte Metadaten als W3C Verifiable Credential (pure-Python EdDSA)."""
+import pytest
+
+from sdata.base import Base
+from sdata.metadata import Metadata
+from sdata import semantic
+from sdata.did import keys, pub_from_priv_jwk
+from sdata.did.errors import VerificationError
+
+
+def _signed():
+    priv = keys.gen_ed25519_jwk()
+    pub = pub_from_priv_jwk(priv)
+    b = Base(name="specimen_vc")
+    b.metadata.add("force_x", 12.5, unit="kN", dtype="float")
+    jws = b.metadata.to_verifiable_credential("did:example:issuer", priv)
+    return jws, pub, b
+
+
+def test_vc_roundtrip_and_verify():
+    jws, pub, b = _signed()
+    assert jws.count(".") == 2                      # Compact-JWS
+    subject = semantic.verify_credential(jws, pub)
+    assert subject["@id"] == b.to_jsonld()["@id"]
+    # Rekonstruktion zu Metadata
+    m = Metadata.from_verifiable_credential(jws, pub)
+    assert m.get("force_x").value == 12.5
+    assert m.name == "specimen_vc"
+
+
+def test_vc_tampered_fails():
+    jws, pub, _ = _signed()
+    header, payload, sig = jws.split(".")
+    # Signatur unverändert, Payload manipulieren -> Verifikation muss scheitern
+    tampered = header + "." + payload[:-4] + "AAAA" + "." + sig
+    with pytest.raises((VerificationError, Exception)):
+        semantic.verify_credential(tampered, pub)
+
+
+def test_vc_extra_claims_and_no_id():
+    priv = keys.gen_ed25519_jwk()
+    pub = pub_from_priv_jwk(priv)
+    # bare Metadata ohne _sdata_sname -> kein 'sub'/@id, aber extra_claims greifen
+    m = Metadata()
+    m.add("note", "frei")
+    jws = m.to_verifiable_credential("did:example:issuer", priv,
+                                     extra_claims={"nonce": "abc"})
+    import sdata.did.jose as jose
+    payload = jose.verify_compact(jws, pub)
+    assert payload["nonce"] == "abc"
+    assert "sub" not in payload                      # kein @id -> kein sub
+    assert payload["vc"]["credentialSubject"]["sdata:note"] == {"@value": "frei", "@type": "xsd:string"}


### PR DESCRIPTION
Letzter PR des Rückgrat-Programms: **verifizierbare, signierte Metadaten**. Nutzt den vorhandenen **pure-Python-EdDSA-Stack** (`sdata.did`) — keine neue/externe Krypto-Dependency.

## `sdata/semantic.py`
- **`to_verifiable_credential(metadata, issuer_did, issuer_priv_jwk, …)`** — wickelt `to_jsonld()` als `credentialSubject` (W3C VC, `type: SdataMetadataCredential`) und signiert als Compact-JWS (`typ: vc+ld+jwt`).
- **`verify_credential(vc_jws, pub_jwk)`** — verifiziert die Signatur, liefert das `credentialSubject` (JSON-LD); `VerificationError` bei Manipulation.

## Delegatoren
`Metadata.to_verifiable_credential` und `Metadata.from_verifiable_credential` (verifizieren → Metadata via `from_jsonld`).

## Tests/Coverage
`tests/test_semantic_vc.py` (Sign/Verify-Roundtrip, Manipulationsnachweis, `extra_claims`, bare Metadata ohne `@id`). **461 passed, 9 skipped, Coverage 100 %**.