### PR TITLE
feat(dataframe): Spalten-Ergonomie für sclass.DataFrame (PR2)

### DIFF
--- a/sdata/interactive.py
+++ b/sdata/interactive.py
@@ -7,7 +7,7 @@ tabulate-Abhängigkeit).
 """
 import html as _html
 
-__all__ = ["attribute_html", "metadata_html", "AttrAccessor"]
+__all__ = ["attribute_html", "metadata_html", "AttrAccessor", "ColumnAccessor"]
 
 
 def _esc(value):
@@ -73,3 +73,44 @@ class AttrAccessor:
 
     def __repr__(self):
         return "AttrAccessor({})".format(self.__dir__())
+
+
+class ColumnAccessor:
+    """Spalten-Annotation-Autocomplete: ``df.col.weight`` / ``df.col['weight']``.
+
+    Liefert das Spalten-:class:`Attribute` aus ``column_metadata``; dessen Felder
+    lassen sich direkt mutieren (``df.col.weight.unit = 'kg'``). Zum Anlegen/Setzen
+    ganzer Felder dient :meth:`~sdata.sclass.dataframe.DataFrame.set_column`.
+
+    Liegt – wie :class:`AttrAccessor` – bewusst auf einem eigenen Objekt, damit die
+    Tab-Completion nur Spaltennamen zeigt und keine Methoden überschattet.
+    """
+
+    def __init__(self, owner):
+        object.__setattr__(self, "_owner", owner)
+
+    def _cm(self):
+        return self._owner.column_metadata
+
+    def __getattr__(self, name):
+        attr = self._cm().get(name)
+        if attr is None:
+            raise AttributeError(name)
+        return attr
+
+    def __getitem__(self, name):
+        attr = self._cm().get(str(name))
+        if attr is None:
+            raise KeyError(name)
+        return attr
+
+    def __setattr__(self, name, value):
+        raise AttributeError(
+            "use df.set_column({0!r}, ...) or mutate fields "
+            "(df.col.{0}.unit = ...) instead of assigning df.col.{0}".format(name))
+
+    def __dir__(self):
+        return [str(c) for c in self._owner.df.columns if str(c).isidentifier()]
+
+    def __repr__(self):
+        return "ColumnAccessor({})".format(self.__dir__())

--- a/sdata/sclass/dataframe.py
+++ b/sdata/sclass/dataframe.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, Optional, Union
 import logging
 
 from sdata.metadata import Metadata, Attribute
-# from sdata.sclass.blob import Blob  # Assuming Blob is in sdata.blob or adjust import
 from sdata.base import Base
+from sdata.interactive import ColumnAccessor
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,9 @@ class DataFrame(Base):
 
         self._df = pd.DataFrame()
         if df is not None:
-            self.df = df
+            # Bei der Konstruktion vom Nutzer gelieferte column_metadata bewahren
+            # (kein Prune); Waisen werden nur gemeldet.
+            self._assign_df(df, prune=False)
             self._warn_orphan_columns()
 
     def _warn_orphan_columns(self):
@@ -92,13 +94,34 @@ class DataFrame(Base):
         return self._df
 
     def _set_df(self, df):
+        # Zuweisung über die ``df``-Property synchronisiert die column_metadata und
+        # entfernt dabei Attribute zu nicht mehr vorhandenen Spalten (prune).
+        self._assign_df(df, prune=True)
+
+    def _assign_df(self, df, prune=False):
         if isinstance(df, pd.DataFrame):
             self._df = df
             if self._df.index.name is None:
                 self._df.index.name = "index"
-            for col in df.columns:
-                dtype = df[col].dtype
-                self._column_metadata.add(name=col, value=dtype.name)
+            self._sync_column_metadata(prune=prune)
+
+    def _sync_column_metadata(self, prune=False):
+        """Halte column_metadata mit den df-Spalten konsistent.
+
+        Ergänzt fehlende Spalten-Attribute (Wert = pandas-dtype-Name) und bewahrt
+        dabei vorhandene Annotationen (unit/label/description/ontology), da
+        :meth:`~sdata.metadata.Metadata.set_attr` vorhandene Attribute wiederverwendet.
+
+        :param prune: wenn ``True``, werden Attribute zu Spalten entfernt, die nicht
+          (mehr) im df vorhanden sind (z. B. nach einer df-Neuzuweisung).
+        """
+        colnames = [str(c) for c in self._df.columns]
+        for col in self._df.columns:
+            self._column_metadata.add(name=str(col), value=self._df[col].dtype.name)
+        if prune:
+            for key in list(self._column_metadata.keys()):
+                if key not in colnames:
+                    self._column_metadata.pop(key)
 
     df = property(fget=_get_df, fset=_set_df, doc="df object(pandas.DataFrame)")
 
@@ -111,6 +134,59 @@ class DataFrame(Base):
           column (e.g. ``label``/``unit`` annotations).
         """
         return self._column_metadata
+
+    def get_column(self, name) -> Optional[Attribute]:
+        """Return the column :class:`~sdata.metadata.Attribute` for ``name``.
+
+        :param name: column name.
+        :return: the column's :class:`Attribute`, or ``None`` if unknown.
+        """
+        return self._column_metadata.get(str(name))
+
+    def set_column(self, name, *, unit=None, label=None, description=None,
+                   ontology=None, required=None, dtype=None) -> Attribute:
+        """Annotate a column; writes through to :attr:`column_metadata`.
+
+        Only the provided fields are changed; existing annotations are preserved
+        (delegates to :meth:`~sdata.metadata.Metadata.set_attr`). A warning is
+        logged if ``name`` is not a column of the current df.
+
+        :param name: column name.
+        :param unit: physical unit (e.g. ``"kg"``).
+        :param label: human-readable label.
+        :param description: free-text description.
+        :param ontology: CURIE/IRI of the column's class.
+        :param required: whether the column is required.
+        :param dtype: declared dtype string.
+        :return: the (created or updated) column :class:`Attribute`.
+        """
+        name = str(name)
+        fields = {"unit": unit, "label": label, "description": description,
+                  "ontology": ontology, "required": required, "dtype": dtype}
+        self._column_metadata.set_attr(
+            name, **{k: v for k, v in fields.items() if v is not None})
+        if name not in {str(c) for c in self._df.columns}:
+            logger.warning("set_column: %r is not a df column", name)
+        return self._column_metadata.get(name)
+
+    @property
+    def col(self) -> ColumnAccessor:
+        """Column-annotation accessor: ``df.col.weight`` / ``df.col['weight']``.
+
+        Returns the column :class:`Attribute`; mutate its fields in place
+        (``df.col.weight.unit = 'kg'``) or use :meth:`set_column`.
+        """
+        return ColumnAccessor(self)
+
+    @property
+    def column_units(self) -> Dict[str, str]:
+        """Mapping ``{column: unit}`` (in df-column order) from column_metadata."""
+        units = {}
+        for col in self._df.columns:
+            attr = self._column_metadata.get(str(col))
+            if attr is not None:
+                units[str(col)] = attr.unit
+        return units
 
     def __len__(self) -> int:
         """Number of rows of the underlying df."""

--- a/tests/test_sclass_dataframe_columns.py
+++ b/tests/test_sclass_dataframe_columns.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Spalten-Ergonomie (PR2) für sdata/sclass/dataframe.py:
+``set_column``/``get_column``, ``col``-Accessor, ``column_units`` und das
+Synchronisieren/Prunen der column_metadata bei df-Neuzuweisung.
+"""
+import logging
+
+import pandas as pd
+import pytest
+
+from sdata.metadata import Attribute
+from sdata.sclass.dataframe import DataFrame
+
+
+def _df():
+    return pd.DataFrame({"weight": [10, 20, 30], "height": [1.5, 1.6, 1.7]})
+
+
+def test_set_and_get_column():
+    sdf = DataFrame(df=_df(), name="x")
+    attr = sdf.set_column("weight", unit="kg", label="Gewicht")
+    assert isinstance(attr, Attribute)
+    got = sdf.get_column("weight")
+    assert got.unit == "kg"
+    assert got.label == "Gewicht"
+    # unbekannte Spalte -> None
+    assert sdf.get_column("nope") is None
+
+
+def test_set_column_preserves_other_fields():
+    sdf = DataFrame(df=_df(), name="x")
+    sdf.set_column("weight", unit="kg")
+    sdf.set_column("weight", label="Gewicht")        # nur label setzen
+    attr = sdf.get_column("weight")
+    assert attr.unit == "kg" and attr.label == "Gewicht"
+
+
+def test_set_column_orphan_warns(caplog):
+    sdf = DataFrame(df=_df(), name="x")
+    with caplog.at_level(logging.WARNING):
+        sdf.set_column("nope", unit="x")
+    assert any("not a df column" in r.getMessage() for r in caplog.records)
+    # Annotation wird dennoch angelegt
+    assert sdf.get_column("nope") is not None
+
+
+def test_col_accessor_get():
+    sdf = DataFrame(df=_df(), name="x")
+    assert isinstance(sdf.col.weight, Attribute)
+    assert isinstance(sdf.col["weight"], Attribute)
+    with pytest.raises(AttributeError):
+        sdf.col.unknown
+    with pytest.raises(KeyError):
+        sdf.col["unknown"]
+
+
+def test_col_accessor_setattr_raises():
+    sdf = DataFrame(df=_df(), name="x")
+    with pytest.raises(AttributeError):
+        sdf.col.weight = 1
+
+
+def test_col_accessor_dir_and_repr():
+    sdf = DataFrame(df=_df(), name="x")
+    assert "weight" in dir(sdf.col) and "height" in dir(sdf.col)
+    assert "ColumnAccessor" in repr(sdf.col)
+
+
+def test_col_mutate_in_place_persists():
+    sdf = DataFrame(df=_df(), name="x")
+    sdf.col["weight"].unit = "kg"
+    sdf.col.weight.label = "Gewicht"
+    attr = sdf.get_column("weight")
+    assert attr.unit == "kg" and attr.label == "Gewicht"
+
+
+def test_column_units_view():
+    sdf = DataFrame(df=_df(), name="x")
+    sdf.set_column("weight", unit="kg")
+    cu = sdf.column_units
+    assert cu == {"weight": "kg", "height": "-"}
+    assert list(cu) == ["weight", "height"]          # df-Spaltenreihenfolge
+
+
+def test_sync_prunes_removed_columns_on_reassign():
+    sdf = DataFrame(df=_df(), name="x")
+    sdf.set_column("weight", unit="kg")
+    # height entfällt -> Annotation wird geprunt, weight bleibt erhalten
+    sdf.df = pd.DataFrame({"weight": [3, 4]})
+    assert sdf.get_column("height") is None
+    assert sdf.get_column("weight").unit == "kg"
+    # neue Spalte -> Annotation wird ergänzt
+    sdf.df = pd.DataFrame({"weight": [5], "depth": [6]})
+    assert sdf.get_column("depth") is not None
+    assert sdf.get_column("weight").unit == "kg"
+
+
+def test_init_keeps_user_orphan_without_pruning():
+    # Bei der Konstruktion gelieferte column_metadata bleibt erhalten (kein Prune)
+    sdf = DataFrame(df=_df(), column_metadata={"zzz": {"unit": "x"}}, name="x")
+    assert sdf.get_column("zzz") is not None


### PR DESCRIPTION
Zweiter von vier PRs zur Verbesserung von `sdata/sclass/dataframe.py` — **Spalten-Ergonomie**. Strikt additiv (load-bearing API unverändert), lokale CI grün, 100 % Coverage.

## Neu
- **`set_column(name, *, unit/label/description/ontology/required/dtype)`** — annotiert eine Spalte schreibdurchgängig auf `column_metadata`; nur gesetzte Felder ändern sich, vorhandene Annotationen bleiben erhalten (über `Metadata.set_attr`). Warnt (nicht-brechend), wenn `name` keine df-Spalte ist.
- **`get_column(name) -> Attribute`** (oder `None`).
- **`col`-Accessor** (`ColumnAccessor`, gespiegelt von `AttrAccessor` in `interactive.py`): `df.col.weight` / `df.col["weight"]` liefern das Spalten-`Attribute` (Tab-Completion via `__dir__`); Felder direkt mutierbar (`df.col.weight.unit = "kg"`). Zuweisung `df.col.x = ...` wirft bewusst `AttributeError` und verweist auf `set_column`.
- **`column_units`** — Mapping `{Spalte: Einheit}` in df-Spaltenreihenfolge.

## Sync/Prune
- `_sync_column_metadata()` im `df`-Setter: ergänzt neue Spalten **und** entfernt Attribute zu nicht mehr vorhandenen Spalten (`prune=True` bei Neuzuweisung); vorhandene `unit`/`label` überlebende Spalten bleiben erhalten.
- Bei der **Konstruktion** gelieferte `column_metadata` bleibt unverändert (`prune=False`, nur Waisen-Warnung aus PR1) — kein Verlust expliziter Nutzereingaben.

## Tests
- Neu: `tests/test_sclass_dataframe_columns.py` (set/get, Accessor get/set/dir/repr/Fehlerpfade, In-place-Mutation, Sync/Prune bei Neuzuweisung, units-View).

Lokale CI grün (`ci/local-ci.sh`); `dataframe.py` und `interactive.py` = **100 %**, Projekt-Total = **100 %** (486 passed, 9 optionale Skips).