### PR TITLE
feat(blob): Teil A abschließen — mime/creation_date-Autofill + write/open

### DIFF
--- a/docs/rfc/0003-blob-as-data-foundation.md
+++ b/docs/rfc/0003-blob-as-data-foundation.md
@@ -2,22 +2,24 @@
 
 | Feld        | Wert                                                         |
 |-------------|--------------------------------------------------------------|
-| Status      | Accepted — Teil A (Kern) implementiert; Rest offen           |
+| Status      | Accepted — Teil A vollständig implementiert; Teil B offen     |
 | Datum       | 2026-06-29                                                  |
 | Autor       | lepy <lepy@tuta.io>                                          |
 | Komponente  | `sdata/sclass/blob.py` (+ `dataframe.py`, `image.py`, `filereference.py`) |
 | Betrifft    | `Blob` als gemeinsame Content-/Integritäts-/Provenienz-Basis |
-| Validierung | Teil-A-Kern umgesetzt; `tests/test_sclass_blob_hardening.py`, blob.py 100 % |
+| Validierung | Teil A komplett; `tests/test_sclass_blob_{hardening,io}.py`, blob.py 100 % |
 
-> **Umsetzungsstand.** Aus **Teil A** umgesetzt (rückwärtskompatibel, kanonische CI
-> grün, `blob.py` 100 %): **B4** `saf:`→Standard-Vokabular (`schema:sha256`,
+> **Umsetzungsstand.** **Teil A vollständig** umgesetzt (rückwärtskompatibel,
+> kanonische CI grün, `blob.py` 100 %):
+> **B1** `sha256`-Property; **B2** Auto-Befüllung `mime_type` (aus `filetype`) und
+> `creation_date` (aus dem reservierten `_sdata_ctime` — kein zweiter Zeitstempel);
+> **B3** Cache als nicht-serialisiertes Instanzattribut `_content_cache` (nicht mehr
+> in `self.data`); **B4** `saf:`→Standard-Vokabular (`schema:sha256`,
 > `dcat:mediaType`, `dcterms:source`/`created`/`modified`/`publisher`/`license`);
-> **B1** `sha256`-Property; **B6** `verify()` + `update_checksum()`; **B3** Cache als
-> nicht-serialisiertes Instanzattribut `_content_cache` (nicht mehr in `self.data`);
-> **B7** `size`-Property.
-> **Offen** (Folge-PRs): **B2** Auto-Befüllung `mime_type`/`creation_date` (Determinismus
-> abzuwägen), **B5** `write(uri)`/`open()` (fsspec-Schreib-API), **Teil B** (Foundation:
-> `FileReference`/`Image` → `Blob`; `DataFrame(Blob)` eigener Folge-RFC).
+> **B5** `write(uri)` + `open(mode)` (fsspec; `open` streamt URIs, `io.BytesIO` für
+> bytes); **B6** `verify()` + `update_checksum()`; **B7** `size`-Property.
+> **Offen:** **Teil B** (Foundation: `FileReference`/`Image` → `Blob`; `DataFrame(Blob)`
+> als eigener Folge-RFC).
 
 ## 1. Zusammenfassung
 

--- a/sdata/sclass/blob.py
+++ b/sdata/sclass/blob.py
@@ -3,6 +3,7 @@ import logging
 import hashlib
 import os
 import io
+import mimetypes
 import typing
 from typing import Any, List, Dict, Optional, Literal, Optional, Type
 from sdata.base import Base
@@ -148,8 +149,21 @@ class Blob(Base):
             'filetype': filetype,
         }
         self._set_value(value)
+        self._autofill_metadata()
 
         logger.debug(f"Created Blob '{self.sname}' with content_type '{content_type}' and filetype '{filetype}'")
+
+    def _autofill_metadata(self) -> None:
+        """Fill derivable metadata: ``mime_type`` from ``filetype`` and
+        ``creation_date`` from the reserved ``_sdata_ctime`` (no second timestamp).
+        Only sets values that can be derived; leaves the rest untouched.
+        """
+        mime = mimetypes.guess_type(f"x.{self.filetype}")[0]
+        if mime:
+            self.metadata.set_attr("mime_type", mime)
+        ctime = self.metadata.get(self.SDATA_CTIME)
+        if ctime is not None and ctime.value:
+            self.metadata.set_attr("creation_date", ctime.value)
 
     def _set_value(self, value: Any) -> None:
         """
@@ -194,6 +208,7 @@ class Blob(Base):
             self.data['content']['filetype'] = filetype
         self._set_value(value)
         self._content_cache = None  # Clear cache for lazy reloading
+        self._autofill_metadata()
         logger.debug(
             f"Updated Blob '{self.sname}' to content_type '{content_type}' and filetype '{self.data['content']['filetype']}'")
 
@@ -367,6 +382,46 @@ class Blob(Base):
             logger.warning("Blob.verify: no checksum stored (call update_checksum first)")
             return False
         return stored == self.sha256
+
+    def write(self, uri: str, **kwargs: Any) -> str:
+        """Write the content to a destination ``uri`` via fsspec (local/S3/zip/…).
+
+        :param uri: destination URI/path (e.g. ``/out/file.pdf``, ``s3://bucket/key``).
+        :param kwargs: forwarded to ``fsspec.open``.
+        :return: the destination ``uri``.
+        :raises ImportError: if fsspec is not installed (``pip install sdata[blob]``).
+        """
+        if fsspec is None:
+            raise ImportError("fsspec is required for write() (pip install sdata[blob]).")
+        data = self.content_bytes
+        with fsspec.open(uri, "wb", **kwargs) as f:
+            f.write(data)
+        logger.info(f"Blob content written to {uri}")
+        return uri
+
+    def open(self, mode: str = "rb"):
+        """Return a file-like handle to the content; use as a context manager.
+
+        For ``uri`` content a **streaming** fsspec handle is returned (no full
+        in-memory load); for ``bytes`` content an :class:`io.BytesIO` over the
+        decoded bytes.
+
+        :param mode: open mode (default ``"rb"``).
+        :raises ValueError: if no content/value is set or the content_type is unknown.
+        :raises ImportError: if fsspec is required (uri) but not installed.
+        """
+        content = self.data.get('content')
+        if content is None or content.get('value') is None:
+            raise ValueError("No content set in Blob.")
+        ctype = content['type']
+        if ctype == 'uri':
+            if fsspec is None:
+                raise ImportError("fsspec is required for uri open() (pip install sdata[blob]).")
+            return fsspec.open(content['value'], mode)
+        elif ctype == 'bytes':
+            return io.BytesIO(self.content_bytes)
+        else:
+            raise ValueError(f"Unknown content_type: {ctype}")
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/tests/test_sclass_blob_io.py
+++ b/tests/test_sclass_blob_io.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""Blob Teil A — Rest (RFC 0003): mime_type/creation_date-Autofill (B2) und
+write()/open() über fsspec (B5)."""
+import pytest
+
+pytest.importorskip("fsspec")
+
+import sdata.sclass.blob as blobmod
+from sdata.sclass.blob import Blob
+
+
+def test_mime_and_creation_autofill():
+    b = Blob(content_type="bytes", value=b"x", filetype="pdf", name="b")
+    assert b.metadata.get("mime_type").value == "application/pdf"
+    ctime = b.metadata.get("_sdata_ctime").value
+    assert ctime and b.metadata.get("creation_date").value == ctime   # aus _sdata_ctime
+    # Default-Filetype 'binary' -> kein MIME ableitbar -> bleibt None
+    b2 = Blob(content_type="bytes", value=b"x", name="b2")
+    assert b2.metadata.get("mime_type").value is None
+
+
+def test_write_and_open_bytes(tmp_path):
+    b = Blob(content_type="bytes", value=b"hello", filetype="bin", name="b")
+    dest = str(tmp_path / "out.bin")
+    assert b.write(dest) == dest
+    assert (tmp_path / "out.bin").read_bytes() == b"hello"
+    with b.open() as f:                          # bytes -> io.BytesIO
+        assert f.read() == b"hello"
+
+
+def test_open_uri(tmp_path):
+    p = tmp_path / "f.txt"
+    p.write_bytes(b"uri-bytes")
+    b = Blob(content_type="uri", value=str(p), filetype="txt", name="u")
+    with b.open() as f:                          # uri -> streamendes fsspec-Handle
+        assert f.read() == b"uri-bytes"
+
+
+def test_open_errors():
+    with pytest.raises(ValueError):
+        Blob(name="b").open()                    # kein value
+    b = Blob(content_type="bytes", value=b"x", name="b2")
+    b.data["content"]["type"] = "weird"
+    with pytest.raises(ValueError):
+        b.open()                                 # unbekannter content_type
+
+
+def test_write_open_fsspec_none(monkeypatch, tmp_path):
+    b = Blob(content_type="bytes", value=b"x", name="b")
+    bu = Blob(content_type="uri", value=str(tmp_path / "f"), name="u")
+    monkeypatch.setattr(blobmod, "fsspec", None)
+    with pytest.raises(ImportError):
+        b.write(str(tmp_path / "x.bin"))
+    with pytest.raises(ImportError):
+        bu.open()


### PR DESCRIPTION
Vervollständigt **RFC 0003, Teil A** (rückwärtskompatibel, kanonische CI grün, `blob.py` **100 %**).

- **B2** `_autofill_metadata()` befüllt `mime_type` aus `filetype` (`mimetypes`) und `creation_date` aus dem reservierten **`_sdata_ctime`** (kein zweiter, abweichender Zeitstempel); in `__init__` und `set_content` aufgerufen.
- **B5** `write(uri, **kwargs)` schreibt den Inhalt via fsspec; `open(mode)` liefert ein file-like Handle — **streamendes** fsspec-Handle für `uri`, `io.BytesIO` für `bytes` — als Context-Manager.

Tests: `tests/test_sclass_blob_io.py` (mime/creation_date-Autofill inkl. None-MIME beim Default-`filetype`; `write`+`open` bytes; `open` uri streaming; `ValueError` ohne value/unbekannter ctype; `ImportError` ohne fsspec). Bestehende Blob-Tests unverändert grün.

Damit ist **Teil A vollständig** (B1–B7). **Offen:** Teil B (Foundation: `FileReference`/`Image`→`Blob`; `DataFrame(Blob)` eigener Folge-RFC). `mkdocs build --strict` exit 0.