### PR TITLE
chore: pandas/datetime-Deprecations beseitigen

### DIFF
--- a/sdata/metadata.py
+++ b/sdata/metadata.py
@@ -484,7 +484,7 @@ class Metadata(object):
     @property
     def dft(self):
         """create transposed dataframe for sdata attributes"""
-        mt = self.df[["value"]].transpose(copy=True)
+        mt = self.df[["value"]].transpose().copy()
         mt.index = [self.get("_sdata_sname").value]
         return mt
 
@@ -492,7 +492,7 @@ class Metadata(object):
         """create transposed dataframe for sdata attributes"""
         if index_name is None:
             index_name = "_sdata_sname"
-        mt = self.df[["value"]].transpose(copy=True)
+        mt = self.df[["value"]].transpose().copy()
         mt.index = [self.get(index_name).value]
         return mt
 
@@ -505,7 +505,7 @@ class Metadata(object):
     @property
     def sdft(self):
         """create transposed dataframe for sdata attributes"""
-        mt = self.sdf[["value"]].transpose(copy=True)
+        mt = self.sdf[["value"]].transpose().copy()
         mt.index = [self.get("_sdata_uuid").value]
         return mt
 

--- a/tests/iolib/test_jsonsqlitestore.py
+++ b/tests/iolib/test_jsonsqlitestore.py
@@ -5,7 +5,7 @@ import zlib
 import base64
 import shutil
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from sdata.iolib.jsonsqlitestore import JSONSQLiteStore
 
 
@@ -126,7 +126,7 @@ def test_backup_and_restore(tmp_path):
 def test_delete_expired(tmp_path):
     db = str(tmp_path / "exp.sqlite")
     store = JSONSQLiteStore(db)
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     rid1 = store.insert({"t": 1})
     # artificially update created_at to past
     past = (now - timedelta(days=1)).strftime('%Y-%m-%dT%H:%M:%fZ')


### PR DESCRIPTION
Beseitigt die Deprecation-Warnungen: `DataFrame.transpose(copy=True)` → `transpose().copy()` (metadata.py dft/get_dft/sdft) und `datetime.utcnow()` → `datetime.now(timezone.utc)` (Test). Suite läuft unter `-W error::DeprecationWarning/FutureWarning` grün; 9→4 Warnungen (Reste keine Deprecations). **465 passed, Coverage 100 %**.