### PR TITLE
docs: README + Sphinx auf maschinenlesbares Metadaten-Rückgrat aktualisieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 [![PyPI version](https://badge.fury.io/py/sdata.svg)](https://badge.fury.io/py/sdata)
 [![PyPI](https://img.shields.io/pypi/v/sdata.svg?style=flat-square)](https://pypi.python.org/pypi/sdata/)
 [![readthedocs](https://readthedocs.org/projects/sdata/badge/?version=latest)](http://sdata.readthedocs.io/en/latest/) 
-[![Build Status](https://travis-ci.org/lepy/sdata.svg?branch=master)](https://travis-ci.org/lepy/sdata)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/107e46dc4eee4b58a6ef82fce3043a3e)](https://www.codacy.com/app/lepy/sdata?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=lepy/sdata&amp;utm_campaign=Badge_Grade)
 [![Coverage Status](https://coveralls.io/repos/github/lepy/sdata/badge.svg?branch=master)](https://coveralls.io/github/lepy/sdata?branch=master)
 [![Das sdata-Format v0.8.4](https://zenodo.org/badge/DOI/10.5281/zenodo.4311323.svg)](https://doi.org/10.5281/zenodo.4311323)
 
@@ -35,24 +33,87 @@ https://lepy.github.io/sdata/
 * (single writer/ multiple reader (swmr) support)
 * (nested data support)
 
-```
-df = pandas.DataFrame({"a":[1,2,3]})
-import sdata
-data = sdata.Data(name="my_data", table=df, comment="A remarkable comment")
-data.metadata.add("my_key", 123, unit="m^3", description="a volume")
-data.metadata.add("force", 1.234, unit="kN", description="x force")
-data.to_xlsx(filepath="my_data.xlsx")
-print(data.metadata.df)
+## Quickstart
+
+```python
+import pandas as pd
+from sdata.sclass.dataframe import DataFrame
+
+df = pd.DataFrame({"force": [1.0, 2.0, 3.0]})
+data = DataFrame(df=df, name="specimen_01", description="a tension test")
+data.metadata.add("max_force", 12.5, unit="kN", dtype="float",
+                  description="max force", ontology="bfo:Quality")
+
+print(data.metadata.df[["value", "unit", "dtype", "ontology"]])
 ```
 
 ```
-          name                             value  dtype unit description
-key                                                                     
-name      name                           my_data    str    -            
-uuid      uuid  08222ca66e5047808bdc3b35d8f17224    str    -            
-my_key  my_key                               123    int  m^3    a volume
-force    force                             1.234  float   kN     x force
+                                          value unit  dtype     ontology
+key
+_sdata_name                         specimen_01    -    str
+_sdata_sname    DataFrame__specimen_01__3003...    -    str
+...
+max_force                                  12.5   kN  float  bfo:Quality
 ```
+
+Every object has a deterministic, content-addressable identity (`SUUID`), a set
+of reserved `_sdata_*` attributes (name, sname, suuid, class, ctime, parent,
+project, topology class) and freely extensible, fully-described user attributes.
+
+## Machine-readable metadata (JSON-LD / Linked Data)
+
+The metadata is the backbone of the data description: it lives next to every
+data blob and fully qualifies the data — units (QUDT/UCUM), ontology classes
+(BFO), provenance (PROV/DCAT), tabular columns (CSVW) and identity (DID).
+
+```python
+# self-describing JSON-LD (qudt:Quantity units, BFO @type, did:suuid @id, csvw columns)
+doc = data.to_jsonld()
+
+# RDF/Turtle (uses rdflib if installed, otherwise returns the JSON-LD)
+print(data.to_turtle())
+
+# write the data + a sidecar <sname>.meta.jsonld right next to it
+data.to_json("specimen_01.sjson", sidecar=True)
+
+# validate / auto-complete against a schema template
+from sdata.schema import MetadataSchema, AttrSpec
+schema = MetadataSchema("TensileTest", [
+    AttrSpec("max_force", dtype="float", unit="kN", required=True, ontology="bfo:Quality"),
+])
+report = data.metadata.validate(schema)      # ValidationReport (truthy if ok)
+
+# sign the metadata as a W3C Verifiable Credential (pure-Python Ed25519)
+from sdata.did import keys, pub_from_priv_jwk
+priv = keys.gen_ed25519_jwk()
+vc = data.metadata.to_verifiable_credential("did:example:issuer", priv)
+subject = data.metadata.from_verifiable_credential(vc, pub_from_priv_jwk(priv))
+
+# interactive: attribute autocomplete + rich Jupyter display
+data.metadata.a.max_force        # -> Attribute; tab-completion in Jupyter
+data.metadata                    # -> _repr_html_ table
+```
+
+Resulting JSON-LD for `max_force` (excerpt):
+
+```json
+{
+  "@id": "did:suuid:DataFrame__specimen_01__3003...:sdata",
+  "@type": ["sdata:DataFrame", "bfo:BFO_0000004"],
+  "name": "specimen_01",
+  "sdata:max_force": {
+    "@type": ["qudt:Quantity", "bfo:Quality"],
+    "value": {"@value": 12.5, "@type": "xsd:double"},
+    "unitRef": "unit:KiloN", "symbol": "kN"
+  },
+  "columns": [{"name": "force", "datatype": "xsd:double"}]
+}
+```
+
+The optional semantic backends degrade gracefully to pure Python (no hard
+dependency): `pip install "sdata[rdf]"` (rdflib), `sdata[units]` (pint),
+`sdata[schema]` (jsonschema). Core install needs only `numpy`, `pandas`, `suuid`.
+
 ## Howto
 
   
@@ -77,6 +138,7 @@ Try to paste some Excel-Data in the forms ...
 * description
 * label
 * required
+* ontology (CURIE/IRI of the value's class, e.g. `bfo:Quality`)
 
 ### dtypes for attributes
 
@@ -84,7 +146,14 @@ Try to paste some Excel-Data in the forms ...
 * float
 * str
 * bool
-* timestamp (datetime.isoformat with timezone)
+* list (list of strings)
+* timestamp (ISO-8601 with timezone, stdlib `zoneinfo`)
+* bytes (base64 in JSON)
+* json (dict/list)
+* uri
+
+Set `strict=True` (e.g. `metadata.add(..., strict=True)`) to raise on invalid
+values instead of the lenient default coercion.
 
 ## paper
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -13,3 +13,52 @@ sdata api
     :undoc-members:
     :inherited-members:
     :show-inheritance:
+
+
+sdata.base
+----------
+
+.. automodule:: sdata.base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+sdata.dtypes
+------------
+
+.. automodule:: sdata.dtypes
+    :members:
+    :undoc-members:
+
+
+Semantic / Linked-Data layer
+----------------------------
+
+.. automodule:: sdata.semantic
+    :members:
+    :undoc-members:
+
+.. automodule:: sdata.vocab
+    :members:
+    :undoc-members:
+
+.. automodule:: sdata.units
+    :members:
+    :undoc-members:
+
+.. automodule:: sdata.schema
+    :members:
+    :undoc-members:
+
+.. automodule:: sdata.interactive
+    :members:
+    :undoc-members:
+
+
+sdata.timestamp
+---------------
+
+.. automodule:: sdata.timestamp
+    :members:
+    :undoc-members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,7 @@
    data_types
    paper
    usage/usage
+   usage/metadata_jsonld
    api
    etc
    _dynamic/sdata

--- a/docs/source/usage/metadata_jsonld.rst
+++ b/docs/source/usage/metadata_jsonld.rst
@@ -1,0 +1,134 @@
+Machine-readable metadata (JSON-LD, schema, signing)
+====================================================
+
+The metadata is the backbone of the data description. It lives next to every
+data blob, *fully qualifies* the data and is fully machine-readable: units
+(QUDT/UCUM), ontology classes (BFO), provenance (PROV/DCAT), tabular columns
+(CSVW) and a content-addressable identity (DID).
+
+The semantic backends are **optional** and degrade gracefully to pure Python::
+
+    pip install sdata            # core only: numpy, pandas, suuid
+    pip install "sdata[rdf]"     # rdflib  -> real Turtle/N-Triples/RDF-XML
+    pip install "sdata[units]"   # pint    -> validate/normalise arbitrary units
+    pip install "sdata[schema]"  # jsonschema -> JSON-Schema validation
+
+
+The metadata model
+------------------
+
+Every :class:`~sdata.metadata.Attribute` carries
+``name, value, unit, dtype, description, label, required, ontology``.
+Supported ``dtype`` values are ``str, int, float, bool, list, timestamp,
+bytes, json, uri``. Coercion is lenient by default; pass ``strict=True`` to
+raise :class:`sdata.dtypes.DtypeError` on invalid values.
+
+.. code-block:: python
+
+    import pandas as pd
+    from sdata.sclass.dataframe import DataFrame
+
+    df = pd.DataFrame({"force": [1.0, 2.0, 3.0]})
+    data = DataFrame(df=df, name="specimen_01", description="a tension test")
+    data.metadata.add("max_force", 12.5, unit="kN", dtype="float",
+                      description="max force", ontology="bfo:Quality")
+
+Reserved ``_sdata_*`` attributes (``name, sname, suuid, class, ctime,
+parent_sname, project_sname, topology_class, version``) are populated
+automatically and back the identity/provenance of the object.
+
+
+JSON-LD / RDF
+-------------
+
+.. code-block:: python
+
+    doc = data.to_jsonld()       # dict, self-describing JSON-LD
+    ttl = data.to_turtle()       # RDF/Turtle via rdflib, else the JSON-LD
+
+The object's ``@id`` is its DID (``did:suuid:<sname>:sdata``); ``@type`` combines
+the sdata class and the BFO topology IRI. Attributes **with a unit** become
+``qudt:Quantity`` nodes, unit-less ones become typed literals; the ``ontology``
+field is always the ``@type``/class of the value. DataFrame columns are emitted
+as an ordered ``csvw:column`` list.
+
+.. code-block:: json
+
+    {
+      "@id": "did:suuid:DataFrame__specimen_01__3003...:sdata",
+      "@type": ["sdata:DataFrame", "bfo:BFO_0000004"],
+      "name": "specimen_01",
+      "sdata:max_force": {
+        "@type": ["qudt:Quantity", "bfo:Quality"],
+        "value": {"@value": 12.5, "@type": "xsd:double"},
+        "unitRef": "unit:KiloN", "symbol": "kN"
+      },
+      "columns": [{"name": "force", "datatype": "xsd:double"}]
+    }
+
+``from_jsonld`` reconstructs a :class:`~sdata.metadata.Metadata` from such a
+document.
+
+
+Sidecar files
+-------------
+
+Metadata can be written as an independent ``<sname>.meta.jsonld`` file right next
+to the data blob (default off, so existing behaviour is unchanged):
+
+.. code-block:: python
+
+    data.to_json("specimen_01.sjson", sidecar=True)   # writes both files
+    data.to_parquet(path="out", sidecar=True)         # <sname>.spq + sidecar
+
+    from sdata.base import Base
+    md = Base.read_sidecar("out/DataFrame__specimen_01__3003....meta.jsonld")
+
+
+Schema / templates
+-------------------
+
+A :class:`~sdata.schema.MetadataSchema` declares the expected attributes of a
+data class and can *validate* and *auto-complete* metadata:
+
+.. code-block:: python
+
+    from sdata.schema import MetadataSchema, AttrSpec
+
+    schema = MetadataSchema("TensileTest", [
+        AttrSpec("max_force", dtype="float", unit="kN", required=True,
+                 ontology="bfo:Quality"),
+        AttrSpec("phase", dtype="str", allowed=["ferrite", "martensite"]),
+    ])
+
+    report = data.metadata.validate(schema)   # ValidationReport (truthy if ok)
+    data.metadata.apply_schema(schema)         # fill defaults/units/ontology
+    schema.to_json_schema()                    # JSON Schema (Draft 2020-12)
+
+A :class:`~sdata.base.Base` subclass may set ``SDATA_SCHEMA`` to have its
+metadata auto-completed on construction; ``obj.validate()`` checks against it.
+
+
+Verifiable Credentials
+----------------------
+
+The JSON-LD can be signed as a W3C Verifiable Credential using the bundled,
+pure-Python Ed25519 stack (no external crypto dependency):
+
+.. code-block:: python
+
+    from sdata.did import keys, pub_from_priv_jwk
+
+    priv = keys.gen_ed25519_jwk()
+    vc = data.metadata.to_verifiable_credential("did:example:issuer", priv)
+    subject = data.metadata.from_verifiable_credential(vc, pub_from_priv_jwk(priv))
+
+
+Interactive use
+---------------
+
+.. code-block:: python
+
+    data.metadata.a.max_force          # attribute access + Jupyter tab-completion
+    data.metadata.get_prefixed("_sdata")  # subset by attribute-name prefix
+    data.metadata                       # rich _repr_html_ table in Jupyter


### PR DESCRIPTION
Die Doku spiegelte noch die alte (deprecated) `Data`/`to_xlsx`-API und erwähnte das neue Rückgrat (JSON-LD/Sidecar/Schema/VC) gar nicht.

## Änderungen
- **README.md**: Quickstart auf die aktuelle `DataFrame`-API; neue Sektion **„Machine-readable metadata (JSON-LD / Linked Data)"** mit `to_jsonld`/`to_turtle`, Sidecar, `MetadataSchema`, Verifiable Credentials, interaktiven Helfern + Beispiel-JSON-LD; Attribut-Liste um `ontology`, dtype-Liste um `list/bytes/json/uri` (+ `strict`); toten travis-ci-Badge entfernt.
- **docs/source/api.rst**: autodoc für `base, dtypes, semantic, vocab, units, schema, interactive, timestamp` (vorher nur `sdata` + `metadata`).
- **docs/source/usage/metadata_jsonld.rst** (neu): narrativer Guide (Modell, JSON-LD/RDF, Sidecar, Schema/Templates, VC, Interaktivität, optionale Extras) + in die `index`-Toctree aufgenommen.

## Verifikation
Alle in der Doku gezeigten API-Aufrufe per Smoke-Test geprüft; RST-Underlines validiert. Doku-only, keine Code-/Coverage-Änderung.