### PR TITLE
docs: Docstring-Warnungen bereinigen + mkdocs --strict

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
           pip install -r docs/requirements.txt
           pip install -e ".[parquet]"
       - name: Build site
-        run: mkdocs build
+        run: mkdocs build --strict
       - name: Preserve legacy static assets (namespace, paper, slides)
         run: cp -r ns paper ipynb site/
       - uses: actions/upload-pages-artifact@v3

--- a/sdata/base.py
+++ b/sdata/base.py
@@ -559,7 +559,7 @@ def cls_from_spec(
     """
     Factory function to create an instance of a dynamically generated subclass.
 
-    :param sdata_class: The base class to inherit from (default: sdata.base:Base).
+    :param sdata_spec: The ``module:class`` spec to inherit from (default: ``sdata.base:Base``).
     :param sdata_attrs: Optional dict of custom attributes/methods to add to the class.
     :param kwargs: Keyword arguments to pass to the instance initialization.
     :return: generated class.
@@ -597,7 +597,7 @@ def sclass_factory(
     """
     Factory function to create an instance of a dynamically generated subclass.
 
-    :param sdata_class: The base class to inherit from (default: sdata.base:Base).
+    :param sdata_spec: The ``module:class`` spec to inherit from (default: ``sdata.base:Base``).
     :param sdata_attrs: Optional dict of custom attributes/methods to add to the class.
     :param kwargs: Keyword arguments to pass to the instance initialization.
     :return: An instance of the generated class.

--- a/sdata/metadata.py
+++ b/sdata/metadata.py
@@ -226,7 +226,7 @@ class Attribute(object):
     ontology = property(fget=_get_ontology, fset=_set_ontology, doc="Attribute ontology")
 
     def to_dict(self):
-        """:returns dict of attribute items"""
+        """Return a dict of the attribute's items (name/value/unit/dtype/...)."""
         return {'name': self.name,
                 'value': self.value,
                 'unit': self.unit,
@@ -808,7 +808,7 @@ class Metadata(object):
             metadata.update_hash(hashobject)
             hash.hexdigest()
 
-        :param hash: hash object
+        :param hashobject: hash object
         :return: hash_function().hexdigest()
         """
         if not (hasattr(hashobject, "update") and hasattr(hashobject, "hexdigest")):

--- a/sdata/timestamp.py
+++ b/sdata/timestamp.py
@@ -220,8 +220,8 @@ def parse_date(datestring, default_timezone=UTC):
                              is specified in the datestring. If this is set to
                              None then a naive datetime object is returned.
     :returns: A datetime.datetime instance
-    :raises: ParseError when there is a problem parsing the date or
-             constructing the datetime instance.
+    :raises ParseError: when there is a problem parsing the date or
+        constructing the datetime instance.
 
     """
     if not isinstance(datestring, _basestring):
@@ -298,13 +298,13 @@ class TimeStamp(object):
     @property
     def utc(self):
         """returns the utc.isoformat string
-        :returns str"""
+        :returns: str"""
         return get_utc_timestamp(self._datetime).isoformat()
 
     @property
     def local(self):
         """returns the datetime isoformat string for the local timezone
-        :returns str"""
+        :returns: str"""
         return get_local_timestamp(self._datetime).isoformat()
 
 def today_str():


### PR DESCRIPTION
Behebt die 10 griffe/mkdocstrings-Warnungen, die `--strict` im Doku-Build verhindert haben, und aktiviert `--strict` wieder (fängt künftig kaputte Links/Doc-Fehler ab).

- **metadata.py** — malformed `:returns dict…` → sauberer Docstring; falsch dokumentierter Param `hash` → `hashobject` (signaturkonform).
- **base.py** — `cls_from_spec`/`sclass_factory` dokumentierten `sdata_class`, der Parameter heißt aber `sdata_spec` → korrigiert.
- **timestamp.py** — `:returns str` → `:returns:`; `:raises:`-Direktive mit Exception-Typ (`:raises ParseError:`).
- **docs.yml** — `mkdocs build` → `mkdocs build --strict`.

Verifikation: `mkdocs build --strict` lokal **exit 0** (0 Warnungen); lokale CI grün, Coverage **100 %**. Reine Docstring-/Build-Änderungen, kein Verhaltensänderung.