### PR TITLE
feat(dataframe): HDF5-Serialisierung (to_hdf/from_hdf) — RFC 0002

### DIFF
--- a/docs/rfc/0002-hdf5-dataframe-serialization.md
+++ b/docs/rfc/0002-hdf5-dataframe-serialization.md
@@ -2,12 +2,20 @@
 
 | Feld        | Wert                                                         |
 |-------------|--------------------------------------------------------------|
-| Status      | Proposed                                                     |
+| Status      | Accepted — implementiert (Option A)                         |
 | Datum       | 2026-06-29                                                  |
 | Autor       | lepy <lepy@tuta.io>                                          |
 | Komponente  | `sdata/sclass/dataframe.py` (+ Extra `sdata[hdf]`)          |
-| Betrifft    | neue Methoden `DataFrame.to_hdf` / `from_hdf`               |
-| Validierung | Designvorschlag — noch nicht implementiert                  |
+| Betrifft    | `DataFrame.to_hdf` / `from_hdf`                             |
+| Validierung | umgesetzt (Option A); verifiziert via `tests/test_sclass_dataframe_hdf.py` (PyTables) |
+
+> **Umsetzung.** Implementiert wie in **Option A** beschrieben (`pd.HDFStore` +
+> `_sdata`-Node-Attribut, wiederverwendetes `_restore_from_attrs`, mehrere Keys/Datei
+> via `mode="a"`). Zur **CI-Frage** (Abschnitt 8): PyTables wird **nicht** in die
+> kanonische CI aufgenommen (das vorbestehende WIP-`tests/iolib/test_hdf.py` bricht mit
+> installiertem PyTables). Stattdessen sind `to_hdf`/`from_hdf` `# pragma: no cover`
+> (wie die übrigen optionalen Backends in `omit`) und werden über
+> `importorskip("tables")`-Tests in Umgebungen mit `sdata[hdf]` real verifiziert.
 
 ## 1. Zusammenfassung
 

--- a/docs/usage/dataframe.md
+++ b/docs/usage/dataframe.md
@@ -109,6 +109,7 @@ the interop you need:
 | pandas `df.attrs` | `to_dataframe` | `_sdata` in `df.attrs` | — |
 | JSON-LD / RDF | `to_jsonld` / `to_turtle` / `write_sidecar` | the metadata itself | rdflib (optional) |
 | Data Package `.zip` | `to_datapackage` / `from_datapackage` | `datapackage.json` (Frictionless) + lossless `sdata` block | — (csv) / pyarrow (parquet) |
+| HDF5 `.h5` | `to_hdf` / `from_hdf` | `_sdata` node attribute (PyTables) | tables (`sdata[hdf]`) |
 
 All file writers share the same shape: an optional `path` (writes
 `<sname>.<ext>`), an optional exact `filename`, and a `sidecar` flag; without a
@@ -180,6 +181,25 @@ DataFrame.from_datapackage("out/<sname>.zip")    # restores data + metadata loss
 Column annotations map to Frictionless field properties (`title`←label, `unit`,
 `rdfType`←ontology, `description`), and the dtype to a Table Schema `type`
 (`integer`/`number`/`boolean`/`datetime`/`string`).
+
+### HDF5
+
+For large/scientific data, `to_hdf()` writes an HDF5 file (PyTables) with the sdata
+metadata stored as the node's `_sdata` attribute; `from_hdf()` reads it back.
+Several DataFrames can share one file via distinct `key`s (HDF5 has no in-memory
+bytes form, so a `path`/`filename` is required). Needs `pip install "sdata[hdf]"`.
+
+```python
+sdf.to_hdf(path="out")                           # -> out/<sname>.h5  (key = sname)
+DataFrame.from_hdf("out/<sname>.h5")             # default: first key in the file
+
+# several tables in one file
+sdf.to_hdf(filename="bundle.h5", key="run1")
+other.to_hdf(filename="bundle.h5", key="run2")
+DataFrame.from_hdf("bundle.h5", key="run2")
+```
+
+See [RFC 0002](../rfc/0002-hdf5-dataframe-serialization.md) for the design rationale.
 
 ## Table schema validation
 

--- a/sdata/sclass/dataframe.py
+++ b/sdata/sclass/dataframe.py
@@ -718,6 +718,80 @@ class DataFrame(Base):
         tt._restore_from_attrs(descriptor.get("sdata"))
         return tt
 
+    # ------------------------------------------------------------------ HDF5
+    # Optionales HDF5-Backend (PyTables, Extra ``sdata[hdf]``), siehe RFC 0002.
+    # Bewusst ``# pragma: no cover``: PyTables ist nicht in der kanonischen CI
+    # (das WIP-Modul ``sdata/iolib/hdf.py`` ist bereits ``omit``, und sein Test
+    # bricht mit installiertem PyTables). Verifiziert über die
+    # ``importorskip("tables")``-Tests in ``tests/test_sclass_dataframe_hdf.py``.
+    def to_hdf(self, path=None, filename=None, key=None, sidecar=False, **kwargs):  # pragma: no cover
+        """Serialize the df to HDF5 (PyTables), embedding sdata metadata as a node attr.
+
+        HDF5 has no in-memory bytes form, so a ``path``/``filename`` is required. The
+        sdata metadata (metadata/column_metadata/description) is stored as the node's
+        ``_sdata`` attribute; several DataFrames can share one file via distinct ``key``.
+
+        :param path: directory to write ``<sname>.h5`` into.
+        :param filename: exact output filename (defaults to ``<sname>.h5``).
+        :param key: HDF5 node/key (default: ``self.sname``).
+        :param sidecar: also write a JSON-LD metadata sidecar next to the file.
+        :param kwargs: forwarded to ``pandas.HDFStore.put`` (e.g. ``format``,
+            ``complevel``, ``complib``).
+        :return: the file path.
+        :raises ImportError: if PyTables is not installed (``pip install sdata[hdf]``).
+        :raises ValueError: if neither ``path`` nor ``filename`` is given.
+        """
+        try:
+            import tables  # noqa: F401
+        except ImportError as exp:
+            raise ImportError("HDF5 support requires PyTables. Install it, e.g. "
+                              "`pip install sdata[hdf]`.") from exp
+        if filename is None and path is not None:
+            filename = self.sname + ".h5"
+        if filename is None:
+            raise ValueError("to_hdf requires a path or filename (HDF5 has no bytes form)")
+        filepath = os.path.join(path, filename) if path else filename
+        key = key or self.sname
+        fmt = kwargs.pop("format", "fixed")
+        with pd.HDFStore(filepath, mode="a") as store:
+            store.put(key, self.df, format=fmt, **kwargs)
+            store.get_storer(key).attrs._sdata = json.dumps({
+                "metadata": self.metadata.to_dict(),
+                "column_metadata": self.column_metadata.to_dict(),
+                "description": self.description,
+            })
+        logger.info(f"DataFrame HDF5 saved to {filepath}")
+        if sidecar:
+            self.write_sidecar(path)
+        return filepath
+
+    @classmethod
+    def from_hdf(cls, filepath, key=None):  # pragma: no cover
+        """Load a DataFrame from an HDF5 file written by :meth:`to_hdf`.
+
+        :param filepath: path to the ``.h5`` file.
+        :param key: HDF5 node/key to read (default: the first key in the file).
+        :return: a :class:`DataFrame` instance.
+        :raises FileNotFoundError: if ``filepath`` does not exist.
+        :raises ImportError: if PyTables is not installed.
+        """
+        if not os.path.exists(filepath):
+            raise FileNotFoundError(f"no HDF5 file {filepath}")
+        try:
+            import tables  # noqa: F401
+        except ImportError as exp:
+            raise ImportError("HDF5 support requires PyTables. Install it, e.g. "
+                              "`pip install sdata[hdf]`.") from exp
+        with pd.HDFStore(filepath, mode="r") as store:
+            if key is None:
+                key = store.keys()[0]
+            df = store.get(key)
+            raw = getattr(store.get_storer(key).attrs, "_sdata", None)
+        tt = cls()
+        tt.df = df
+        tt._restore_from_attrs(json.loads(raw) if raw else None)
+        return tt
+
 
 if __name__ == '__main__':
     # Erstelle einen Pandas DataFrame

--- a/tests/test_sclass_dataframe_hdf.py
+++ b/tests/test_sclass_dataframe_hdf.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""HDF5-Serialisierung (RFC 0002): to_hdf / from_hdf (PyTables, Extra sdata[hdf]).
+
+PyTables ist nicht in der kanonischen CI -> die Suite skippt hier; die Methoden
+sind in dataframe.py ``# pragma: no cover``. Diese Tests verifizieren das Verhalten
+in Umgebungen mit installiertem PyTables (z. B. Scratchpad / ``sdata[hdf]``).
+"""
+import pandas as pd
+import pytest
+
+pytest.importorskip("tables")
+
+from sdata.sclass.dataframe import DataFrame
+
+
+def _annotated():
+    df = pd.DataFrame({"weight": [10, 20, 30], "height": [1.5, 1.6, 1.7]})
+    sdf = DataFrame(df=df, name="specimen", description="a tension test")
+    sdf.set_column("weight", unit="kg", label="Gewicht", ontology="bfo:Quality")
+    return sdf
+
+
+def test_hdf_roundtrip_default_key(tmp_path):
+    sdf = _annotated()
+    fp = sdf.to_hdf(path=str(tmp_path), sidecar=True)
+    assert fp.endswith(".h5")
+    assert list(tmp_path.glob("*.meta.jsonld"))          # Sidecar geschrieben
+    back = DataFrame.from_hdf(fp)                          # Default-Key
+    assert list(back.df.columns) == ["weight", "height"]
+    assert back.description == "a tension test"
+    assert back.get_column("weight").unit == "kg"
+    assert back.get_column("weight").ontology == "bfo:Quality"
+
+
+def test_hdf_explicit_key_and_multiple_in_one_file(tmp_path):
+    a = _annotated()
+    b = DataFrame(df=pd.DataFrame({"x": [1, 2]}), name="bbb", description="second")
+    shared = str(tmp_path / "both.h5")
+    a.to_hdf(filename=shared, key="a")
+    b.to_hdf(filename=shared, key="b")                     # mode="a" -> beide Keys
+    ra = DataFrame.from_hdf(shared, key="a")
+    rb = DataFrame.from_hdf(shared, key="b")
+    assert ra.get_column("weight").unit == "kg"
+    assert list(rb.df.columns) == ["x"] and rb.description == "second"
+
+
+def test_hdf_table_format(tmp_path):
+    fp = _annotated().to_hdf(path=str(tmp_path), format="table")
+    back = DataFrame.from_hdf(fp)
+    assert back.get_column("weight").unit == "kg"
+
+
+def test_to_hdf_requires_path_or_filename():
+    with pytest.raises(ValueError):
+        _annotated().to_hdf()                              # kein path/filename
+
+
+def test_from_hdf_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        DataFrame.from_hdf(str(tmp_path / "nope.h5"))
+
+
+def test_from_hdf_plain_without_sdata_attr(tmp_path):
+    # einfaches pandas-HDF ohne _sdata-Attribut -> Restore-None-Pfad
+    fp = str(tmp_path / "plain.h5")
+    pd.DataFrame({"weight": [1, 2]}).to_hdf(fp, key="data", format="fixed")
+    back = DataFrame.from_hdf(fp, key="data")
+    assert list(back.df.columns) == ["weight"]
+    assert back.description == ""


### PR DESCRIPTION
Setzt **RFC 0002** (Option A) um: **`DataFrame.to_hdf` / `from_hdf`** via `pd.HDFStore` (PyTables, Extra `sdata[hdf]`).

## Was
- sdata-Metadaten als **`_sdata`-Node-Attribut**, verlustfrei über das vorhandene `_restore_from_attrs` (gleiche Restore-Logik wie Parquet/Arrow).
- **Mehrere DataFrames pro Datei** über distinkte `key`s (`mode="a"`); `key` default = `sname`.
- HDF5 hat keinen Bytes-Pfad → `path`/`filename` erforderlich (`ValueError` ohne Ziel); `format="fixed"` Default, `complevel`/`complib` durchreichbar; klare `ImportError` ohne PyTables; `from_hdf` Default = erster Key, `FileNotFoundError` bei Fehlen.

## CI / Coverage (RFC §8)
PyTables wird **nicht** in die kanonische CI aufgenommen — das vorbestehende WIP `tests/iolib/test_hdf.py` bricht mit installiertem PyTables. Daher sind `to_hdf`/`from_hdf` `# pragma: no cover` (wie die übrigen optionalen Backends in `omit`) und werden über **`importorskip("tables")`-Tests** real verifiziert. Ergebnis: kanonische CI **grün**, `dataframe.py` + Total **100 %**; HDF-Tests im Scratchpad mit PyTables **6/6 grün**.

## Doku
`usage/dataframe.md` (Tabellen-Zeile + HDF5-Abschnitt), RFC 0002 auf „implementiert". `mkdocs build --strict` exit 0.