### PR TITLE
docs(dataframe): DataFrame-I/O, Spalten-API & TableSchema dokumentieren; v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,40 @@ The optional semantic backends degrade gracefully to pure Python (no hard
 dependency): `pip install "sdata[rdf]"` (rdflib), `sdata[units]` (pint),
 `sdata[schema]` (jsonschema). Core install needs only `numpy`, `pandas`, `suuid`.
 
+## Tabular data (`DataFrame`)
+
+`DataFrame` wraps a pandas frame plus per-column metadata and serializes to
+Parquet, CSV, Arrow/Feather, dict/JSON and JSON-LD — embedded or as a sidecar.
+
+```python
+import pandas as pd
+from sdata.sclass.dataframe import DataFrame
+
+sdf = DataFrame(df=pd.DataFrame({"weight": [10, 20], "height": [1.5, 1.6]}),
+                name="specimen_01", description="a tension test")
+
+# per-column annotations (only the fields you pass are changed)
+sdf.set_column("weight", unit="kg", label="Gewicht", ontology="bfo:Quality")
+sdf.col["height"].unit = "m"          # mutate the column Attribute in place
+sdf.column_units                       # {'weight': 'kg', 'height': 'm'}
+
+# serialize (optional <sname>.meta.jsonld sidecar; bytes/str without a path)
+sdf.to_parquet(path="out", sidecar=True)      # out/<sname>.spq + sidecar
+sdf.to_csv(path="out")                         # data-only CSV (pure pandas)
+sdf.to_feather(path="out")                     # Arrow IPC (needs sdata[parquet])
+DataFrame.from_parquet("out/specimen_01.spq")
+
+# validate the table against a schema (missing/dtype/unit/extra columns)
+from sdata.schema import TableSchema, AttrSpec
+schema = TableSchema("TensileTable", [
+    AttrSpec("weight", dtype="int", unit="kg", required=True),
+])
+report = sdf.validate_table(schema)            # ValidationReport (truthy if ok)
+```
+
+Arrow/Feather/Parquet need `pip install "sdata[parquet]"`; CSV, dict and JSON-LD
+work with the core install. See `docs/source/usage/dataframe.rst` for details.
+
 ## Howto
 
   

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -24,6 +24,15 @@ sdata.base
     :show-inheritance:
 
 
+sdata.sclass.dataframe
+----------------------
+
+.. automodule:: sdata.sclass.dataframe
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 sdata.dtypes
 ------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,7 @@
    data_types
    paper
    usage/usage
+   usage/dataframe
    usage/metadata_jsonld
    api
    etc

--- a/docs/source/usage/dataframe.rst
+++ b/docs/source/usage/dataframe.rst
@@ -1,0 +1,110 @@
+Tabular data: the ``DataFrame`` container
+=========================================
+
+:class:`sdata.sclass.dataframe.DataFrame` is the self-describing tabular
+container (it supersedes the deprecated ``Data`` class). It wraps a pandas
+``DataFrame`` together with per-column metadata and serializes to Parquet, CSV,
+Arrow/Feather, dict/JSON and JSON-LD/RDF — with the qualifying metadata either
+embedded or written as an independent sidecar.
+
+.. code-block:: python
+
+    import pandas as pd
+    from sdata.sclass.dataframe import DataFrame
+
+    df = pd.DataFrame({"weight": [10, 20, 30], "height": [1.5, 1.6, 1.7]})
+    sdf = DataFrame(df=df, name="specimen_01", description="a tension test")
+
+The pandas frame is always available via ``sdf.df``; convenience pass-throughs
+(``len(sdf)``, ``sdf.shape``, ``sdf.columns``, ``sdf.dtypes``, ``sdf.head()``,
+``sdf.describe()``) delegate to it.
+
+
+Column metadata
+---------------
+
+Each column carries an :class:`~sdata.metadata.Attribute`
+(``unit``/``label``/``description``/``ontology``/``required``) in
+``sdf.column_metadata``. Annotate columns with :meth:`~sdata.sclass.dataframe.DataFrame.set_column`
+(only the fields you pass are changed; existing annotations are preserved):
+
+.. code-block:: python
+
+    sdf.set_column("weight", unit="kg", label="Gewicht", ontology="bfo:Quality")
+    sdf.set_column("height", unit="m")
+
+    sdf.get_column("weight").unit        # 'kg'
+    sdf.column_units                     # {'weight': 'kg', 'height': 'm'}
+
+The ``col`` accessor offers attribute-style access with Jupyter tab-completion;
+the returned ``Attribute`` can be mutated in place:
+
+.. code-block:: python
+
+    sdf.col.weight                       # -> Attribute (tab-completion on df.col.)
+    sdf.col["weight"].unit = "kg"        # mutate a field in place
+
+When the df is reassigned (``sdf.df = other``), ``column_metadata`` is kept in
+sync: new columns are added and annotations for removed columns are pruned, while
+surviving columns keep their ``unit``/``label``. Column metadata supplied at
+construction time is preserved as-is (orphan keys are only logged as a warning).
+
+
+Serialization
+-------------
+
+All writers take an optional ``path`` and a ``sidecar`` flag; without a path they
+return bytes (or, for CSV, a string). The metadata travels embedded in the
+binary formats and via the optional ``<sname>.meta.jsonld`` sidecar everywhere.
+
+.. code-block:: python
+
+    # Parquet (.spq) — metadata embedded in df.attrs / schema
+    sdf.to_parquet(path="out", sidecar=True)        # -> out/<sname>.spq + sidecar
+    DataFrame.from_parquet("out/<sname>.spq")
+    raw = sdf.to_parquet()                           # in-memory bytes
+    DataFrame.from_parquet_bytes(raw)
+
+    # CSV — data only (pure pandas); metadata via the sidecar
+    sdf.to_csv(path="out", sidecar=True)             # index dropped by default
+    DataFrame.from_csv("out/<sname>.csv")
+    text = sdf.to_csv()                              # CSV string
+
+    # Arrow / Feather — metadata embedded in the Arrow schema
+    table = sdf.to_arrow()                           # pyarrow.Table
+    DataFrame.from_arrow(table)
+    sdf.to_feather(path="out")                       # -> out/<sname>.feather
+    DataFrame.from_feather("out/<sname>.feather")
+
+    # dict / JSON-LD / RDF
+    d = sdf.to_dict();  DataFrame.from_dict(d)
+    sdf.to_jsonld();    sdf.to_turtle();    sdf.write_sidecar("out")
+
+Arrow, Feather and Parquet need pyarrow (``pip install "sdata[parquet]"``); CSV,
+dict and JSON-LD work with the core install. A missing backend raises a clear
+``ImportError`` pointing at the extra.
+
+
+Table schema validation
+------------------------
+
+A :class:`~sdata.schema.TableSchema` declares the expected columns (reusing
+:class:`~sdata.schema.AttrSpec`) and validates a DataFrame against them — missing
+columns, dtype mismatches (against ``df.dtypes``), unit mismatches (against
+``column_metadata``) and extra, unspecified columns:
+
+.. code-block:: python
+
+    from sdata.schema import TableSchema, AttrSpec
+
+    schema = TableSchema("TensileTable", [
+        AttrSpec("weight", dtype="int", unit="kg", required=True),
+        AttrSpec("height", dtype="float", unit="m"),
+    ])
+
+    report = sdf.validate_table(schema)   # ValidationReport (truthy if ok)
+    schema.apply(sdf)                      # fill missing column_metadata from the schema
+
+A :class:`~sdata.sclass.dataframe.DataFrame` subclass may set ``TABLE_SCHEMA`` to
+have its ``column_metadata`` auto-completed on construction; ``sdf.validate_table()``
+then checks against it — analogous to ``Base.SDATA_SCHEMA`` for metadata.

--- a/sdata/__init__.py
+++ b/sdata/__init__.py
@@ -1,7 +1,7 @@
 # -*-coding: utf-8-*-
 from __future__ import division
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 __revision__ = None
 __version_info__ = tuple([int(num) for num in __version__.split('.')])
 


### PR DESCRIPTION
Dokumentiert die in der 4-PR-Reihe (#51–#54) gewachsene öffentliche `DataFrame`-API und hebt die Version auf **1.2.0** (öffentliche API spürbar erweitert, vollständig rückwärtskompatibel).

## Inhalt
- **Neue Usage-Seite** `docs/source/usage/dataframe.rst`: Container & Convenience-Pass-throughs, Spalten-Metadaten (`set_column`/`get_column`/`col`/`column_units`), Serialisierung (Parquet/CSV/Arrow/Feather/dict/JSON-LD + Sidecar) und `TableSchema`-Validierung inkl. `TABLE_SCHEMA`-Hook.
- `index.rst`: Seite in den Toctree aufgenommen.
- `api.rst`: `automodule` für `sdata.sclass.dataframe` ergänzt (`sdata.schema` war bereits enthalten → `TableSchema` wird automatisch dokumentiert).
- `README.md`: kompakter Abschnitt **„Tabular data (`DataFrame`)"**.
- `__version__` **1.1.0 → 1.2.0** (Single Source of Truth; `setup.py` liest daraus).

## Verifikation
Lokale CI grün (`ci/local-ci.sh`), Projekt-Total **100 %** (507 passed, 9 optionale Skips). `test_base.py` vergleicht `SDATA_VERSION` gegen das importierte `__version__` (kein hartkodierter String) → Bump unkritisch.