### PR TITLE
refactor: pytz → stdlib zoneinfo

### DIFF
--- a/sdata/metadata.py
+++ b/sdata/metadata.py
@@ -6,7 +6,6 @@ import pandas as pd
 import numpy as np
 from sdata.timestamp import TimeStamp
 import sdata.dtypes as dtypes
-import pytz
 import datetime
 from dateutil.parser import parse as parse_date
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
@@ -60,8 +59,8 @@ def extract_name_unit(value):
 def _to_utc(dt: datetime.datetime) -> datetime.datetime:
     """Sichere UTC-Normalisierung (aware)."""
     if dt.tzinfo is None:
-        return dt.replace(tzinfo=pytz.UTC)
-    return dt.astimezone(pytz.UTC)
+        return dt.replace(tzinfo=datetime.timezone.utc)
+    return dt.astimezone(datetime.timezone.utc)
 
 class Attribute(object):
     """Attribute class"""

--- a/sdata/timestamp.py
+++ b/sdata/timestamp.py
@@ -36,7 +36,7 @@ import datetime
 from decimal import Decimal
 import sys
 import re
-import pytz
+import zoneinfo
 
 __all__ = ["parse_date", "ParseError", "UTC",
            "FixedOffset", "TimeStamp"]
@@ -263,13 +263,17 @@ def get_utc_timestamp(dt):
     """datetime --> 2017-04-26T09:04:00.660000+00:00"""
     if not isinstance(dt, datetime.datetime):
         return
-    return dt.astimezone(tz=pytz.UTC)
+    return dt.astimezone(tz=UTC)
 
 
 def get_local_timestamp(dt):
     """datetime --> 2017-04-26T09:04:00.660000+02:00"""
     tzname = local_tzname()
-    return dt.astimezone(tz=pytz.timezone(tzname))
+    try:
+        tz = zoneinfo.ZoneInfo(tzname)
+    except zoneinfo.ZoneInfoNotFoundError:  # pragma: no cover - System ohne tz-Datenbank
+        return dt.astimezone()              # System-Lokalzeit (ohne tzdata)
+    return dt.astimezone(tz=tz)
 
 
 class TimeStamp(object):
@@ -278,7 +282,7 @@ class TimeStamp(object):
     def __init__(self, datetimestr=None):
         """'2017-04-26T09:04:00.660000+00:00' --> datetime"""
         if datetimestr is None:
-            self._datetime = datetime.datetime.now(tz=pytz.UTC)
+            self._datetime = datetime.datetime.now(tz=UTC)
         else:
             try:
                 self._datetime = parse_date(datetimestr)

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,9 @@ with open('sdata/__init__.py', 'r') as f:
 with open('README.md', 'rb') as f:
     readme = f.read().decode('utf-8')
 
-# Schlanker Kern: nur numpy/pandas (Datenmodell), pytz (Zeitzonen) und suuid.
-REQUIRES = ['numpy', 'pandas', 'pytz', 'suuid>=0.2.0']
+# Schlanker Kern: nur numpy/pandas (Datenmodell) und suuid. Zeitzonen über das
+# stdlib-Modul zoneinfo (Python >= 3.9).
+REQUIRES = ['numpy', 'pandas', 'suuid>=0.2.0']
 
 # Optionale Abhängigkeiten:
 #   pip install "sdata[did]"     DID-/VC-Subpackage (sdata.did, pure Python)
@@ -62,8 +63,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -71,7 +70,7 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.9',
 
     install_requires=REQUIRES,
     extras_require=EXTRAS,

--- a/tests/test_metadata_coverage.py
+++ b/tests/test_metadata_coverage.py
@@ -19,11 +19,11 @@ def test_extract_name_unit_variants():
 
 
 def test_to_utc_naive_and_aware():
-    import pytz
+    import zoneinfo
     naive = datetime.datetime(2020, 1, 1, 12, 0, 0)
     assert _to_utc(naive).tzinfo is not None
-    aware = pytz.timezone("Europe/Berlin").localize(naive)
-    assert _to_utc(aware).tzinfo == pytz.UTC
+    aware = naive.replace(tzinfo=zoneinfo.ZoneInfo("Europe/Berlin"))
+    assert _to_utc(aware).tzinfo == datetime.timezone.utc
 
 
 # --- Attribute ----------------------------------------------------------

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -8,7 +8,6 @@ sys.path.insert(0, os.path.join(modulepath, "..", "..", "src"))
 
 import time
 import datetime
-import pytz
 import sdata.timestamp
 
 def to_timestamp(dt, epoch=datetime.datetime(1970,1,1)):
@@ -30,53 +29,12 @@ def local_tzname():
     return 'Etc/GMT%+d' % offsetHour
 
 
-def datetime2timestamp():
-    ts = 1493197440.66  # time.time()
-    utctime = datetime.datetime.utcfromtimestamp(ts)
-    utctime = utctime.replace(tzinfo=pytz.utc)
-
-    # utctime = datetime.datetime.now(tz=pytz.UTC)
-    print("UTC:", utctime.astimezone(tz=pytz.UTC).isoformat())
-    print("CEST", utctime.astimezone(tz=pytz.timezone('Europe/Berlin')).isoformat())
-    print("CET ", utctime.astimezone(tz=pytz.timezone('CET')).isoformat())
-
-    assert utctime.astimezone(tz=pytz.UTC).isoformat() == '2017-04-26T09:04:00.660000+00:00'
-    assert utctime.astimezone(tz=pytz.timezone('Europe/Berlin')).isoformat() == '2017-04-26T11:04:00.660000+02:00'
-
-    print(utctime.strftime('%Y-%m-%d %H:%M:%S.%f %Z'))
-    print(utctime.strftime('%Y-%m-%d %H:%M:%S.%f %z'))
-    print(utctime.isoformat())
-
-    tz = pytz.timezone('Europe/Berlin')
-    localtime = datetime.datetime.now(tz=tz)
-    print(localtime.strftime('%Y-%m-%d %H:%M:%S.%f %Z'))
-    print(localtime.strftime('%Y-%m-%d %H:%M:%S.%f%z'))
-    print(localtime.astimezone(tz=pytz.UTC).strftime('%Y-%m-%d %H:%M:%S.%f%z'))
-
-    # tzname = local_tzname()
-    # print tzname
-    tzname = "Etc/GMT-2"
-    localtime = utctime.astimezone(tz=pytz.timezone(tzname))
-    print("!", localtime.astimezone(tz=pytz.timezone(tzname)).isoformat())
-    # print localtime.astimezone(tz=pytz.timezone(tzname)).strftime('%Y-%m-%d %H:%M:%S.%f%z')
-    # print localtime.astimezone(tz=pytz.timezone(tzname)).strftime('%Y-%m-%d %H:%M:%S.%f(%Z)')
-    assert localtime.astimezone(tz=pytz.timezone(tzname)).isoformat() == "2017-04-26T11:04:00.660000+02:00"
-    print("UTC:", localtime.astimezone(tz=pytz.UTC).isoformat())
-    assert localtime.astimezone(tz=pytz.timezone("UTC")).isoformat() == "2017-04-26T09:04:00.660000+00:00"
-
-    timestr = "2017-04-26T09:04:00.660000+00:00"
-    time2 = sdata.timestamp.parse_date(timestr)
-    print(time2.astimezone(tz=pytz.timezone("UTC")).isoformat())
-    print(timestr)
-    assert timestr == time2.astimezone(tz=pytz.timezone("UTC")).isoformat()
-
-
 def test_timestamp():
     timestr = "2017-04-26T09:04:00.660000+00:00"
     utctime = sdata.timestamp.parse_date(timestr)
-    print(utctime.astimezone(tz=pytz.timezone("UTC")).isoformat())
+    print(utctime.astimezone(tz=datetime.timezone.utc).isoformat())
     print(timestr)
-    assert timestr == utctime.astimezone(tz=pytz.timezone("UTC")).isoformat()
+    assert timestr == utctime.astimezone(tz=datetime.timezone.utc).isoformat()
 
     utctime2 = sdata.timestamp.get_utc_timestamp(utctime)
     print(utctime2.isoformat())
@@ -103,4 +61,3 @@ def test_timestamp():
 
 if __name__ == '__main__':
     test_timestamp()
-    # datetime2timestamp()


### PR DESCRIPTION
Entfernt die **letzte Nicht-numpy/pandas-Core-Dependency** (`pytz`). Zeitzonen laufen jetzt über die Standardbibliothek.

## Änderungen
- **UTC** → `datetime.timezone.utc` (`timestamp.py` hatte `UTC` ohnehin schon stdlib; `metadata.py._to_utc` umgestellt).
- **Benannte Zonen** (Lokalzeit) → `zoneinfo.ZoneInfo` statt `pytz.timezone`; bei fehlender System-tz-Datenbank Fallback auf `dt.astimezone()`.
- `setup.py`: `pytz` aus `REQUIRES`; `python_requires='>=3.9'` (zoneinfo); 3.7/3.8-Classifier entfernt.
- Tests entpytzt; tote `datetime2timestamp`-Hilfsfunktion entfernt.

## Verifikation
Mit **deinstalliertem** `pytz`: `import sdata` + Suite grün — **465 passed, 9 skipped, Coverage 100 %**. Kern-`REQUIRES` jetzt: `numpy, pandas, suuid`.