### PR TITLE
docs(dataframe): vollständige Feature-Übersicht

### DIFF
--- a/docs/usage/dataframe.md
+++ b/docs/usage/dataframe.md
@@ -2,9 +2,9 @@
 
 [`sdata.sclass.dataframe.DataFrame`][sdata.sclass.dataframe.DataFrame] is the
 self-describing tabular container (it supersedes the deprecated `Data` class). It
-wraps a pandas `DataFrame` together with per-column metadata and serializes to
-Parquet, CSV, Arrow/Feather, dict/JSON and JSON-LD/RDF — with the qualifying
-metadata either embedded or written as an independent sidecar.
+wraps a pandas `DataFrame` together with **per-column metadata** and **dataset-level
+metadata**, and serializes to Parquet, CSV, Arrow/Feather, dict/JSON and JSON-LD/RDF
+— with the qualifying metadata either embedded or written as an independent sidecar.
 
 ```python
 import pandas as pd
@@ -14,16 +14,61 @@ df = pd.DataFrame({"weight": [10, 20, 30], "height": [1.5, 1.6, 1.7]})
 sdf = DataFrame(df=df, name="specimen_01", description="a tension test")
 ```
 
-The pandas frame is always available via `sdf.df`; convenience pass-throughs
-(`len(sdf)`, `sdf.shape`, `sdf.columns`, `sdf.dtypes`, `sdf.head()`,
-`sdf.describe()`) delegate to it.
+`__init__` accepts `df`, `column_metadata` (a dict `{col: {unit, label, ...}}` or a
+[`Metadata`][sdata.metadata.Metadata]) and any `Base` keyword (`name`,
+`description`, `project`, …). Passing no `df` yields an empty table.
+
+## The pandas frame
+
+The wrapped frame is always available via `sdf.df` (settable). Thin convenience
+pass-throughs delegate to it:
+
+```python
+sdf.df                 # the pandas DataFrame
+len(sdf)               # number of rows
+sdf.shape              # (3, 2)
+sdf.columns            # Index(['weight', 'height'])
+sdf.dtypes             # per-column pandas dtypes
+sdf.head(2)            # first n rows
+sdf.describe()         # descriptive statistics
+repr(sdf)              # (DataFrame <…> shape=(3, 2))
+```
+
+Assigning a new frame (`sdf.df = other`) keeps the column metadata in sync — see
+[Column metadata](#column-metadata).
+
+## Dataset metadata
+
+Every object carries fully-qualified, machine-readable dataset metadata
+(`sdf.metadata`), a free-text `sdf.description`, and a deterministic identity
+(`sdf.name` / `sdf.sname` / `sdf.suuid`). Reserved `_sdata_*` attributes
+(name, sname, suuid, class, ctime, parent, project, topology) are populated
+automatically.
+
+```python
+sdf.metadata.add("max_force", 12.5, unit="kN", dtype="float",
+                 description="max force", ontology="bfo:Quality")
+sdf.metadata.df       # the metadata as a pandas table
+sdf.udf               # only the user-defined attributes
+```
+
+See [Machine-readable metadata](metadata-jsonld.md) for the metadata model,
+JSON-LD/RDF, schema validation and signing.
 
 ## Column metadata
 
 Each column carries an [`Attribute`][sdata.metadata.Attribute]
-(`unit`/`label`/`description`/`ontology`/`required`) in `sdf.column_metadata`.
+(`unit`/`label`/`description`/`ontology`/`required`) in `sdf.column_metadata`
+(a [`Metadata`][sdata.metadata.Metadata]). Three views of the same store:
+
+```python
+sdf.column_metadata    # the Metadata (one Attribute per column)
+sdf.cmd                # alias of column_metadata
+sdf.cmdf               # the column metadata rendered as a pandas DataFrame
+```
+
 Annotate columns with `set_column` (only the fields you pass are changed; existing
-annotations are preserved):
+annotations are preserved) and read them back with `get_column`:
 
 ```python
 sdf.set_column("weight", unit="kg", label="Gewicht", ontology="bfo:Quality")
@@ -41,44 +86,68 @@ sdf.col.weight                       # -> Attribute (tab-completion on df.col.)
 sdf.col["weight"].unit = "kg"        # mutate a field in place
 ```
 
-When the df is reassigned (`sdf.df = other`), `column_metadata` is kept in sync:
-new columns are added and annotations for removed columns are pruned, while
-surviving columns keep their `unit`/`label`. Column metadata supplied at
-construction time is preserved as-is (orphan keys are only logged as a warning).
+**Sync & prune.** When the frame is reassigned (`sdf.df = other`),
+`column_metadata` is kept in sync: new columns are added and annotations for
+removed columns are pruned, while surviving columns keep their `unit`/`label`.
+Column metadata supplied at construction time is preserved as-is (orphan keys —
+keys that match no column — are only logged as a warning, never dropped).
 
 ## Serialization
 
-All writers take an optional `path` and a `sidecar` flag; without a path they
-return bytes (or, for CSV, a string). The metadata travels embedded in the binary
-formats and via the optional `<sname>.meta.jsonld` sidecar everywhere.
+sdata writes the **data** in an efficient, typed container and the **metadata**
+either embedded in that container or alongside it as a sidecar. Pick the format by
+the interop you need:
+
+| Format | Write / read | Metadata carrier | Needs |
+|--------|--------------|------------------|-------|
+| Parquet `.spq` | `to_parquet` / `from_parquet`, `from_parquet_bytes` | `_sdata` JSON blob in the schema | pyarrow |
+| Arrow | `to_arrow` / `from_arrow` | `_sdata` blob **+ native per-column field metadata** | pyarrow |
+| Feather | `to_feather` / `from_feather` | same as Arrow | pyarrow |
+| dict | `to_dict` / `from_dict` | base64 Parquet + explicit `column_metadata` | pyarrow |
+| JSON `.sjson` | `to_json` / `from_json` | via `to_dict` | pyarrow |
+| CSV | `to_csv` / `from_csv` | **sidecar only** (data-only file) | — (pure pandas) |
+| pandas `df.attrs` | `to_dataframe` | `_sdata` in `df.attrs` | — |
+| JSON-LD / RDF | `to_jsonld` / `to_turtle` / `write_sidecar` | the metadata itself | rdflib (optional) |
+
+All file writers share the same shape: an optional `path` (writes
+`<sname>.<ext>`), an optional exact `filename`, and a `sidecar` flag; without a
+path they return bytes (or, for CSV, a string).
 
 ```python
-# Parquet (.spq) — metadata embedded in df.attrs / schema
+# Parquet (.spq) — metadata embedded in the schema; zstd-compressed
 sdf.to_parquet(path="out", sidecar=True)        # -> out/<sname>.spq + sidecar
 DataFrame.from_parquet("out/<sname>.spq")
 raw = sdf.to_parquet()                           # in-memory bytes
 DataFrame.from_parquet_bytes(raw)
+
+# Arrow / Feather — metadata in the Arrow schema (+ native per-column field metadata)
+table = sdf.to_arrow()                           # pyarrow.Table
+DataFrame.from_arrow(table)
+sdf.to_feather(path="out")                       # -> out/<sname>.feather
+DataFrame.from_feather("out/<sname>.feather")
+
+# dict / JSON — for nesting in JSON documents
+d = sdf.to_dict();      DataFrame.from_dict(d)
+sdf.to_json("specimen_01.sjson", sidecar=True)   # text; from_json reconstructs
 
 # CSV — data only (pure pandas); metadata via the sidecar
 sdf.to_csv(path="out", sidecar=True)             # index dropped by default
 DataFrame.from_csv("out/<sname>.csv")
 text = sdf.to_csv()                              # CSV string
 
-# Arrow / Feather — metadata embedded in the Arrow schema
-table = sdf.to_arrow()                           # pyarrow.Table
-DataFrame.from_arrow(table)
-sdf.to_feather(path="out")                       # -> out/<sname>.feather
-DataFrame.from_feather("out/<sname>.feather")
+# hand back a plain pandas frame with sdata metadata in df.attrs["_sdata"]
+plain = sdf.to_dataframe()
 
-# dict / JSON-LD / RDF
-d = sdf.to_dict();  DataFrame.from_dict(d)
-sdf.to_jsonld();    sdf.to_turtle();    sdf.write_sidecar("out")
+# linked data
+sdf.to_jsonld();   sdf.to_turtle();   sdf.write_sidecar("out")
+from sdata.base import Base
+Base.read_sidecar("out/<sname>.meta.jsonld")     # read a sidecar back
 ```
 
 !!! note "Optional backend"
-    Arrow, Feather and Parquet need pyarrow (`pip install "sdata[parquet]"`); CSV,
-    dict and JSON-LD work with the core install. A missing backend raises a clear
-    `ImportError` pointing at the extra.
+    Arrow, Feather and Parquet (and therefore `to_dict`/`to_json`) need pyarrow
+    (`pip install "sdata[parquet]"`); CSV, `to_dataframe` and JSON-LD work with the
+    core install. A missing backend raises a clear `ImportError` pointing at the extra.
 
 !!! tip "Native per-column metadata (Arrow / Feather)"
     Besides the `_sdata` JSON blob, `to_arrow()` (and therefore `to_feather()`)
@@ -88,8 +157,7 @@ sdf.to_jsonld();    sdf.to_turtle();    sdf.write_sidecar("out")
     field metadata from foreign Arrow tables back into `column_metadata`.
 
     ```python
-    table = sdf.to_arrow()
-    table.schema.field("weight").metadata   # {b'unit': b'kg', b'label': b'Gewicht', ...}
+    sdf.to_arrow().schema.field("weight").metadata   # {b'unit': b'kg', b'label': ...}
     ```
 
 ## Table schema validation
@@ -113,4 +181,9 @@ schema.apply(sdf)                      # fill missing column_metadata from the s
 
 A `DataFrame` subclass may set `TABLE_SCHEMA` to have its `column_metadata`
 auto-completed on construction; `sdf.validate_table()` then checks against it —
-analogous to `Base.SDATA_SCHEMA` for metadata.
+analogous to `Base.SDATA_SCHEMA` for the dataset metadata.
+
+## Full API
+
+See the [API reference](../api.md#sdatasclassdataframe) for the complete,
+auto-generated signature list.


### PR DESCRIPTION
Erweitert `usage/dataframe.md` auf die **komplette** öffentliche DataFrame-API: pandas-Frame + Convenience (`shape`/`columns`/`dtypes`/`head`/`describe`/`len`/`repr`), Dataset-Metadaten, Spalten-Metadaten (`column_metadata`/`cmd`/`cmdf`/`set_column`/`get_column`/`col`/`column_units` + Sync&Prune), eine **Serialisierungs-Referenztabelle** (Parquet/Arrow/Feather/dict/JSON/CSV/`df.attrs`/JSON-LD mit Metadaten-Carrier + Abhängigkeiten) mit Beispielen, native Per-Spalten-Field-Metadata und `TableSchema`-Validierung. `mkdocs build --strict` exit 0.