### PR TITLE
fix(dataframe): from_dict stellt description wieder her

### DIFF
--- a/sdata/sclass/dataframe.py
+++ b/sdata/sclass/dataframe.py
@@ -297,6 +297,7 @@ class DataFrame(Base):
         instance = cls()
         instance.metadata = metadata
         instance._column_metadata = column_metadata
+        instance.description = d.get("description", "")
 
         parquet_str = d['data'].get('parquet_bytes', '')
         parquet_bytes = base64.b64decode(parquet_str.encode("ascii"))

--- a/tests/test_sclass_dataframe_correctness.py
+++ b/tests/test_sclass_dataframe_correctness.py
@@ -103,6 +103,16 @@ def test_require_parquet_ok():
     dfm._require_parquet("pyarrow")
 
 
+def test_dict_roundtrip_preserves_description_and_annotations():
+    """to_dict/from_dict erhält description UND Spalten-Annotationen (Regression)."""
+    sdf = DataFrame(df=_df(), name="rt", description="a tension test")
+    sdf.set_column("weight", unit="kg", label="Gewicht", ontology="bfo:Quality")
+    r = DataFrame.from_dict(sdf.to_dict())
+    assert r.description == "a tension test"     # zuvor verloren (nur to_dict schrieb sie)
+    w = r.get_column("weight")
+    assert w.unit == "kg" and w.label == "Gewicht" and w.ontology == "bfo:Quality"
+
+
 def test_convenience_passthroughs():
     """Dünne Delegationen an das innere pandas-DataFrame."""
     sdf = DataFrame(df=_df(), name="c")


### PR DESCRIPTION
Per End-to-End-Lasttest der DataFrame-API gefunden: der **`dict`-Round-Trip verlor die `description`**. `to_dict()` schreibt sie auf Top-Level (`d["description"]`), aber `DataFrame.from_dict()` rekonstruierte nur `metadata`/`column_metadata`/`df` und ließ die `description` fallen. Die binären Formate (Parquet/Arrow/Feather) waren korrekt (Restore via `_restore_from_attrs`); nur der dict-Pfad nicht. Bestehende Unit-Tests prüften lediglich die Spalten → durchgerutscht.

- `from_dict`: `instance.description = d.get("description", "")`.
- Regression-Test (`test_dict_roundtrip_preserves_description_and_annotations`): dict-Round-Trip erhält `description` **und** Spalten-Annotationen (`unit`/`label`/`ontology`).

Lokale CI grün, Projekt-Total **100 %**.