### PR TITLE
feat(dataframe): Frictionless Data Package (.zip) Bündel

### DIFF
--- a/docs/usage/dataframe.md
+++ b/docs/usage/dataframe.md
@@ -108,6 +108,7 @@ the interop you need:
 | CSV | `to_csv` / `from_csv` | **sidecar only** (data-only file) | — (pure pandas) |
 | pandas `df.attrs` | `to_dataframe` | `_sdata` in `df.attrs` | — |
 | JSON-LD / RDF | `to_jsonld` / `to_turtle` / `write_sidecar` | the metadata itself | rdflib (optional) |
+| Data Package `.zip` | `to_datapackage` / `from_datapackage` | `datapackage.json` (Frictionless) + lossless `sdata` block | — (csv) / pyarrow (parquet) |
 
 All file writers share the same shape: an optional `path` (writes
 `<sname>.<ext>`), an optional exact `filename`, and a `sidecar` flag; without a
@@ -159,6 +160,26 @@ Base.read_sidecar("out/<sname>.meta.jsonld")     # read a sidecar back
     ```python
     sdf.to_arrow().schema.field("weight").metadata   # {b'unit': b'kg', b'label': ...}
     ```
+
+### Data Package (portable bundle)
+
+`to_datapackage()` writes a self-contained **Frictionless Data Package** (`.zip`):
+a standard `datapackage.json` descriptor (so generic Frictionless tooling can read
+it), the data as CSV (default, no extra dependency) or Parquet, and the full sdata
+metadata under the descriptor's `"sdata"` key for a **lossless** round-trip. The
+JSON-LD sidecar is embedded too (toggle with `sidecar=`).
+
+```python
+sdf.to_datapackage(path="out")                  # -> out/<sname>.zip  (CSV inside)
+sdf.to_datapackage(path="out", fmt="parquet")   # Parquet inside (needs sdata[parquet])
+raw = sdf.to_datapackage()                       # zip bytes (no path)
+
+DataFrame.from_datapackage("out/<sname>.zip")    # restores data + metadata losslessly
+```
+
+Column annotations map to Frictionless field properties (`title`←label, `unit`,
+`rdfType`←ontology, `description`), and the dtype to a Table Schema `type`
+(`integer`/`number`/`boolean`/`datetime`/`string`).
 
 ## Table schema validation
 

--- a/sdata/sclass/dataframe.py
+++ b/sdata/sclass/dataframe.py
@@ -605,6 +605,119 @@ class DataFrame(Base):
         import pyarrow.feather as feather
         return cls.from_arrow(feather.read_table(filepath))
 
+    # --------------------------------------------------------- Data Package
+    def _frictionless_type(self, series):
+        """Map a pandas dtype to a Frictionless Table Schema type."""
+        return {"i": "integer", "u": "integer", "f": "number",
+                "b": "boolean", "M": "datetime"}.get(series.dtype.kind, "string")
+
+    def _datapackage_descriptor(self, data_path, fmt):
+        """Build a Frictionless ``tabular-data-package`` descriptor.
+
+        Emits standard Frictionless fields (so generic tooling can read it) plus a
+        lossless ``"sdata"`` block (full metadata/column_metadata) for a perfect
+        round-trip.
+        """
+        fields = []
+        for col in self.df.columns:
+            field = {"name": str(col), "type": self._frictionless_type(self.df[col])}
+            attr = self.column_metadata.get(str(col))
+            if attr is not None:
+                if attr.label:
+                    field["title"] = attr.label
+                if attr.description:
+                    field["description"] = attr.description
+                if attr.unit not in ("-", "", None):
+                    field["unit"] = attr.unit
+                if attr.ontology:
+                    field["rdfType"] = attr.ontology
+            fields.append(field)
+        resource = {"name": self.sname.lower(), "path": data_path, "format": fmt,
+                    "profile": "tabular-data-resource", "schema": {"fields": fields}}
+        return {"name": self.sname.lower(), "title": self.name,
+                "description": self.description, "profile": "tabular-data-package",
+                "resources": [resource],
+                "sdata": {"metadata": self.metadata.to_dict(),
+                          "column_metadata": self.column_metadata.to_dict(),
+                          "description": self.description}}
+
+    def to_datapackage(self, path=None, filename=None, fmt="csv", sidecar=True):
+        """Write a Frictionless **Data Package** (``.zip``) — a portable bundle.
+
+        The zip holds a standard ``datapackage.json`` descriptor (so generic
+        Frictionless tooling can read it), the data as CSV or Parquet, and — for a
+        lossless sdata round-trip — the full sdata metadata under the descriptor's
+        ``"sdata"`` key. Optionally the ``<sname>.meta.jsonld`` JSON-LD sidecar.
+
+        :param path: directory to write ``<sname>.zip`` into (if given).
+        :param filename: exact output filename (defaults to ``<sname>.zip``).
+        :param fmt: data format inside the package, ``"csv"`` (default) or ``"parquet"``.
+        :param sidecar: also embed the JSON-LD sidecar in the zip (default ``True``).
+        :return: the file path (if written to disk) or the zip bytes.
+        :raises ValueError: if ``fmt`` is not ``"csv"``/``"parquet"``.
+        """
+        import zipfile
+        if fmt == "csv":
+            data_path = f"data/{self.sname}.csv"
+            data_bytes = self.df.to_csv(index=False).encode("utf-8")
+        elif fmt == "parquet":
+            data_path = f"data/{self.sname}.spq"
+            data_bytes = self.to_parquet()
+        else:
+            raise ValueError(f"unsupported data package format: {fmt!r} (csv|parquet)")
+
+        descriptor = self._datapackage_descriptor(data_path, fmt)
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(data_path, data_bytes)
+            zf.writestr("datapackage.json", json.dumps(descriptor, indent=2))
+            if sidecar:
+                zf.writestr(f"{self.sname}.meta.jsonld",
+                            json.dumps(self.to_jsonld(), indent=2))
+        payload = buffer.getvalue()
+
+        if filename is None and path is not None:
+            filename = self.sname + ".zip"
+        if filename is not None:
+            filepath = os.path.join(path, filename) if path else filename
+            with open(filepath, "wb") as fh:
+                fh.write(payload)
+            logger.info(f"DataFrame Data Package saved to {filepath}")
+            return filepath
+        return payload
+
+    @classmethod
+    def from_datapackage(cls, filepath):
+        """Load a DataFrame from a Data Package ``.zip`` written by :meth:`to_datapackage`.
+
+        Restores the data and — losslessly — metadata/column_metadata/description
+        from the descriptor's ``"sdata"`` block.
+
+        :param filepath: path to the ``.zip`` data package.
+        :return: a :class:`DataFrame` instance.
+        :raises FileNotFoundError: if ``filepath`` does not exist.
+        """
+        import zipfile
+        if not os.path.exists(filepath):
+            raise FileNotFoundError(f"no Data Package {filepath}")
+        with zipfile.ZipFile(filepath) as zf:
+            descriptor = json.loads(zf.read("datapackage.json"))
+            resource = descriptor["resources"][0]
+            data_path = resource["path"]
+            fmt = resource.get("format", "csv")
+            data_bytes = zf.read(data_path)
+
+        if fmt == "parquet":
+            _require_parquet("pyarrow")
+            df = pd.read_parquet(io.BytesIO(data_bytes))
+        else:
+            df = pd.read_csv(io.BytesIO(data_bytes))
+
+        tt = cls()
+        tt.df = df
+        tt._restore_from_attrs(descriptor.get("sdata"))
+        return tt
+
 
 if __name__ == '__main__':
     # Erstelle einen Pandas DataFrame

--- a/tests/test_sclass_dataframe_datapackage.py
+++ b/tests/test_sclass_dataframe_datapackage.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""Frictionless Data Package (.zip) Bündel: to_datapackage / from_datapackage."""
+import io
+import json
+import zipfile
+
+import pandas as pd
+import pytest
+
+from sdata.sclass.dataframe import DataFrame
+
+
+def _annotated():
+    df = pd.DataFrame({"weight": [10, 20, 30], "height": [1.5, 1.6, 1.7]})
+    sdf = DataFrame(df=df, name="specimen", description="a tension test")
+    sdf.set_column("weight", unit="kg", label="Gewicht",
+                   description="mass", ontology="bfo:Quality")
+    # height bleibt un-annotiert
+    return sdf
+
+
+# ------------------------------------------------------------------- CSV
+def test_datapackage_csv_roundtrip(tmp_path):
+    sdf = _annotated()
+    fp = sdf.to_datapackage(path=str(tmp_path))
+    assert fp.endswith(".zip")
+    back = DataFrame.from_datapackage(fp)
+    assert list(back.df.columns) == ["weight", "height"]
+    assert back.description == "a tension test"
+    assert back.get_column("weight").unit == "kg"
+    assert back.get_column("weight").ontology == "bfo:Quality"
+
+
+def test_datapackage_descriptor_is_frictionless(tmp_path):
+    fp = _annotated().to_datapackage(path=str(tmp_path))
+    with zipfile.ZipFile(fp) as zf:
+        names = zf.namelist()
+        dp = json.loads(zf.read("datapackage.json"))
+    assert dp["profile"] == "tabular-data-package"
+    res = dp["resources"][0]
+    assert res["profile"] == "tabular-data-resource"
+    assert res["path"].startswith("data/") and res["format"] == "csv"
+    fields = {f["name"]: f for f in res["schema"]["fields"]}
+    assert fields["weight"]["type"] == "integer"
+    assert fields["weight"]["title"] == "Gewicht"
+    assert fields["weight"]["unit"] == "kg"
+    assert fields["weight"]["rdfType"] == "bfo:Quality"
+    assert fields["height"]["type"] == "number"
+    assert "title" not in fields["height"]          # un-annotiert
+    # verlustfreier sdata-Block + Daten + Sidecar im Zip
+    assert "metadata" in dp["sdata"] and "column_metadata" in dp["sdata"]
+    assert any(n.endswith(".meta.jsonld") for n in names)
+    assert res["path"] in names
+
+
+def test_datapackage_returns_bytes_without_path():
+    raw = _annotated().to_datapackage()
+    assert isinstance(raw, (bytes, bytearray))
+    assert zipfile.is_zipfile(io.BytesIO(raw))
+
+
+def test_datapackage_no_sidecar(tmp_path):
+    fp = _annotated().to_datapackage(path=str(tmp_path), sidecar=False)
+    with zipfile.ZipFile(fp) as zf:
+        names = zf.namelist()
+    assert not any(n.endswith(".meta.jsonld") for n in names)
+
+
+def test_datapackage_explicit_filename(tmp_path):
+    target = str(tmp_path / "pkg.zip")
+    fp = _annotated().to_datapackage(filename=target)   # filename ohne path
+    assert fp == target
+    assert DataFrame.from_datapackage(fp).get_column("weight").unit == "kg"
+
+
+def test_datapackage_column_without_metadata(tmp_path):
+    sdf = _annotated()
+    sdf.column_metadata.pop("weight")                   # Annotation entfernen, Spalte bleibt
+    fp = sdf.to_datapackage(path=str(tmp_path))
+    with zipfile.ZipFile(fp) as zf:
+        dp = json.loads(zf.read("datapackage.json"))
+    weight = {f["name"]: f for f in dp["resources"][0]["schema"]["fields"]}["weight"]
+    assert weight["type"] == "integer" and "title" not in weight
+
+
+def test_datapackage_bad_format_raises():
+    with pytest.raises(ValueError, match="csv|parquet"):
+        _annotated().to_datapackage(fmt="orc")
+
+
+def test_from_datapackage_missing_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        DataFrame.from_datapackage(str(tmp_path / "nope.zip"))
+
+
+# --------------------------------------------------------------- Parquet
+def test_datapackage_parquet_roundtrip(tmp_path):
+    pytest.importorskip("pyarrow")
+    sdf = _annotated()
+    fp = sdf.to_datapackage(path=str(tmp_path), fmt="parquet")
+    with zipfile.ZipFile(fp) as zf:
+        assert any(n.endswith(".spq") for n in zf.namelist())
+    back = DataFrame.from_datapackage(fp)
+    assert list(back.df.columns) == ["weight", "height"]
+    assert back.get_column("weight").unit == "kg"


### PR DESCRIPTION
**`to_datapackage()` / `from_datapackage()`** — ein portables **Frictionless Data Package** (`.zip`) als Bündel. Strikt additiv, lokale CI grün, 100 % Coverage.

## Was drin ist
- **`datapackage.json`** — standardkonformer Frictionless `tabular-data-package`-Descriptor (generische Frictionless-Tools können ihn lesen): `resources[0].schema.fields` mit `name`/`type` und den Spalten-Annotationen (`title`←label, `unit`, `rdfType`←ontology, `description`).
- **Daten** als **CSV** (Default, *keine* neue Dependency — `zipfile`/`json`/`pandas`) oder **Parquet** (`fmt="parquet"`, via `sdata[parquet]`).
- **Verlustfreier `"sdata"`-Block** im Descriptor (volle `metadata`/`column_metadata`) → perfekter Round-Trip über `from_datapackage`.
- Eingebetteter **JSON-LD-Sidecar** (`sidecar=`, Default an).

## API
```python
sdf.to_datapackage(path="out")                  # out/<sname>.zip (CSV)
sdf.to_datapackage(path="out", fmt="parquet")   # Parquet im Paket
raw = sdf.to_datapackage()                       # zip-bytes
DataFrame.from_datapackage("out/<sname>.zip")    # Daten + Metadaten verlustfrei
```

## Tests
`tests/test_sclass_dataframe_datapackage.py`: CSV/Parquet-Round-Trip, Frictionless-Descriptor-Struktur, Bytes/`filename`/`sidecar`-Varianten, Spalte ohne Annotation, `ValueError` (fmt) / `FileNotFoundError`. Doku (`usage/dataframe.md`) ergänzt.

Lokale CI grün, `dataframe.py` + Projekt-Total **100 %** (522 passed); `mkdocs build --strict` exit 0.