### PR TITLE
feat(dataframe): native Per-Spalten-Field-Metadata in Arrow/Feather

### DIFF
--- a/docs/usage/dataframe.md
+++ b/docs/usage/dataframe.md
@@ -80,6 +80,18 @@ sdf.to_jsonld();    sdf.to_turtle();    sdf.write_sidecar("out")
     dict and JSON-LD work with the core install. A missing backend raises a clear
     `ImportError` pointing at the extra.
 
+!!! tip "Native per-column metadata (Arrow / Feather)"
+    Besides the `_sdata` JSON blob, `to_arrow()` (and therefore `to_feather()`)
+    attaches each column's `unit`/`label`/`description`/`ontology` **natively** to
+    that column's Arrow field metadata. Arrow-aware tools (DuckDB, Polars, pyarrow)
+    can read the per-column annotations without sdata, and `from_arrow()` merges
+    field metadata from foreign Arrow tables back into `column_metadata`.
+
+    ```python
+    table = sdf.to_arrow()
+    table.schema.field("weight").metadata   # {b'unit': b'kg', b'label': b'Gewicht', ...}
+    ```
+
 ## Table schema validation
 
 A [`TableSchema`][sdata.schema.TableSchema] declares the expected columns (reusing

--- a/sdata/sclass/dataframe.py
+++ b/sdata/sclass/dataframe.py
@@ -12,6 +12,10 @@ from sdata.interactive import ColumnAccessor
 
 logger = logging.getLogger(__name__)
 
+#: Spalten-Annotationen, die zusätzlich nativ als Arrow-Field-Metadata mitreisen
+#: (tool-agnostisch lesbar, z. B. von DuckDB/Polars), neben dem ``_sdata``-Blob.
+_COL_FIELD_KEYS = ("unit", "label", "description", "ontology")
+
 
 def _require_parquet(engine: str = "pyarrow") -> None:
     """Stelle sicher, dass die Parquet-Engine importierbar ist.
@@ -473,11 +477,31 @@ class DataFrame(Base):
         return tt
 
     # ---------------------------------------------------------------- Arrow
+    def _field_metadata_for(self, colname):
+        """Per-column annotations as an Arrow field-metadata ``bytes->bytes`` dict.
+
+        :param colname: column name.
+        :return: ``{b"unit": b"kg", ...}`` for the annotated keys, or ``None`` if the
+          column has no (non-default) annotation.
+        """
+        attr = self._column_metadata.get(str(colname))
+        if attr is None:
+            return None
+        md = {}
+        for key in _COL_FIELD_KEYS:
+            val = getattr(attr, key, "")
+            if val not in (None, "", "-"):
+                md[key.encode("utf-8")] = str(val).encode("utf-8")
+        return md or None
+
     def to_arrow(self):
         """Return a :class:`pyarrow.Table` with sdata metadata in the schema.
 
-        The metadata, column_metadata and description are embedded as JSON under
-        the ``b"_sdata"`` schema-metadata key (alongside pandas' own metadata).
+        The dataset metadata, column_metadata and description are embedded as JSON
+        under the ``b"_sdata"`` schema-metadata key. In addition, each column's
+        ``unit``/``label``/``description``/``ontology`` are attached **natively** to
+        that column's Arrow field metadata, so Arrow-aware tools (DuckDB, Polars,
+        pyarrow) can read the per-column annotations without sdata.
 
         :return: a ``pyarrow.Table``.
         :raises ImportError: if pyarrow is not installed (``pip install sdata[parquet]``).
@@ -485,17 +509,30 @@ class DataFrame(Base):
         _require_parquet("pyarrow")
         import pyarrow as pa
         table = pa.Table.from_pandas(self.df)
-        meta = dict(table.schema.metadata or {})
-        meta[b"_sdata"] = json.dumps({
+        fields = []
+        for field in table.schema:
+            fmd = self._field_metadata_for(field.name)
+            if fmd:
+                merged = dict(field.metadata or {})
+                merged.update(fmd)
+                field = field.with_metadata(merged)
+            fields.append(field)
+        schema_meta = dict(table.schema.metadata or {})
+        schema_meta[b"_sdata"] = json.dumps({
             "metadata": self.metadata.to_dict(),
             "column_metadata": self.column_metadata.to_dict(),
             "description": self.description,
         }).encode("utf-8")
-        return table.replace_schema_metadata(meta)
+        new_schema = pa.schema(fields, metadata=schema_meta)
+        return pa.Table.from_arrays(list(table.columns), schema=new_schema)
 
     @classmethod
     def from_arrow(cls, table):
         """Build a DataFrame from a :class:`pyarrow.Table` written by :meth:`to_arrow`.
+
+        The ``b"_sdata"`` schema blob is restored if present; per-column Arrow field
+        metadata (``unit``/``label``/...) is also merged into ``column_metadata``, so
+        tables produced by other Arrow-native tools keep their column annotations.
 
         :param table: a ``pyarrow.Table`` (sdata metadata restored if present).
         :return: a :class:`DataFrame` instance.
@@ -507,7 +544,24 @@ class DataFrame(Base):
         raw = (table.schema.metadata or {}).get(b"_sdata")
         if raw is not None:
             tt._restore_from_attrs(json.loads(raw.decode("utf-8")))
+        tt._merge_field_metadata(table.schema)
         return tt
+
+    def _merge_field_metadata(self, schema):
+        """Merge per-column Arrow field metadata into ``column_metadata`` (in-place).
+
+        :param schema: a ``pyarrow.Schema``; fields carrying ``unit``/``label``/...
+          metadata update the matching column's annotation.
+        """
+        cols = {str(c) for c in self._df.columns}
+        for field in schema:
+            if not field.metadata or field.name not in cols:
+                continue
+            kwargs = {key: field.metadata[key.encode("utf-8")].decode("utf-8")
+                      for key in _COL_FIELD_KEYS
+                      if key.encode("utf-8") in field.metadata}
+            if kwargs:
+                self.set_column(field.name, **kwargs)
 
     # -------------------------------------------------------------- Feather
     def to_feather(self, path=None, filename=None, sidecar=False, **kwargs):

--- a/tests/test_sclass_dataframe_field_metadata.py
+++ b/tests/test_sclass_dataframe_field_metadata.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""Native Per-Spalten-Field-Metadata in Arrow/Feather (zusätzlich zum _sdata-Blob)."""
+import pandas as pd
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+
+from sdata.sclass.dataframe import DataFrame
+
+
+def _df():
+    return pd.DataFrame({"weight": [10, 20, 30], "height": [1.5, 1.6, 1.7]})
+
+
+def test_to_arrow_attaches_per_field_metadata():
+    sdf = DataFrame(df=_df(), name="x")
+    sdf.set_column("weight", unit="kg", label="Gewicht", ontology="bfo:Quality")
+    # height bleibt un-annotiert
+    schema = sdf.to_arrow().schema
+    wmeta = schema.field("weight").metadata
+    assert wmeta[b"unit"] == b"kg"
+    assert wmeta[b"label"] == b"Gewicht"
+    assert wmeta[b"ontology"] == b"bfo:Quality"
+    assert schema.field("height").metadata is None       # keine Default-Annotation
+    assert b"_sdata" in (schema.metadata or {})           # Blob weiterhin vorhanden
+
+
+def test_field_metadata_for_none_cases():
+    sdf = DataFrame(df=_df(), name="x")
+    assert sdf._field_metadata_for("height") is None      # nur dtype-Default ("-"/"")
+    assert sdf._field_metadata_for("missing") is None     # keine solche Spalte
+
+
+def test_from_arrow_merges_field_metadata_without_blob():
+    # externe Arrow-Tabelle: nur Per-Field-Metadata, KEIN _sdata-Blob
+    t = pa.Table.from_pandas(_df())
+    fields = []
+    for f in t.schema:
+        if f.name == "weight":
+            f = f.with_metadata({b"unit": b"kg", b"label": b"Gewicht"})
+        fields.append(f)
+    table = pa.Table.from_arrays(list(t.columns), schema=pa.schema(fields))
+    assert b"_sdata" not in (table.schema.metadata or {})  # kein Blob
+    back = DataFrame.from_arrow(table)
+    assert back.get_column("weight").unit == "kg"
+    assert back.get_column("weight").label == "Gewicht"
+
+
+def test_arrow_roundtrip_preserves_field_metadata():
+    sdf = DataFrame(df=_df(), name="x")
+    sdf.set_column("weight", unit="kg")
+    back = DataFrame.from_arrow(sdf.to_arrow())
+    assert back.get_column("weight").unit == "kg"
+
+
+def test_feather_carries_field_metadata(tmp_path):
+    import pyarrow.feather as feather
+    sdf = DataFrame(df=_df(), name="x")
+    sdf.set_column("height", unit="m", ontology="bfo:Quality")
+    fp = sdf.to_feather(path=str(tmp_path))
+    table = feather.read_table(fp)                         # nativ lesbar
+    assert table.schema.field("height").metadata[b"unit"] == b"m"
+    back = DataFrame.from_feather(fp)
+    assert back.get_column("height").unit == "m"


### PR DESCRIPTION
Macht die Per-Spalten-Annotationen (`unit`/`label`/`description`/`ontology`) **nativ** in Arrow/Feather lesbar — zusätzlich zum bestehenden `_sdata`-JSON-Blob. Strikt additiv, lokale CI grün, 100 % Coverage.

## Was
- **`to_arrow()`** — hängt pro Spalte deren Annotationen an die **Arrow-Field-Metadata** (`field.metadata[b"unit"]` usw.), zusätzlich zum `b"_sdata"`-Schema-Blob. So lesen DuckDB/Polars/pyarrow die Per-Spalten-Infos ohne sdata. **`to_feather()`** erbt es (baut auf `to_arrow()`).
- **`from_arrow()`** — `_merge_field_metadata` übernimmt Per-Field-Annotationen ins `column_metadata`, auch für **fremd erzeugte** Arrow-Tabellen ohne `_sdata`-Blob.
- **Parquet** bleibt bewusst auf dem robusten `_sdata`-Blob-Pfad (ein Reroute über die Arrow-Tabelle würde das Lesen alter `.spq`-Dateien gefährden — ggf. eigener Folge-PR).

## Tests
`tests/test_sclass_dataframe_field_metadata.py`: Field-Metadata gesetzt + None-Fälle, Merge ohne Blob (externe Tabelle), Arrow- und Feather-Round-Trip. Doku (`usage/dataframe.md`) ergänzt.

Lokale CI grün, `dataframe.py` und Projekt-Total **100 %** (513 passed); `mkdocs build --strict` exit 0.