### PR TITLE
feat(blob): Blob-Härtung (RFC 0003, Teil A)

### DIFF
--- a/docs/rfc/0003-blob-as-data-foundation.md
+++ b/docs/rfc/0003-blob-as-data-foundation.md
@@ -2,12 +2,22 @@
 
 | Feld        | Wert                                                         |
 |-------------|--------------------------------------------------------------|
-| Status      | Proposed                                                     |
+| Status      | Accepted — Teil A (Kern) implementiert; Rest offen           |
 | Datum       | 2026-06-29                                                  |
 | Autor       | lepy <lepy@tuta.io>                                          |
 | Komponente  | `sdata/sclass/blob.py` (+ `dataframe.py`, `image.py`, `filereference.py`) |
 | Betrifft    | `Blob` als gemeinsame Content-/Integritäts-/Provenienz-Basis |
-| Validierung | Designvorschlag — noch nicht implementiert                  |
+| Validierung | Teil-A-Kern umgesetzt; `tests/test_sclass_blob_hardening.py`, blob.py 100 % |
+
+> **Umsetzungsstand.** Aus **Teil A** umgesetzt (rückwärtskompatibel, kanonische CI
+> grün, `blob.py` 100 %): **B4** `saf:`→Standard-Vokabular (`schema:sha256`,
+> `dcat:mediaType`, `dcterms:source`/`created`/`modified`/`publisher`/`license`);
+> **B1** `sha256`-Property; **B6** `verify()` + `update_checksum()`; **B3** Cache als
+> nicht-serialisiertes Instanzattribut `_content_cache` (nicht mehr in `self.data`);
+> **B7** `size`-Property.
+> **Offen** (Folge-PRs): **B2** Auto-Befüllung `mime_type`/`creation_date` (Determinismus
+> abzuwägen), **B5** `write(uri)`/`open()` (fsspec-Schreib-API), **Teil B** (Foundation:
+> `FileReference`/`Image` → `Blob`; `DataFrame(Blob)` eigener Folge-RFC).
 
 ## 1. Zusammenfassung
 

--- a/sdata/sclass/blob.py
+++ b/sdata/sclass/blob.py
@@ -55,7 +55,7 @@ class Blob(Base):
         "description": "A hash value (based on the SHA-256 algorithm) that verifies the integrity of the asset. It ensures that the resource has not been modified (e.g., during downloads or storage).",
         "label": "Checksum (SHA-256)",
         "required": True,
-        "ontology": "saf:checksum"
+        "ontology": "schema:sha256"
     },
     "mime_type": {
         "name": "mime_type",
@@ -65,7 +65,7 @@ class Blob(Base):
         "description": "The MIME type of the resource (e.g., 'application/pdf' for PDFs or 'text/html' for web pages), which indicates how the asset should be interpreted and processed.",
         "label": "MIME Type",
         "required": True,
-        "ontology": "saf:mimeType"
+        "ontology": "dcat:mediaType"
     },
     "source_uri": {
         "name": "source_uri",
@@ -75,7 +75,7 @@ class Blob(Base):
         "description": "The original URI (Uniform Resource Identifier) from which the asset originates (e.g., a URL to a website or file).",
         "label": "Source URI",
         "required": False,
-        "ontology": "saf:sourceURI"
+        "ontology": "dcterms:source"
     },
     "creation_date": {
         "name": "creation_date",
@@ -85,7 +85,7 @@ class Blob(Base):
         "description": "The creation date of the asset, to track the history.",
         "label": "Creation Date",
         "required": True,
-        "ontology": "saf:creationDate"
+        "ontology": "dcterms:created"
     },
     "modified_date": {
         "name": "modified_date",
@@ -95,7 +95,7 @@ class Blob(Base):
         "description": "The date of the last modification, important for version control.",
         "label": "Modified Date",
         "required": False,
-        "ontology": "saf:modifiedDate"
+        "ontology": "dcterms:modified"
     },
     "publisher": {
         "name": "publisher",
@@ -105,7 +105,7 @@ class Blob(Base):
         "description": "The publisher or owner of the resource (e.g., an organization like ISO or a company).",
         "label": "Publisher",
         "required": False,
-        "ontology": "saf:publisher"
+        "ontology": "dcterms:publisher"
     },
     "license": {
         "name": "license",
@@ -115,7 +115,7 @@ class Blob(Base):
         "description": "Information about the license (e.g., Creative Commons, proprietary), which regulates the usage rights.",
         "label": "License",
         "required": False,
-        "ontology": "saf:license"
+        "ontology": "dcterms:license"
     }
 }
 
@@ -137,6 +137,7 @@ class Blob(Base):
         :raises ValueError: If invalid content_type or mismatched value type.
         """
         super().__init__(**kwargs)
+        self._content_cache = None  # nicht-serialisierter Lazy-Cache (nicht in self.data)
         self.metadata.update_from_dict(self.DEFAULT_METADATA)
 
         if content_type not in typing.get_args(self.ContentType):
@@ -192,7 +193,7 @@ class Blob(Base):
         if filetype is not None:
             self.data['content']['filetype'] = filetype
         self._set_value(value)
-        self.data.pop('content_cached', None)  # Clear cache for lazy reloading
+        self._content_cache = None  # Clear cache for lazy reloading
         logger.debug(
             f"Updated Blob '{self.sname}' to content_type '{content_type}' and filetype '{self.data['content']['filetype']}'")
 
@@ -207,8 +208,8 @@ class Blob(Base):
         :raises ValueError: If loading fails or no value set.
         :raises Exception: If fsspec encounters an error (e.g., invalid URI, missing dependencies like s3fs for S3).
         """
-        if 'content_cached' in self.data:
-            return self.data['content_cached']
+        if getattr(self, '_content_cache', None) is not None:
+            return self._content_cache
 
         content = self.data.get('content')
         if content is None:
@@ -232,7 +233,7 @@ class Blob(Base):
         else:
             raise ValueError(f"Unknown content_type: {ctype}")
 
-        self.data['content_cached'] = loaded_bytes  # Cache the loaded bytes
+        self._content_cache = loaded_bytes  # Cache the loaded bytes (instance, not serialized)
         return loaded_bytes
 
     @property
@@ -301,6 +302,21 @@ class Blob(Base):
             logger.error(f"Failed to compute MD5: {str(e)}")
             return None
 
+    @property
+    def sha256(self) -> Optional[str]:
+        """
+        Calculate the SHA-256 hash of the blob content lazily.
+
+        :return: the hex digest, or ``None`` if the content cannot be loaded.
+        """
+        try:
+            hash_obj = hashlib.sha256()
+            self._update_hash(hash_obj)
+            return hash_obj.hexdigest()
+        except Exception as e:
+            logger.error(f"Failed to compute SHA256: {str(e)}")
+            return None
+
     def _update_hash(self, hash_obj: Any, buffer_size: int = 65536) -> None:
         """
         Update the hash object with the blob content.
@@ -314,13 +330,50 @@ class Blob(Base):
                 break
             hash_obj.update(data)
 
+    @property
+    def size(self) -> Optional[int]:
+        """
+        Size of the content in bytes (loads the content lazily).
+
+        :return: the byte count, or ``None`` if the content cannot be loaded.
+        """
+        try:
+            return len(self.content_bytes)
+        except Exception as e:
+            logger.error(f"Failed to determine size: {str(e)}")
+            return None
+
+    def update_checksum(self) -> Optional[str]:
+        """
+        Compute the SHA-256 of the content and store it in the ``checksum`` metadata
+        (ontology ``schema:sha256``).
+
+        :return: the stored SHA-256 hex digest (or ``None`` if the content is unavailable).
+        """
+        digest = self.sha256
+        self.metadata.set_attr("checksum", digest)
+        return digest
+
+    def verify(self) -> bool:
+        """
+        Verify the content against the stored ``checksum`` (SHA-256) metadata.
+
+        :return: ``True`` iff a checksum is stored and matches the current content;
+          ``False`` on mismatch or when no checksum has been stored yet.
+        """
+        attr = self.metadata.get("checksum")
+        stored = attr.value if attr is not None else None
+        if not stored:
+            logger.warning("Blob.verify: no checksum stored (call update_checksum first)")
+            return False
+        return stored == self.sha256
+
     def to_dict(self) -> Dict[str, Any]:
         """
         Extend Base.to_dict to include the content dict as-is (with base64 for bytes and filetype).
         Does not include or load the actual content bytes.
         """
         data_copy = self.data.copy()
-        data_copy.pop('content_cached', None)  # Remove cache if present
         result = super().to_dict()
         result['data'] = data_copy
         return result

--- a/tests/test_sclass_blob_hardening.py
+++ b/tests/test_sclass_blob_hardening.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Blob-Härtung (RFC 0003, Teil A): sha256/verify/update_checksum, size,
+nicht-serialisierter Cache und Standard-Vokabular statt undefiniertem saf:-Prefix.
+"""
+import json
+
+from sdata.sclass.blob import Blob
+
+
+def test_sha256_and_size():
+    b = Blob(content_type="bytes", value=b"hello", filetype="bin", name="b")
+    assert len(b.sha256) == 64
+    assert b.size == 5
+
+
+def test_sha256_size_none_on_error():
+    b = Blob(name="b")                              # value None -> content_bytes wirft
+    assert b.sha256 is None
+    assert b.size is None
+
+
+def test_update_checksum_and_verify():
+    b = Blob(content_type="bytes", value=b"data", name="b")
+    assert b.verify() is False                      # noch keine checksum gespeichert
+    digest = b.update_checksum()
+    assert digest == b.sha256 and len(digest) == 64
+    assert b.verify() is True                       # Inhalt passt zur checksum
+    b.set_content("bytes", b"tampered")             # Inhalt ändern (Cache wird geleert)
+    assert b.verify() is False                      # stimmt nicht mehr
+
+
+def test_ontology_uses_standard_vocab():
+    b = Blob(content_type="bytes", value=b"x", name="b")
+    assert b.metadata.get("checksum").ontology == "schema:sha256"
+    assert b.metadata.get("mime_type").ontology == "dcat:mediaType"
+    assert b.metadata.get("source_uri").ontology == "dcterms:source"
+    assert b.metadata.get("creation_date").ontology == "dcterms:created"
+    assert b.metadata.get("modified_date").ontology == "dcterms:modified"
+    assert b.metadata.get("publisher").ontology == "dcterms:publisher"
+    assert b.metadata.get("license").ontology == "dcterms:license"
+    # JSON-LD enthält keinen undefinierten saf:-Prefix mehr
+    assert "saf:" not in json.dumps(b.to_jsonld())
+
+
+def test_cache_is_not_serialized():
+    b = Blob(content_type="bytes", value=b"hello", name="b")
+    assert b.content_bytes == b"hello"              # füllt den Lazy-Cache
+    assert b._content_cache == b"hello"             # Instanzattribut ...
+    d = b.to_dict()
+    assert "content_cached" not in d["data"]        # ... nicht im serialisierten data
+    assert "content" in d["data"]


### PR DESCRIPTION
Setzt den Kern von **RFC 0003, Teil A** um — rückwärtskompatibel, kanonische CI grün, `blob.py` **100 %**.

- **B4** Undefinierter `saf:`-Prefix → **Standard-Vokabular** (alles bereits im `@context`): `checksum`→`schema:sha256`, `mime_type`→`dcat:mediaType`, `source_uri`→`dcterms:source`, `creation_date`→`dcterms:created`, `modified_date`→`dcterms:modified`, `publisher`→`dcterms:publisher`, `license`→`dcterms:license`. `to_jsonld()` erzeugt damit nur noch **auflösbare** Terme.
- **B1** `sha256`-Property (analog `sha1`/`md5`).
- **B6** `verify()` (Inhalt gegen gespeicherte `checksum`) + `update_checksum()` (SHA-256 ins `checksum`-Metadatum).
- **B3** Lazy-Cache als **nicht-serialisiertes** Instanzattribut `_content_cache` (nicht mehr in `self.data`); `to_dict` poppt nichts mehr aus.
- **B7** `size`-Property.

Tests: `tests/test_sclass_blob_hardening.py` (sha256/size inkl. None-Fälle; `verify` match/mismatch/ohne-checksum; Vokabular + kein `saf:` in `to_jsonld`; Cache nicht serialisiert). Bestehende Blob-Tests unverändert grün.

**Offen** (Folge-PRs, in RFC 0003 vermerkt): B2 (`mime_type`/`creation_date`-Autofill, Determinismus), B5 (`write(uri)`/`open()`), Teil B (Foundation: `FileReference`/`Image`→`Blob`; `DataFrame(Blob)` eigener RFC).

`mkdocs build --strict` exit 0.