### PR TITLE
feat(filereference): FileReference auf Blob heben (RFC 0003, Teil B)

### DIFF
--- a/docs/rfc/0003-blob-as-data-foundation.md
+++ b/docs/rfc/0003-blob-as-data-foundation.md
@@ -18,8 +18,12 @@
 > `dcat:mediaType`, `dcterms:source`/`created`/`modified`/`publisher`/`license`);
 > **B5** `write(uri)` + `open(mode)` (fsspec; `open` streamt URIs, `io.BytesIO` für
 > bytes); **B6** `verify()` + `update_checksum()`; **B7** `size`-Property.
-> **Offen:** **Teil B** (Foundation: `FileReference`/`Image` → `Blob`; `DataFrame(Blob)`
-> als eigener Folge-RFC).
+> Aus **Teil B** (Foundation, Option 3 gestaffelt) umgesetzt: **`FileReference(Blob)`**
+> — die Datei wird als `uri`-Content gehalten (der Pfad bleibt jetzt erhalten, ging
+> zuvor verloren) und `FileReference` erbt `content_bytes`/`open`/`exists`/`verify`/
+> `size`; `blob.py`/`filereference.py` 100 %.
+> **Offen:** `Image` → `Blob` (experimentell/`omit`, vorher stabilisieren);
+> `DataFrame(Blob)` als eigener Folge-RFC.
 
 ## 1. Zusammenfassung
 

--- a/sdata/sclass/filereference.py
+++ b/sdata/sclass/filereference.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 from sdata import SUUID
 from sdata.metadata import Metadata, Attribute
-# from sdata.sclass.blob import Blob  # Assuming Blob is in sdata.blob or adjust import
+from sdata.sclass.blob import Blob
 from sdata.base import Base
 import hashlib
 import datetime
@@ -16,7 +16,7 @@ from sdata.timestamp import get_utc_timestamp
 logger = logging.getLogger(__name__)
 
 
-class FileReference(Base):
+class FileReference(Blob):
     SDATA_CLS = "sdata.sclass.filereference.FileReference"
 
     def __init__(
@@ -25,17 +25,22 @@ class FileReference(Base):
             **kwargs: Any
     ) -> None:
         """
-        Initialize FileReference with content type, value, and filetype.
-        :param filetype: The type of the file (e.g., 'pdf', 'png', 'jpg', 'txt').
-        :param kwargs: Keyword arguments passed to Base.__init__ (e.g., name, description).
-        :raises ValueError: If invalid content_type or mismatched value type.
+        Initialize FileReference as a :class:`~sdata.sclass.blob.Blob` over a file URI.
+
+        The file path is kept as the Blob ``uri`` content, so the reference also
+        provides ``content_bytes``/``open``/``exists``/``verify``/``size`` from Blob.
+
+        :param filetype: vestigial; the file suffix is derived from ``name``.
+        :param kwargs: Keyword arguments passed to Base (e.g. ``name`` = file path).
         """
         filepath = kwargs.get("name", "noname")
         basename = os.path.basename(filepath)
         kwargs["name"] = basename
-        super().__init__(**kwargs)
-
         path = Path(filepath)
+        # Blob-Grundlage: die Datei als uri-Content -> behält den Pfad (zuvor verloren)
+        super().__init__(content_type="uri", value=filepath,
+                         filetype=path.suffix.lstrip(".").lower() or "binary", **kwargs)
+
         self.metadata.add("_sdata_name", basename, description="base name of the file without folder")
         self.metadata.add("_sdata_stem", path.stem, description="file name without suffix")
         self.metadata.add("_sdata_filetype", path.suffix.lower(), description="file suffix")
@@ -68,7 +73,10 @@ class FileReference(Base):
 
     @property
     def filetype(self) -> str:
-        return self.metadata.get("_sdata_filetype").value
+        # robust: _sdata_filetype wird erst nach super().__init__() gesetzt, Blobs
+        # _autofill_metadata fragt filetype aber bereits währenddessen ab.
+        attr = self.metadata.get("_sdata_filetype")
+        return attr.value if attr is not None else ""
 
     @property
     def stem(self) -> str:

--- a/tests/test_sclass_filereference_blob.py
+++ b/tests/test_sclass_filereference_blob.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""FileReference(Blob) — RFC 0003 Teil B (1. Schritt): FileReference auf Blob.
+
+Verifiziert den Foundation-Gewinn: der Datei-Pfad bleibt als uri-Content erhalten
+(ging zuvor verloren) und FileReference erbt die Blob-Content-API.
+"""
+import pytest
+
+pytest.importorskip("fsspec")
+
+from sdata.sclass.blob import Blob
+from sdata.sclass.filereference import FileReference
+
+
+def test_filereference_is_blob_and_retains_path(tmp_path):
+    p = tmp_path / "doc.pdf"
+    p.write_bytes(b"hello pdf")
+    fr = FileReference.from_file(str(p))
+    assert isinstance(fr, Blob)
+    # Pfad als uri-Content erhalten (zuvor ging er verloren)
+    assert fr.data["content"]["type"] == "uri"
+    assert fr.data["content"]["value"] == str(p)
+    # geerbte Blob-Fähigkeiten
+    assert fr.content_bytes == b"hello pdf"
+    assert fr.exists() is True
+    assert fr.size == len(b"hello pdf")
+    with fr.open() as f:
+        assert f.read() == b"hello pdf"
+
+
+def test_filereference_missing_path_not_exists(tmp_path):
+    fr = FileReference(name=str(tmp_path / "missing.txt"))
+    assert fr.exists() is False
+    assert fr.filetype == ".txt"          # robuste Property weiterhin korrekt


### PR DESCRIPTION
Erster **Teil-B-Schritt** aus RFC 0003 (Option 3, gestaffelt): **`FileReference(Blob)`** — realisiert den auskommentierten `Blob`-Import.

## Gewinn
- Die Datei wird als **`uri`-Content** gehalten → der **Pfad bleibt erhalten** (ging in der bisherigen `FileReference(Base)` verloren — es wurden nur basename/stem/suffix gespeichert).
- `FileReference` erbt damit `content_bytes`/`open`/`exists`/`verify`/`size` aus `Blob`.

## Verträglichkeit
- `__init__` ruft `Blob.__init__(content_type="uri", value=<filepath>, filetype=<suffix>)`; die FileReference-Metadaten (`_sdata_stem`/`_filetype`/`_filesize`/`_filectime`/`_sha3_256`) bleiben.
- `filetype`-Property **robust** gemacht: `_sdata_filetype` wird erst nach `super().__init__` gesetzt, Blobs `_autofill_metadata` fragt `filetype` aber bereits währenddessen ab.
- **Bestehende Tests unverändert grün**; neuer Test (`tests/test_sclass_filereference_blob.py`): Pfad erhalten + `content_bytes`/`exists`/`size`/`open`.

Kanonische CI grün, `blob.py` + `filereference.py` **100 %**; `mkdocs build --strict` exit 0. RFC 0003 aktualisiert (offen: `Image`→`Blob`, `DataFrame(Blob)` eigener RFC).