### PR TITLE
feat(dataframe): Tabellen-Schema-Validierung – TableSchema (PR4)

### DIFF
--- a/sdata/schema.py
+++ b/sdata/schema.py
@@ -22,7 +22,7 @@ try:  # optionales Backend ([schema]=jsonschema)
 except ImportError:  # pragma: no cover - abhängig vom Environment
     _jsonschema = None
 
-__all__ = ["AttrSpec", "MetadataSchema", "ValidationReport"]
+__all__ = ["AttrSpec", "MetadataSchema", "TableSchema", "ValidationReport"]
 
 # sdata-dtype -> JSON-Schema-Typ
 _JSON_TYPE = {
@@ -188,3 +188,86 @@ class MetadataSchema:
             return ValidationReport(ok=True)
         except _jsonschema.ValidationError as exp:
             return ValidationReport(ok=False, messages=[str(exp).splitlines()[0]])
+
+
+class TableSchema:
+    """Spalten-Schema für eine :class:`~sdata.sclass.dataframe.DataFrame`.
+
+    Deklariert je Spalte den erwarteten ``name``/``dtype``/``unit``/``required``
+    (wiederverwendet :class:`AttrSpec`) und kann ein DataFrame dagegen *validieren*
+    sowie dessen ``column_metadata`` aus dem Schema *vervollständigen*.
+
+    Der dtype wird gegen die tatsächlichen ``df.dtypes`` geprüft, die Einheit gegen
+    die ``column_metadata``-Annotation der Spalte.
+    """
+
+    def __init__(self, name, columns):
+        self.name = name
+        self.columns = list(columns)
+
+    @property
+    def _by_name(self):
+        return {s.name: s for s in self.columns}
+
+    def to_dict(self):
+        return {"name": self.name, "columns": [s.to_dict() for s in self.columns]}
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(name=d.get("name", "N.N."),
+                   columns=[AttrSpec.from_dict(s) for s in d.get("columns", [])])
+
+    def validate(self, dataframe):
+        """Prüfe ein :class:`DataFrame` gegen das Spalten-Schema.
+
+        Wirft nie; liefert einen :class:`ValidationReport` mit fehlenden Spalten,
+        dtype-Abweichungen (gegen ``df.dtypes``), Einheiten-Abweichungen (gegen
+        ``column_metadata``) und zusätzlichen (nicht spezifizierten) Spalten.
+        """
+        report = ValidationReport(ok=True)
+        df = dataframe.df
+        cm = dataframe.column_metadata
+        present = {str(c) for c in df.columns}
+        specs = self._by_name
+        for name, spec in specs.items():
+            if name not in present:
+                report.missing.append(name)
+                continue
+            actual = dtypes.resolve(str(df[name].dtype))
+            if actual is not None and dtypes.resolve(spec.dtype) != actual:
+                report.type_errors.append((name, spec.dtype))
+            if spec.unit not in ("-", ""):
+                attr = cm.get(name)
+                attr_unit = attr.unit if attr is not None else "-"
+                if units.normalize_symbol(attr_unit) != units.normalize_symbol(spec.unit):
+                    report.unit_errors.append(name)
+        for name in present:
+            if name not in specs:
+                report.extra.append(name)
+        report.ok = not (report.missing or report.type_errors or report.unit_errors)
+        return report
+
+    def apply(self, dataframe):
+        """Vervollständige ``column_metadata`` in-place aus dem Schema.
+
+        Für jede im df vorhandene Schema-Spalte: fehlende Annotation anlegen bzw.
+        leere ``unit``/``ontology``/``description`` auffüllen. Gibt ``dataframe`` zurück.
+        """
+        cm = dataframe.column_metadata
+        present = {str(c) for c in dataframe.df.columns}
+        for spec in self.columns:
+            if spec.name not in present:
+                continue
+            attr = cm.get(spec.name)
+            if attr is None:
+                cm.set_attr(spec.name, spec.default, dtype=spec.dtype,
+                            unit=spec.unit, ontology=spec.ontology,
+                            description=spec.description)
+                continue
+            if attr.unit in ("-", "", None) and spec.unit not in ("-", ""):
+                attr.unit = spec.unit
+            if not attr.ontology and spec.ontology:
+                attr.ontology = spec.ontology
+            if not attr.description and spec.description:
+                attr.description = spec.description
+        return dataframe

--- a/sdata/sclass/dataframe.py
+++ b/sdata/sclass/dataframe.py
@@ -34,6 +34,9 @@ def _require_parquet(engine: str = "pyarrow") -> None:
 class DataFrame(Base):
     SDATA_CLS = "sdata.sclass.dataframe.DataFrame"
 
+    #: optionales :class:`~sdata.schema.TableSchema`; beim Init angewandt (Default None)
+    TABLE_SCHEMA = None
+
 
     def __init__(
             self,
@@ -75,6 +78,10 @@ class DataFrame(Base):
             # (kein Prune); Waisen werden nur gemeldet.
             self._assign_df(df, prune=False)
             self._warn_orphan_columns()
+
+        # Optionales Tabellen-Schema anwenden (column_metadata vollqualifizieren)
+        if self.TABLE_SCHEMA is not None:
+            self.TABLE_SCHEMA.apply(self)
 
     def _warn_orphan_columns(self):
         """Warne, wenn column_metadata-Schlüssel keiner df-Spalte entsprechen."""
@@ -188,6 +195,19 @@ class DataFrame(Base):
             if attr is not None:
                 units[str(col)] = attr.unit
         return units
+
+    def validate_table(self, schema=None):
+        """Validate the df/column_metadata against a :class:`~sdata.schema.TableSchema`.
+
+        :param schema: a ``TableSchema``; defaults to the class-level
+          :attr:`TABLE_SCHEMA`. Without any schema the result is trivially valid.
+        :return: a :class:`~sdata.schema.ValidationReport` (truthy if valid).
+        """
+        from sdata.schema import ValidationReport
+        schema = schema or self.TABLE_SCHEMA
+        if schema is None:
+            return ValidationReport(ok=True)
+        return schema.validate(self)
 
     def __len__(self) -> int:
         """Number of rows of the underlying df."""

--- a/tests/test_sclass_dataframe_tableschema.py
+++ b/tests/test_sclass_dataframe_tableschema.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""Tabellen-Schema-Validierung (PR4): sdata.schema.TableSchema sowie
+DataFrame.validate_table / der DataFrame.TABLE_SCHEMA-Hook.
+"""
+import pandas as pd
+
+from sdata.schema import TableSchema, AttrSpec
+from sdata.sclass.dataframe import DataFrame
+
+
+def _df():
+    return pd.DataFrame({"weight": [10, 20, 30], "height": [1.5, 1.6, 1.7]})
+
+
+# ----------------------------------------------------------------- validate
+def test_validate_ok():
+    sdf = DataFrame(df=_df(), name="x")
+    sdf.set_column("weight", unit="kg")
+    schema = TableSchema("t", [AttrSpec("weight", dtype="int", unit="kg")])
+    rep = sdf.validate_table(schema)
+    assert rep.ok
+    assert rep.extra == ["height"]                 # nicht spezifiziert, aber kein Fehler
+
+
+def test_validate_missing_column():
+    sdf = DataFrame(df=_df(), name="x")
+    schema = TableSchema("t", [AttrSpec("zzz", dtype="float")])
+    rep = sdf.validate_table(schema)
+    assert not rep.ok and "zzz" in rep.missing
+
+
+def test_validate_dtype_mismatch():
+    sdf = DataFrame(df=_df(), name="x")
+    schema = TableSchema("t", [AttrSpec("weight", dtype="float")])  # ist int
+    rep = sdf.validate_table(schema)
+    assert not rep.ok and rep.type_errors and rep.type_errors[0][0] == "weight"
+
+
+def test_validate_unit_mismatch_and_match():
+    sdf = DataFrame(df=_df(), name="x")
+    schema = TableSchema("t", [AttrSpec("weight", dtype="int", unit="kg")])
+    assert "weight" in sdf.validate_table(schema).unit_errors   # Spalte hat "-"
+    sdf.set_column("weight", unit="kg")
+    assert sdf.validate_table(schema).ok                        # jetzt passend
+
+
+# -------------------------------------------------------------------- apply
+def test_apply_fills_annotations():
+    sdf = DataFrame(df=_df(), name="x")
+    schema = TableSchema("t", [AttrSpec("weight", unit="kg",
+                                        ontology="bfo:Quality",
+                                        description="the weight")])
+    schema.apply(sdf)
+    attr = sdf.get_column("weight")
+    assert attr.unit == "kg"
+    assert attr.ontology == "bfo:Quality"
+    assert attr.description == "the weight"
+
+
+def test_apply_recreates_missing_attr():
+    sdf = DataFrame(df=_df(), name="x")
+    sdf.column_metadata.pop("weight")              # Annotation entfernen, Spalte bleibt
+    assert sdf.get_column("weight") is None
+    schema = TableSchema("t", [AttrSpec("weight", dtype="int", unit="kg")])
+    schema.apply(sdf)
+    assert sdf.get_column("weight").unit == "kg"
+
+
+def test_apply_skips_absent_column():
+    sdf = DataFrame(df=_df(), name="x")
+    schema = TableSchema("t", [AttrSpec("zzz", unit="kg")])     # nicht im df
+    schema.apply(sdf)
+    assert sdf.get_column("zzz") is None           # nichts angelegt
+
+
+# ---------------------------------------------------------------- to/from dict
+def test_tableschema_to_from_dict_roundtrip():
+    schema = TableSchema("t", [AttrSpec("weight", dtype="int", unit="kg"),
+                               AttrSpec("height", dtype="float", unit="m")])
+    d = schema.to_dict()
+    back = TableSchema.from_dict(d)
+    assert back.name == "t"
+    assert [c.name for c in back.columns] == ["weight", "height"]
+    assert back._by_name["weight"].unit == "kg"
+
+
+# ----------------------------------------------------- validate_table method
+def test_validate_table_default_without_schema():
+    sdf = DataFrame(df=_df(), name="x")
+    assert sdf.validate_table().ok                 # kein Schema -> trivial gültig
+
+
+def test_validate_table_explicit_schema():
+    sdf = DataFrame(df=_df(), name="x")
+    rep = sdf.validate_table(TableSchema("s", [AttrSpec("weight", dtype="float")]))
+    assert not rep.ok
+
+
+# --------------------------------------------------------- TABLE_SCHEMA hook
+class _TblDataFrame(DataFrame):
+    TABLE_SCHEMA = TableSchema("auto", [
+        AttrSpec("weight", dtype="int", unit="kg", ontology="bfo:Quality"),
+    ])
+
+
+def test_table_schema_hook_applied_at_init():
+    sdf = _TblDataFrame(df=_df())
+    # Annotationen wurden beim Init aus dem Schema vervollständigt
+    assert sdf.get_column("weight").unit == "kg"
+    assert sdf.get_column("weight").ontology == "bfo:Quality"
+    # validate_table() ohne Argument nutzt den Hook
+    assert sdf.validate_table().ok


### PR DESCRIPTION
Vierter und letzter PR zur Verbesserung von `sdata/sclass/dataframe.py` — **Tabellen-Schema-Validierung**. Strikt additiv (load-bearing API unverändert), lokale CI grün, 100 % Coverage.

## Neu
- **`sdata.schema.TableSchema(name, columns: [AttrSpec])`** — wiederverwendet `AttrSpec`/`ValidationReport`:
  - **`validate(dataframe) -> ValidationReport`**: fehlende Spalten, dtype-Abweichungen (gegen `df.dtypes`), Einheiten-Abweichungen (gegen `column_metadata`) und zusätzliche, nicht spezifizierte Spalten. Wirft nie.
  - **`apply(dataframe)`**: vervollständigt `column_metadata` in-place (fehlende Annotation anlegen bzw. leere `unit`/`ontology`/`description` auffüllen).
  - `to_dict`/`from_dict`.
- **`DataFrame.validate_table(schema=None)`** — validiert gegen `schema` oder den klassenweiten `TABLE_SCHEMA`; ohne Schema trivial gültig.
- **`DataFrame.TABLE_SCHEMA`** (Default `None`) — wird, **analog `Base.SDATA_SCHEMA`**, beim Init angewandt, um `column_metadata` zu vollqualifizieren.

## Tests
- Neu: `tests/test_sclass_dataframe_tableschema.py` — `validate` ok/missing/dtype/unit(+match), `apply` inkl. Neuanlage/Skip, `to_dict`/`from_dict`-Round-Trip, `validate_table` default/explizit, Hook-Anwendung beim Init.

Lokale CI grün (`ci/local-ci.sh`); `dataframe.py` und `schema.py` = **100 %**, Projekt-Total = **100 %** (507 passed, 9 optionale Skips).

---

Schließt die 4-PR-Reihe zur DataFrame-Verbesserung ab (PR1 #51 Korrektheit, PR2 #52 Spalten-Ergonomie, PR3 #53 Interop, PR4 Schema).