### PR TITLE
feat(vocab): auflösbare Namespace-IRI (GitHub Pages)

### DIFF
--- a/ns/context.jsonld
+++ b/ns/context.jsonld
@@ -1,0 +1,54 @@
+{
+  "@context": {
+    "sdata": "https://lepy.github.io/sdata/ns#",
+    "schema": "https://schema.org/",
+    "dcterms": "http://purl.org/dc/terms/",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "prov": "http://www.w3.org/ns/prov#",
+    "qudt": "http://qudt.org/schema/qudt/",
+    "unit": "http://qudt.org/vocab/unit/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "bfo": "http://purl.obolibrary.org/obo/",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "csvw": "http://www.w3.org/ns/csvw#",
+    "did": "https://www.w3.org/ns/did#",
+    "name": "schema:name",
+    "description": "schema:description",
+    "generatedAtTime": {
+      "@id": "prov:generatedAtTime",
+      "@type": "xsd:dateTime"
+    },
+    "wasDerivedFrom": {
+      "@id": "prov:wasDerivedFrom",
+      "@type": "@id"
+    },
+    "isPartOf": {
+      "@id": "dcterms:isPartOf",
+      "@type": "@id"
+    },
+    "identifier": "dcterms:identifier",
+    "topologyClass": {
+      "@id": "sdata:topologyClass",
+      "@type": "@id"
+    },
+    "value": "qudt:value",
+    "unitRef": {
+      "@id": "qudt:unit",
+      "@type": "@id"
+    },
+    "symbol": "qudt:symbol",
+    "label": "rdfs:label",
+    "required": {
+      "@id": "sdata:required",
+      "@type": "xsd:boolean"
+    },
+    "columns": {
+      "@id": "csvw:column",
+      "@container": "@list"
+    },
+    "datatype": {
+      "@id": "csvw:datatype",
+      "@type": "@id"
+    }
+  }
+}

--- a/sdata/vocab.py
+++ b/sdata/vocab.py
@@ -22,9 +22,11 @@ __all__ = [
     "safe_term", "predicate_for", "type_iri",
 ]
 
-#: Default-Namespace-IRI des sdata-Vokabulars (Platzhalter – bei Bedarf anpassen).
-SDATA_NS = "https://sdata.tools/ns#"
-CONTEXT_URL = "https://sdata.tools/ns/context.jsonld"
+#: Namespace-IRI des sdata-Vokabulars (auflösbar via GitHub Pages des Repos).
+SDATA_NS = "https://lepy.github.io/sdata/ns#"
+#: gehostetes JSON-LD-@context (statische Datei ``ns/context.jsonld`` im Repo-Root,
+#: von GitHub Pages unter dieser URL ausgeliefert).
+CONTEXT_URL = "https://lepy.github.io/sdata/ns/context.jsonld"
 
 NAMESPACES = {
     "sdata":   SDATA_NS,

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,6 +1,21 @@
 # -*- coding: utf-8 -*-
 """Tests für sdata/vocab.py (Namespaces, @context, XSD/BFO, CURIE/Prädikat/Typ)."""
+import json
+import os
+
 from sdata import vocab
+
+_CONTEXT_FILE = os.path.join(os.path.dirname(__file__), "..", "ns", "context.jsonld")
+
+
+def test_hosted_context_file_in_sync():
+    """Die statische, von GitHub Pages gehostete context.jsonld muss zum
+    inline-@context passen (sonst driften CONTEXT_URL und Inline auseinander)."""
+    with open(_CONTEXT_FILE) as fh:
+        hosted = json.load(fh)
+    assert hosted["@context"] == vocab.build_context("inline")
+    # NS und Context-URL bleiben konsistent (gleiche Basis)
+    assert vocab.CONTEXT_URL == vocab.SDATA_NS.rstrip("#") + "/context.jsonld"
 
 
 def test_build_context_inline_and_url():


### PR DESCRIPTION
Ersetzt den Platzhalter-Namespace `https://sdata.tools/ns#` durch eine **stabile, auflösbare** IRI über die bereits aktiven GitHub Pages des Repos (`https://lepy.github.io/sdata/`, served from `master/`).

## Änderungen
- `SDATA_NS = https://lepy.github.io/sdata/ns#`
- `CONTEXT_URL = https://lepy.github.io/sdata/ns/context.jsonld`
- **`ns/context.jsonld`**: statisches JSON-LD-`@context` im Repo-Root → von GitHub Pages unter `CONTEXT_URL` ausgeliefert. Damit verweist `to_jsonld(context_mode="url")` auf ein dereferenzierbares `@context`, und `sdata:`-Terme expandieren zu auflösbaren IRIs.
- **Sync-Guard** (`test_vocab.test_hosted_context_file_in_sync`): stellt sicher, dass die statische Datei zum inline-`@context` passt (bei Vokabular-Änderungen `build_context('inline')` → `ns/context.jsonld` neu generieren).

## Verifikation
`expand_curie('sdata:force_x')` → `https://lepy.github.io/sdata/ns#force_x`. **466 passed, 9 skipped, Coverage 100 %, 0 Warnungen.**

Hinweis: Default bleibt `context_mode="inline"` (selbst-enthaltene Dokumente); die gehostete URL ist die auflösbare Referenz.