### PR TITLE
ci(release): workflow_dispatch als manuellen Trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ name: release
 on:
   release:
     types: [published]
+  # Manueller Fallback: ein per API/Token erzeugtes Release-Event löst keine
+  # kaskadierenden Workflows aus (GitHub-Regel); workflow_dispatch triggert immer
+  # und erfüllt denselben Trusted Publisher (Workflow release.yml + Env pypi).
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Ein per API-/`gh`-Token erzeugtes `release`-Event löst (GitHub-Regel) keine kaskadierenden Workflows aus — daher hat das Veröffentlichen von `v1.2.0` `release.yml` nicht gestartet. `workflow_dispatch` triggert immer und erfüllt denselben Trusted Publisher (Workflow `release.yml` + Env `pypi`); der Build checkt master-HEAD aus (= Version 1.2.0).