### PR TITLE
release: v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to **sdata** are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-29
+
 A large, strictly **additive** increment: a content/integrity foundation under all
 data containers (`Blob`), a much broader `DataFrame` serialization portfolio, and
 native, format-agnostic metadata embedding for images. Core dependencies remain
@@ -65,5 +67,6 @@ native, format-agnostic metadata embedding for images. Core dependencies remain
   dependencies reduced to `numpy`/`pandas`/`suuid` (stdlib `zoneinfo`); warning-free
   test suite.
 
-[Unreleased]: https://github.com/lepy/sdata/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/lepy/sdata/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/lepy/sdata/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/lepy/sdata/releases/tag/v1.2.0

--- a/sdata/__init__.py
+++ b/sdata/__init__.py
@@ -1,7 +1,7 @@
 # -*-coding: utf-8-*-
 from __future__ import division
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 __revision__ = None
 __version_info__ = tuple([int(num) for num in __version__.split('.')])
 


### PR DESCRIPTION
## Release-Vorbereitung 1.3.0

- **Version-Bump** `1.2.0 → 1.3.0` in `sdata/__init__.py` (einzige Versionsquelle;
  `setup.py` liest sie, `pyproject.toml` hat keine eigene Version).
- **CHANGELOG**: `[Unreleased] → [1.3.0] - 2026-06-29` + Compare-Links.

### Inhalt von 1.3.0 (additiv seit dem nie veröffentlichten `v1.2.0`)

Blob-Foundation (RFC 0003) · Integritäts-Mixin + `DataFrame.as_blob` (RFC 0004) ·
DataFrame-Serialisierung (Arrow-Field-Metadata, Data Package, HDF5/RFC 0002) ·
native Bild-Metadaten über 6 Container + Sidecar (RFC 0005).

### Verifikation

- Lokale CI: **603 passed, 7 skipped, Coverage 100 %** (`test_base` prüft gegen das
  importierte `__version__`).
- `uv build` → `sdata-1.3.0.tar.gz` + `sdata-1.3.0-py3-none-any.whl`;
  `uvx twine check dist/*` **PASSED** (beide).

### Danach (manuell, deine Schritte)

1. PyPI **Trusted Publisher** registrieren (falls noch nicht): owner `lepy`, repo
   `sdata`, workflow `release.yml`, environment `pypi`.
2. Release + Tag anlegen → triggert `release.yml` (build + publish):
   `gh release create v1.3.0 --title v1.3.0 --generate-notes`

Dieser PR **veröffentlicht nichts** — nur Version + CHANGELOG.