### PR TITLE
chore: bump version 1.0.0 → 1.1.0

### DIFF
--- a/sdata/__init__.py
+++ b/sdata/__init__.py
@@ -1,7 +1,7 @@
 # -*-coding: utf-8-*-
 from __future__ import division
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 __revision__ = None
 __version_info__ = tuple([int(num) for num in __version__.split('.')])
 


### PR DESCRIPTION
Minor-Release. Umfangreiche **additive, API-kompatible** Erweiterungen des Metadaten-Rückgrats (dtype-Registry, JSON-LD/RDF, Sidecar, MetadataSchema, Verifiable Credentials, Interaktivität, CSVW-Spalten) + Modernisierung (pytz→zoneinfo, `python_requires>=3.9`, Kern-Deps nur `numpy/pandas/suuid`). Öffentliche Python-API bleibt rückwärtskompatibel; `__version_info__` → `(1, 1, 0)`. 466 passed, Coverage 100 %.