### PR TITLE
docs: Doku an vollständiges Serialisierungs-Portfolio angleichen

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,10 @@ dependency): `pip install "sdata[rdf]"` (rdflib), `sdata[units]` (pint),
 
 ## Tabular data (`DataFrame`)
 
-`DataFrame` wraps a pandas frame plus per-column metadata and serializes to
-Parquet, CSV, Arrow/Feather, dict/JSON and JSON-LD — embedded or as a sidecar.
+`DataFrame` wraps a pandas frame plus per-column metadata and serializes to many
+formats — Parquet, Arrow/Feather, CSV, dict/JSON, JSON-LD, a Frictionless **Data
+Package** and **HDF5** — with the qualifying metadata embedded or written as a
+sidecar.
 
 ```python
 import pandas as pd
@@ -131,7 +133,9 @@ sdf.column_units                       # {'weight': 'kg', 'height': 'm'}
 # serialize (optional <sname>.meta.jsonld sidecar; bytes/str without a path)
 sdf.to_parquet(path="out", sidecar=True)      # out/<sname>.spq + sidecar
 sdf.to_csv(path="out")                         # data-only CSV (pure pandas)
-sdf.to_feather(path="out")                     # Arrow IPC (needs sdata[parquet])
+sdf.to_feather(path="out")                     # Arrow IPC + native per-column field metadata
+sdf.to_datapackage(path="out")                 # Frictionless Data Package (.zip)
+sdf.to_hdf(path="out")                         # HDF5 (needs sdata[hdf])
 DataFrame.from_parquet("out/specimen_01.spq")
 
 # validate the table against a schema (missing/dtype/unit/extra columns)
@@ -142,9 +146,10 @@ schema = TableSchema("TensileTable", [
 report = sdf.validate_table(schema)            # ValidationReport (truthy if ok)
 ```
 
-Arrow/Feather/Parquet need `pip install "sdata[parquet]"`; CSV, dict and JSON-LD
-work with the core install. See the [Tabular data docs](https://lepy.github.io/sdata/usage/dataframe/)
-([`docs/usage/dataframe.md`](docs/usage/dataframe.md)) for details.
+Arrow/Feather/Parquet need `pip install "sdata[parquet]"`, HDF5 `sdata[hdf]`; CSV,
+dict, JSON-LD and the (CSV) Data Package work with the core install. See the
+[Tabular data docs](https://lepy.github.io/sdata/usage/dataframe/)
+([`docs/usage/dataframe.md`](docs/usage/dataframe.md)) for the full reference.
 
 ## Howto
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ and freely extensible, fully-qualified user metadata — all machine-readable
 ```bash
 pip install sdata                 # core: numpy, pandas, suuid
 pip install "sdata[parquet]"      # pyarrow -> Parquet/Arrow/Feather DataFrame I/O
+pip install "sdata[hdf]"          # tables  -> HDF5 DataFrame I/O
 pip install "sdata[rdf]"          # rdflib  -> real Turtle/N-Triples/RDF-XML
 pip install "sdata[units]"        # pint    -> validate/normalise units
 pip install "sdata[schema]"       # jsonschema -> JSON-Schema validation

--- a/docs/usage/dataframe.md
+++ b/docs/usage/dataframe.md
@@ -3,8 +3,9 @@
 [`sdata.sclass.dataframe.DataFrame`][sdata.sclass.dataframe.DataFrame] is the
 self-describing tabular container (it supersedes the deprecated `Data` class). It
 wraps a pandas `DataFrame` together with **per-column metadata** and **dataset-level
-metadata**, and serializes to Parquet, CSV, Arrow/Feather, dict/JSON and JSON-LD/RDF
-— with the qualifying metadata either embedded or written as an independent sidecar.
+metadata**, and serializes to Parquet, Arrow/Feather, CSV, dict/JSON, JSON-LD/RDF, a
+Frictionless Data Package and HDF5 — with the qualifying metadata either embedded or
+written as an independent sidecar.
 
 ```python
 import pandas as pd


### PR DESCRIPTION
Bringt die Doku auf den aktuellen Stand, nachdem Data Package (#64) und HDF5 (#66) hinzukamen:

- **README** „Tabular data": Intro nennt jetzt alle Formate; Beispiele für `to_datapackage`/`to_hdf` + native Per-Spalten-Field-Metadata; Deps-Hinweis um `sdata[hdf]`.
- **docs/index.md**: Install-Liste um `pip install "sdata[hdf]"` ergänzt.
- **usage/dataframe.md**: Intro-Satz listet jetzt Parquet/Arrow/Feather/CSV/dict/JSON/JSON-LD/Data Package/HDF5.

Reine Doku. `mkdocs build --strict` exit 0.