### PR TITLE
chore: Test-Lauf vollständig warnungsfrei

### DIFF
--- a/sdata/experiments/__init__.py
+++ b/sdata/experiments/__init__.py
@@ -21,6 +21,10 @@ class TestProgram(Data):
     """A sdata Testprogram
 
     """
+    # Trotz "Test"-Präfix keine pytest-Testklasse (gilt via Vererbung auch für
+    # TestSeries/Test) -> unterdrückt PytestCollectionWarning.
+    __test__ = False
+
     ATTRIBUTES = [
         ['material_name', '', 'str', '-', 'Der Name des Materials.', '', False],
         ['material_norm_name', '', 'str', '-', 'Der normative Name des Materials.', '', False],

--- a/tests/iolib/test_json1sqlitestore_coverage.py
+++ b/tests/iolib/test_json1sqlitestore_coverage.py
@@ -42,7 +42,8 @@ def test_find_by_variants(store):
     assert len(store.find_by("_sdata_class", "C", limit=1, offset=0)) == 1
     # nicht-generierte Spalte -> Warnung + json_extract-Pfad
     store.insert(_rec(custom="abc"))
-    assert len(store.find_by("custom", "abc")) == 1
+    with pytest.warns(UserWarning, match="not optimized"):
+        assert len(store.find_by("custom", "abc")) == 1
 
 
 def test_get_index_df(store):


### PR DESCRIPTION
Beseitigt die letzten Test-Warnungen (von 9 → **0**).

- `experiments/__init__.py`: `__test__ = False` auf `TestProgram` (erbt an `TestSeries`/`Test`) → keine `PytestCollectionWarning` mehr für die „Test*"-Domänenklassen.
- `test_json1sqlitestore_coverage.py`: die **bewusste** „not optimized"-`UserWarning` des json1-Stores wird jetzt via `pytest.warns` geprüft statt in die Summary zu lecken.

**465 passed, 9 skipped, 0 Warnungen, Coverage 100 %.**