### PR TITLE
ci(release): PyPI Trusted Publishing per GitHub Release (kein Test-CI)

### DIFF
--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -1,0 +1,39 @@
+# Generalprobe: lädt sdata nach TestPyPI (test.pypi.org), manuell ausgelöst.
+#
+# Wie release.yml, aber on: workflow_dispatch und Environment testpypi.
+# Erfordert einen separaten Trusted Publisher auf test.pypi.org
+# (Owner lepy, Repo sdata, Workflow release-testpypi.yml, Environment testpypi).
+name: release-testpypi
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Build sdist + wheel
+        run: uv build
+      - name: Check metadata
+        run: uvx twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write   # OIDC-Token für Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+# Veröffentlicht sdata auf PyPI, wenn ein GitHub Release publiziert wird.
+#
+# Bewusst KEIN Test-CI: die Testsuite läuft ausschließlich lokal
+# (ci/local-ci.sh). Dieser Workflow baut nur, prüft die Metadaten und lädt via
+# OIDC Trusted Publishing hoch — ohne API-Token-Secret.
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Build sdist + wheel
+        run: uv build
+      - name: Check metadata
+        run: uvx twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # OIDC-Token für Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,58 @@
+# Releasing sdata
+
+Releases gehen über **OIDC Trusted Publishing** (kein `PYPI_API_TOKEN`-Secret).
+Das Veröffentlichen eines GitHub Release löst `.github/workflows/release.yml` aus:
+ein `build`-Job (`uv build` + `uvx twine check`) und ein `publish`-Job
+(`pypa/gh-action-pypi-publish`, `environment: pypi`, `permissions: id-token: write`).
+
+> Hinweis: Es gibt bewusst **kein** Test-CI auf GitHub. Die Testsuite läuft
+> ausschließlich lokal über `ci/local-ci.sh`. Dieser Workflow baut/prüft/lädt nur.
+
+## Versionsquelle
+
+Die Version steht an **einer** Stelle:
+
+- `sdata/__init__.py` → `__version__`
+
+`setup.py` liest sie von dort; `pyproject.toml` enthält keine eigene Version.
+
+## Einmalige Voraussetzung (PyPI-seitig)
+
+Auf PyPI (und für die Generalprobe auf TestPyPI) je einen **Trusted Publisher**
+für das Projekt `sdata` registrieren:
+
+| Feld          | Production (pypi.org)        | TestPyPI (test.pypi.org)        |
+| ------------- | --------------------------- | ------------------------------- |
+| Owner         | `lepy`                      | `lepy`                          |
+| Repository    | `sdata`                     | `sdata`                         |
+| Workflow      | `release.yml`               | `release-testpypi.yml`          |
+| Environment   | `pypi`                      | `testpypi`                      |
+
+## Generalprobe (TestPyPI)
+
+```bash
+gh workflow run release-testpypi.yml
+gh run watch
+```
+
+Lädt den aktuellen `master`-Stand nach test.pypi.org. Installations-Check:
+
+```bash
+pip install -i https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ "sdata==X.Y.Z"
+```
+
+## Release (Production-PyPI)
+
+```bash
+# 1. Version in sdata/__init__.py bumpen, committen, pushen:
+git commit -am "release: vX.Y.Z" && git push
+
+# 2. GitHub Release + Tag anlegen -> triggert release.yml:
+gh release create vX.Y.Z --title vX.Y.Z --generate-notes
+gh run watch
+```
+
+Existiert der Tag bereits (z. B. vorab `git tag` gesetzt), erstellt
+`gh release create vX.Y.Z` das Release auf dem vorhandenen Tag und löst den
+Upload aus.


### PR DESCRIPTION
Reine **Publish**-Workflows für token-loses Veröffentlichen via OIDC Trusted Publishing. **Kein Test-CI auf GitHub** — die Testsuite bleibt strikt lokal (`ci/local-ci.sh`); diese Workflows bauen/prüfen/laden nur.

- `.github/workflows/release.yml` — `on: release.published`: `uv build` + `uvx twine check`, dann `pypa/gh-action-pypi-publish` (`environment: pypi`, `permissions: id-token: write`).
- `.github/workflows/release-testpypi.yml` — `on: workflow_dispatch`: dasselbe gegen `test.pypi.org` (`environment: testpypi`).
- `RELEASING.md` — Versionsquelle (`sdata/__init__.py`, single source), Trusted-Publisher-Setup (pypi + testpypi), Generalprobe- und Release-Schritte.

YAML validiert; Trigger korrekt (`release.published` bzw. `workflow_dispatch`). `uv build` nutzt das vorhandene `[build-system]` (`setuptools.build_meta`); Version bleibt einzig in `sdata/__init__.py`.