### PR TITLE
feat(units): Einheiten-Konvertierung + DataFrame.convert_units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to **sdata** are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+
+- **Unit conversion (`sdata.units`).** A pure-Python conversion layer over the
+  curated unit table — `convert`/`convert_factor`/`quantity_of` and a `UnitSystem`
+  helper (consistent unit systems such as `["kN", "mm", "ms"]`). It covers the common
+  engineering quantities (length, force, time, mass, pressure, strain-rate,
+  temperature incl. offset units), works on scalars/lists/NumPy arrays/pandas Series,
+  and raises a clear `UnitConversionError` on incompatible quantities.
+- **`DataFrame.convert_units(units, inplace=False)`.** Rescale a table's columns into
+  a target unit system (a unit list, a `UnitSystem`, or an explicit `{column: unit}`
+  mapping) and update the per-column `unit` annotations in one step — returning a
+  converted copy by default. Columns without a unit or whose quantity the system does
+  not cover are left unchanged.
+- **Docs.** A worked tensile-test example (`force [N]` / `time [s]` /
+  `displacement [mm]`, fully semantically described, converted to `[kN, mm, ms]`) and
+  a unit-conversion reference in `usage/dataframe.md`.
+
 ## [1.3.0] - 2026-06-29
 
 A large, strictly **additive** increment: a content/integrity foundation under all

--- a/docs/usage/dataframe.md
+++ b/docs/usage/dataframe.md
@@ -19,6 +19,74 @@ sdf = DataFrame(df=df, name="specimen_01", description="a tension test")
 [`Metadata`][sdata.metadata.Metadata]) and any `Base` keyword (`name`,
 `description`, `project`, …). Passing no `df` yields an empty table.
 
+## Worked example: a tensile test
+
+A short, end-to-end example: a quasi-static tensile test with three measured
+channels — **force [N]**, **time [s]** and **displacement [mm]**. Each column is
+described *semantically completely* (unit, human label, free-text description and an
+ontology class), and the whole table is then converted into the consistent unit
+system **[kN, mm, ms]** for downstream FE/explicit-dynamics tooling.
+
+```python
+import pandas as pd
+from sdata.sclass.dataframe import DataFrame
+
+raw = pd.DataFrame({
+    "time":         [0.0, 0.25, 0.50],     # s
+    "force":        [0.0, 2500.0, 5000.0],  # N
+    "displacement": [0.0, 1.2, 2.4],        # mm
+})
+
+sdf = DataFrame(df=raw, name="tensile_specimen_01",
+                description="quasi-static tensile test, specimen 01")
+
+# describe every column completely: unit, label, description, ontology class
+sdf.set_column("time", unit="s", label="Time",
+               description="elapsed test time", ontology="bfo:Quality")
+sdf.set_column("force", unit="N", label="Force",
+               description="measured load-cell force", ontology="bfo:Quality")
+sdf.set_column("displacement", unit="mm", label="Displacement",
+               description="crosshead displacement", ontology="bfo:Quality")
+
+sdf.column_units            # {'time': 's', 'force': 'N', 'displacement': 'mm'}
+```
+
+Because the columns are fully qualified, every channel becomes a self-describing,
+unit-bearing node in the JSON-LD (`sdf.to_jsonld()["columns"]`) — units carry their
+QUDT IRI, the pandas dtype maps to an XSD datatype:
+
+```json
+[
+  {"name": "time", "datatype": "xsd:double",
+   "unitRef": "unit:SEC", "symbol": "s",
+   "label": "Time", "description": "elapsed test time"},
+  {"name": "force", "datatype": "xsd:double",
+   "unitRef": "unit:N", "symbol": "N",
+   "label": "Force", "description": "measured load-cell force"},
+  {"name": "displacement", "datatype": "xsd:double",
+   "unitRef": "unit:MilliM", "symbol": "mm",
+   "label": "Displacement", "description": "crosshead displacement"}
+]
+```
+
+Now convert the whole table into the **[kN, mm, ms]** unit system. `convert_units`
+rescales the data of every column whose physical quantity the system addresses and
+updates its `unit` annotation — by default returning a converted copy, so the
+original stays in SI:
+
+```python
+si = sdf.convert_units(["kN", "mm", "ms"])
+
+si.column_units              # {'time': 'ms', 'force': 'kN', 'displacement': 'mm'}
+list(si.df["force"])         # [0.0, 2.5, 5.0]     N  -> kN  (÷ 1000)
+list(si.df["time"])          # [0.0, 250.0, 500.0] s  -> ms  (× 1000)
+list(si.df["displacement"])  # [0.0, 1.2, 2.4]     mm -> mm  (unchanged)
+
+list(sdf.df["force"])        # [0.0, 2500.0, 5000.0]  — original untouched
+```
+
+See [Unit conversion](#unit-conversion) for the full conversion API.
+
 ## The pandas frame
 
 The wrapped frame is always available via `sdf.df` (settable). Thin convenience
@@ -92,6 +160,47 @@ sdf.col["weight"].unit = "kg"        # mutate a field in place
 removed columns are pruned, while surviving columns keep their `unit`/`label`.
 Column metadata supplied at construction time is preserved as-is (orphan keys —
 keys that match no column — are only logged as a warning, never dropped).
+
+### Unit conversion
+
+`convert_units` rescales column data into a target **unit system** and updates the
+`unit` annotations in one step (pure Python, no extra dependency — the curated table
+in [`sdata.units`][sdata.units] covers the common engineering units: length, force,
+time, mass, pressure, strain-rate and temperature). The argument may be
+
+* a list/tuple of unit symbols — e.g. `["kN", "mm", "ms"]` — wrapped into a
+  [`UnitSystem`][sdata.units.UnitSystem] (one unit per physical quantity),
+* a [`UnitSystem`][sdata.units.UnitSystem] instance, or
+* a dict `{column: target_unit}` for explicit, per-column targets.
+
+```python
+si = sdf.convert_units(["kN", "mm", "ms"])      # -> converted copy (original kept)
+sdf.convert_units(["kN", "mm", "ms"], inplace=True)   # mutate in place
+
+# explicit per-column targets
+sdf.convert_units({"stress": "GPa", "strain": "%"})
+```
+
+Only columns whose physical quantity the system addresses are touched; columns
+without a unit, dimensionless columns, and quantities the system does not cover are
+left unchanged. Converting across incompatible quantities (e.g. a length column to a
+force unit) raises [`UnitConversionError`][sdata.units.UnitConversionError].
+
+The same machinery is available standalone for scalars, lists, NumPy arrays and
+pandas Series:
+
+```python
+from sdata.units import convert, convert_factor, UnitSystem
+
+convert(5000, "N", "kN")        # 5.0
+convert([0.1, 0.2], "s", "ms")  # [100.0, 200.0]
+convert(25, "degC", "K")        # 298.15   (offset units handled)
+convert_factor("N", "kN")       # 0.001    (pure scale factor)
+
+system = UnitSystem(["kN", "mm", "ms"])
+system.target_for("N")          # 'kN'  (same quantity as the system's force unit)
+system.target_for("MPa")        # None  (pressure not in this system)
+```
 
 ## Serialization
 

--- a/sdata/sclass/dataframe.py
+++ b/sdata/sclass/dataframe.py
@@ -214,6 +214,72 @@ class DataFrame(ContentIntegrityMixin, Base):
                 units[str(col)] = attr.unit
         return units
 
+    def _converted_copy(self):
+        """Tiefe Kopie dieses DataFrame (Daten + Metadaten) für nicht-mutierende Ops."""
+        new = self.__class__(df=self._df.copy(deep=True))
+        new.metadata = self.metadata.copy()
+        new._column_metadata = self._column_metadata.copy()
+        new.description = self.description
+        return new
+
+    def _resolve_unit_targets(self, units, U):
+        """Bestimme je Spalte die Ziel-Einheit für :meth:`convert_units`.
+
+        :param units: ``UnitSystem`` / Einheiten-Liste / ``{Spalte: Einheit}``-dict.
+        :param U: das :mod:`sdata.units`-Modul (injiziert, spart Re-Import).
+        :return: ``{Spalte: Ziel-Einheit-oder-None}``.
+        """
+        if isinstance(units, dict):
+            return {str(col): unit for col, unit in units.items()}
+        system = units if isinstance(units, U.UnitSystem) else U.UnitSystem(units)
+        targets = {}
+        for col in self._df.columns:
+            attr = self._column_metadata.get(str(col))
+            if attr is not None:
+                targets[str(col)] = system.target_for(attr.unit)
+        return targets
+
+    def convert_units(self, units, inplace=False):
+        """Convert numeric columns into a target unit system (or explicit units).
+
+        ``units`` may be
+
+        * a :class:`~sdata.units.UnitSystem`,
+        * a list/tuple of unit symbols, e.g. ``["kN", "mm", "ms"]`` — wrapped into a
+          :class:`~sdata.units.UnitSystem` (one unit per physical quantity), or
+        * a dict ``{column: target_unit}`` for explicit per-column targets.
+
+        Every column that carries a unit in :attr:`column_metadata` and whose
+        physical quantity is addressed by ``units`` has its **values rescaled** and
+        its ``unit`` annotation updated. Columns without a unit, dimensionless
+        columns, and quantities the system does not cover are left untouched. By
+        default a converted **copy** is returned (data + metadata); pass
+        ``inplace=True`` to mutate this DataFrame.
+
+        :param units: target unit system, unit list, or ``{column: unit}`` mapping.
+        :param inplace: mutate this DataFrame instead of returning a converted copy.
+        :return: the converted :class:`DataFrame` (``self`` if ``inplace``).
+        :raises sdata.units.UnitConversionError: on incompatible units (e.g. an
+          explicit mapping that converts a length column to a force unit).
+        """
+        from sdata import units as U
+        targets = self._resolve_unit_targets(units, U)
+        sdf = self if inplace else self._converted_copy()
+        for col, target in targets.items():
+            if target is None:
+                continue
+            attr = sdf._column_metadata.get(str(col))
+            current = attr.unit if attr is not None else None
+            if not current or current in ("-", ""):
+                logger.warning("convert_units: column %r has no unit; skipped", col)
+                continue
+            if str(target) == str(current):
+                continue
+            sdf._df[col] = U.convert(sdf._df[col], current, target)
+            sdf.set_column(col, unit=str(target))
+            logger.info("convert_units: %s %s -> %s", col, current, target)
+        return sdf
+
     def validate_table(self, schema=None):
         """Validate the df/column_metadata against a :class:`~sdata.schema.TableSchema`.
 

--- a/sdata/units.py
+++ b/sdata/units.py
@@ -8,6 +8,8 @@ die kuratierte Tabelle.
 __all__ = [
     "UNIT_MAP", "normalize_symbol", "qudt_iri", "ucum_code", "unit_node",
     "validate_unit", "has_pint",
+    "UnitConversionError", "quantity_of", "convert", "convert_factor",
+    "UnitSystem",
 ]
 
 try:  # optionales Backend
@@ -98,3 +100,164 @@ def validate_unit(symbol):
         except Exception:
             return False
     return False
+
+
+# --------------------------------------------------------------- Konvertierung
+
+class UnitConversionError(ValueError):
+    """Eine Einheit ist unbekannt oder die Größen sind inkompatibel (z. B. mm → kN)."""
+
+
+#: Einheit -> (Größe, Faktor, Offset) für die Umrechnung in die SI-Basis der Größe:
+#: ``si = wert * faktor + offset``. Reine Skalierung hat ``offset == 0``; nur
+#: Temperatur trägt einen Offset. Zwei Einheiten sind genau dann ineinander
+#: umrechenbar, wenn ihre *Größe* übereinstimmt. Die Tabelle deckt die im
+#: Ingenieurkontext üblichen mechanischen Einheiten ab (für beliebige Einheiten
+#: bliebe das optionale ``pint``-Backend – die Konvertierung bleibt jedoch bewusst
+#: deterministisch auf dieser kuratierten Tabelle).
+_CONVERT = {
+    # Länge (SI: m)
+    "km": ("length", 1e3, 0.0), "m": ("length", 1.0, 0.0),
+    "dm": ("length", 1e-1, 0.0), "cm": ("length", 1e-2, 0.0),
+    "mm": ("length", 1e-3, 0.0), "um": ("length", 1e-6, 0.0),
+    "nm": ("length", 1e-9, 0.0),
+    # Kraft (SI: N)
+    "MN": ("force", 1e6, 0.0), "kN": ("force", 1e3, 0.0),
+    "N": ("force", 1.0, 0.0), "mN": ("force", 1e-3, 0.0),
+    # Zeit (SI: s)
+    "h": ("time", 3600.0, 0.0), "min": ("time", 60.0, 0.0),
+    "s": ("time", 1.0, 0.0), "ms": ("time", 1e-3, 0.0),
+    "us": ("time", 1e-6, 0.0), "ns": ("time", 1e-9, 0.0),
+    # Masse (SI: kg)
+    "t": ("mass", 1e3, 0.0), "kg": ("mass", 1.0, 0.0),
+    "g": ("mass", 1e-3, 0.0), "mg": ("mass", 1e-6, 0.0),
+    # Druck / Spannung (SI: Pa)
+    "GPa": ("pressure", 1e9, 0.0), "MPa": ("pressure", 1e6, 0.0),
+    "kPa": ("pressure", 1e3, 0.0), "Pa": ("pressure", 1.0, 0.0),
+    # Dehnrate (SI: 1/s)
+    "1/s": ("strain_rate", 1.0, 0.0), "1/ms": ("strain_rate", 1e3, 0.0),
+    # Temperatur (SI: K) – mit Offset
+    "K": ("temperature", 1.0, 0.0), "degC": ("temperature", 1.0, 273.15),
+}
+
+#: Symbol-Aliasse speziell für die Konvertierung (verlustfrei, anders als die
+#: lockeren Validierungs-Aliasse – z. B. ``µm`` ist hier Mikrometer, nicht ``mm``).
+_CONVERT_ALIASES = {
+    "µm": "um", "μm": "um", "µs": "us", "μs": "us",
+    "°C": "degC", "celsius": "degC", "C": "degC",
+    "sec": "s", "second": "s", "seconds": "s", "minute": "min", "hour": "h",
+}
+
+
+def _norm_convert(symbol):
+    """Normalisiere ein Symbol auf einen Schlüssel der Konvertierungstabelle."""
+    if symbol is None:
+        return "-"
+    text = str(symbol).strip()
+    if text in _CONVERT:
+        return text
+    return _CONVERT_ALIASES.get(text, _CONVERT_ALIASES.get(text.lower(), text))
+
+
+def quantity_of(symbol):
+    """Physikalische Größe einer Einheit (``"force"``/``"length"``/…) oder ``None``.
+
+    :param symbol: Einheiten-Symbol (z. B. ``"kN"``).
+    :return: Name der Größe, oder ``None`` wenn die Einheit nicht in der
+      Konvertierungstabelle steht (z. B. ``"-"`` oder eine unbekannte Einheit).
+    """
+    entry = _CONVERT.get(_norm_convert(symbol))
+    return entry[0] if entry else None
+
+
+def _entry(symbol, role):
+    """Tabellen-Eintrag für ``symbol`` holen oder mit klarer Meldung scheitern."""
+    entry = _CONVERT.get(_norm_convert(symbol))
+    if entry is None:
+        raise UnitConversionError(f"unknown {role} unit {symbol!r}")
+    return entry
+
+
+def convert(value, from_unit, to_unit):
+    """Rechne ``value`` von ``from_unit`` in ``to_unit`` um.
+
+    Funktioniert für Skalare, Listen/Tupel, NumPy-Arrays und pandas-Series (alle
+    elementweise). Beide Einheiten müssen dieselbe physikalische Größe haben.
+
+    :param value: Zahl(en) in ``from_unit``.
+    :param from_unit: Quell-Einheit (z. B. ``"N"``).
+    :param to_unit: Ziel-Einheit (z. B. ``"kN"``).
+    :return: der umgerechnete Wert (gleiche Containerform wie ``value``; Listen/
+      Tupel werden als Liste zurückgegeben).
+    :raises UnitConversionError: bei unbekannter Einheit oder inkompatiblen Größen.
+    """
+    qf, ff, fo = _entry(from_unit, "source")
+    qt, tf, to = _entry(to_unit, "target")
+    if qf != qt:
+        raise UnitConversionError(
+            f"incompatible units: {from_unit!r} ({qf}) -> {to_unit!r} ({qt})")
+    # si = wert*ff + fo ; ziel = (si - to) / tf
+    if isinstance(value, (list, tuple)):
+        return [(v * ff + fo - to) / tf for v in value]
+    return (value * ff + fo - to) / tf
+
+
+def convert_factor(from_unit, to_unit):
+    """Reiner Skalierungsfaktor ``from_unit`` → ``to_unit`` (nur Offset-freie Einheiten).
+
+    Praktisch, um eine ganze Spalte/Reihe mit *einem* Faktor zu multiplizieren.
+
+    :raises UnitConversionError: bei unbekannten/inkompatiblen Einheiten oder wenn
+      eine der Einheiten einen Offset trägt (z. B. ``degC`` – dann ``convert`` nutzen).
+    """
+    qf, ff, fo = _entry(from_unit, "source")
+    qt, tf, to = _entry(to_unit, "target")
+    if qf != qt:
+        raise UnitConversionError(
+            f"incompatible units: {from_unit!r} ({qf}) -> {to_unit!r} ({qt})")
+    if fo or to:
+        raise UnitConversionError(
+            f"offset units need convert(): {from_unit!r} -> {to_unit!r}")
+    return ff / tf
+
+
+class UnitSystem:
+    """Konsistentes Einheitensystem: je physikalischer Größe genau eine Einheit.
+
+    Aus einer Liste von Einheiten (z. B. ``["kN", "mm", "ms"]``) wird eine
+    Abbildung *Größe → Einheit* gebaut. :meth:`target_for` liefert die
+    System-Einheit derselben Größe wie eine gegebene Einheit – ideal, um einen
+    ganzen :class:`~sdata.sclass.dataframe.DataFrame` in ein gemeinsames System
+    umzurechnen.
+
+    :param units: iterierbare Einheiten-Symbole; jede muss in der
+      Konvertierungstabelle bekannt sein. Bei mehreren Einheiten derselben Größe
+      gewinnt die zuletzt genannte.
+    :raises UnitConversionError: wenn eine Einheit unbekannt ist.
+    """
+
+    def __init__(self, units):
+        self.units = []
+        self.by_quantity = {}
+        for symbol in units:
+            quantity = quantity_of(symbol)
+            if quantity is None:
+                raise UnitConversionError(f"unknown unit in system: {symbol!r}")
+            sym = str(symbol).strip()
+            self.units.append(sym)
+            self.by_quantity[quantity] = sym
+
+    def unit_for(self, quantity):
+        """System-Einheit für eine Größe (``"force"`` …) oder ``None``."""
+        return self.by_quantity.get(quantity)
+
+    def target_for(self, symbol):
+        """System-Einheit derselben Größe wie ``symbol`` – sonst ``None``.
+
+        ``None`` heißt: die Einheit ist unbekannt/dimensionslos oder ihre Größe
+        kommt im System nicht vor (die Spalte bleibt dann unverändert).
+        """
+        return self.by_quantity.get(quantity_of(symbol))
+
+    def __repr__(self):
+        return f"UnitSystem({self.units!r})"

--- a/tests/test_sclass_dataframe_units.py
+++ b/tests/test_sclass_dataframe_units.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""Tests für DataFrame.convert_units (Umrechnung in ein Einheitensystem)."""
+import logging
+
+import pandas as pd
+import pytest
+
+from sdata import units
+from sdata.sclass.dataframe import DataFrame
+
+
+def _tensile():
+    """Ein vollständig annotierter Zugversuch-DataFrame (force[N]/time[s]/disp[mm])."""
+    df = pd.DataFrame({
+        "force": [0.0, 2500.0, 5000.0],
+        "time": [0.0, 0.25, 0.5],
+        "displacement": [0.0, 1.2, 2.4],
+    })
+    sdf = DataFrame(df=df, name="tensile_test", description="a tension test")
+    sdf.set_column("force", unit="N", label="Force", ontology="bfo:Quality")
+    sdf.set_column("time", unit="s", label="Time", ontology="bfo:Quality")
+    sdf.set_column("displacement", unit="mm", label="Displacement",
+                   ontology="bfo:Quality")
+    return sdf
+
+
+def test_convert_to_unit_system_copy():
+    sdf = _tensile()
+    conv = sdf.convert_units(["kN", "mm", "ms"])
+
+    # umgerechnete Kopie
+    assert conv.column_units == {"force": "kN", "time": "ms", "displacement": "mm"}
+    assert list(conv.df["force"]) == [0.0, 2.5, 5.0]
+    assert list(conv.df["time"]) == [0.0, 250.0, 500.0]
+    assert list(conv.df["displacement"]) == [0.0, 1.2, 2.4]   # mm -> mm unverändert
+
+    # Original bleibt unangetastet
+    assert sdf.column_units == {"force": "N", "time": "s", "displacement": "mm"}
+    assert list(sdf.df["force"]) == [0.0, 2500.0, 5000.0]
+    assert conv is not sdf
+
+
+def test_convert_preserves_other_column_metadata():
+    sdf = _tensile()
+    conv = sdf.convert_units(["kN", "mm", "ms"])
+    assert conv.get_column("force").label == "Force"
+    assert conv.get_column("force").ontology == "bfo:Quality"
+    assert conv.description == "a tension test"
+
+
+def test_convert_inplace():
+    sdf = _tensile()
+    ret = sdf.convert_units(["kN", "mm", "ms"], inplace=True)
+    assert ret is sdf
+    assert list(sdf.df["force"]) == [0.0, 2.5, 5.0]
+    assert sdf.column_units["time"] == "ms"
+
+
+def test_convert_accepts_unit_system_object():
+    sdf = _tensile()
+    system = units.UnitSystem(["kN", "mm", "ms"])
+    conv = sdf.convert_units(system)
+    assert conv.column_units["force"] == "kN"
+
+
+def test_convert_leaves_unaddressed_quantity_unchanged():
+    df = pd.DataFrame({"force": [1000.0], "stress": [200.0]})
+    sdf = DataFrame(df=df, name="mix")
+    sdf.set_column("force", unit="N")
+    sdf.set_column("stress", unit="MPa")
+    conv = sdf.convert_units(["kN", "mm", "ms"])   # kein Druck im System
+    assert conv.column_units["force"] == "kN"
+    assert conv.column_units["stress"] == "MPa"     # unverändert
+    assert list(conv.df["stress"]) == [200.0]
+
+
+def test_convert_dict_mapping():
+    df = pd.DataFrame({"stress": [1000.0]})
+    sdf = DataFrame(df=df, name="d")
+    sdf.set_column("stress", unit="MPa")
+    conv = sdf.convert_units({"stress": "GPa"})
+    assert conv.column_units["stress"] == "GPa"
+    assert list(conv.df["stress"]) == [1.0]          # 1000 MPa -> 1 GPa
+
+
+def test_convert_dict_column_without_unit_warns(caplog):
+    df = pd.DataFrame({"x": [1.0, 2.0]})
+    sdf = DataFrame(df=df, name="d")                 # x hat keine Einheit ("-")
+    with caplog.at_level(logging.WARNING):
+        conv = sdf.convert_units({"x": "kN"})
+    assert "has no unit" in caplog.text
+    assert list(conv.df["x"]) == [1.0, 2.0]          # unverändert
+
+
+def test_convert_dict_unknown_column_warns(caplog):
+    sdf = _tensile()
+    with caplog.at_level(logging.WARNING):
+        sdf.convert_units({"ghost": "kN"})           # Spalte existiert nicht
+    assert "has no unit" in caplog.text
+
+
+def test_convert_dict_incompatible_raises():
+    sdf = _tensile()
+    with pytest.raises(units.UnitConversionError, match="incompatible"):
+        sdf.convert_units({"force": "mm"})           # Kraft -> Länge

--- a/tests/test_units_convert.py
+++ b/tests/test_units_convert.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""Tests für die Einheiten-Konvertierung (sdata/units.py): convert / convert_factor /
+quantity_of / UnitSystem."""
+import numpy as np
+import pandas as pd
+import pytest
+
+from sdata import units
+
+
+def test_quantity_of():
+    assert units.quantity_of("kN") == "force"
+    assert units.quantity_of("mm") == "length"
+    assert units.quantity_of("ms") == "time"
+    assert units.quantity_of("MPa") == "pressure"
+    assert units.quantity_of("degC") == "temperature"
+    assert units.quantity_of("-") is None          # dimensionslos
+    assert units.quantity_of(None) is None          # _norm_convert(None) -> "-"
+    assert units.quantity_of("furlong") is None      # unbekannt
+
+
+def test_convert_scalar():
+    assert units.convert(5000, "N", "kN") == 5.0
+    assert units.convert(0.5, "s", "ms") == 500.0
+    assert units.convert(1.2, "mm", "mm") == 1.2     # Identität
+    assert units.convert(2, "m", "mm") == 2000.0
+
+
+def test_convert_list_and_tuple():
+    assert units.convert([1000, 2000], "N", "kN") == [1.0, 2.0]
+    assert units.convert((0.1, 0.2), "s", "ms") == [100.0, 200.0]
+
+
+def test_convert_numpy_and_series():
+    out = units.convert(np.array([1000.0, 2000.0]), "N", "kN")
+    assert isinstance(out, np.ndarray)
+    assert list(out) == [1.0, 2.0]
+    ser = units.convert(pd.Series([1000.0, 2000.0]), "N", "kN")
+    assert isinstance(ser, pd.Series)
+    assert list(ser) == [1.0, 2.0]
+
+
+def test_convert_temperature_offset():
+    assert units.convert(25, "degC", "K") == 298.15
+    assert round(units.convert(300, "K", "degC"), 2) == 26.85
+    assert units.convert(20, "degC", "degC") == 20      # Offset hebt sich auf
+
+
+def test_convert_aliases():
+    assert units.convert(1, "µm", "nm") == pytest.approx(1000.0)  # Mikrometer (nicht mm!)
+    assert units.quantity_of("CELSIUS") == "temperature"  # .lower()-Alias
+    assert units.convert(2, "sec", "ms") == 2000.0
+
+
+def test_convert_unknown_units_raise():
+    with pytest.raises(units.UnitConversionError, match="source"):
+        units.convert(1, "furlong", "mm")
+    with pytest.raises(units.UnitConversionError, match="target"):
+        units.convert(1, "mm", "furlong")
+
+
+def test_convert_incompatible_raises():
+    with pytest.raises(units.UnitConversionError, match="incompatible"):
+        units.convert(1, "mm", "kN")
+
+
+def test_convert_factor():
+    assert units.convert_factor("N", "kN") == 0.001
+    assert units.convert_factor("s", "ms") == 1000.0
+
+
+def test_convert_factor_incompatible_raises():
+    with pytest.raises(units.UnitConversionError, match="incompatible"):
+        units.convert_factor("mm", "kN")
+
+
+def test_convert_factor_offset_raises():
+    with pytest.raises(units.UnitConversionError, match="offset"):
+        units.convert_factor("degC", "K")
+
+
+def test_unit_system():
+    sys = units.UnitSystem(["kN", "mm", "ms"])
+    assert sys.unit_for("force") == "kN"
+    assert sys.unit_for("length") == "mm"
+    assert sys.unit_for("time") == "ms"
+    assert sys.unit_for("pressure") is None
+    assert sys.target_for("N") == "kN"
+    assert sys.target_for("s") == "ms"
+    assert sys.target_for("mm") == "mm"
+    assert sys.target_for("MPa") is None              # Größe nicht im System
+    assert sys.target_for("-") is None                # dimensionslos
+    assert repr(sys) == "UnitSystem(['kN', 'mm', 'ms'])"
+
+
+def test_unit_system_last_unit_wins():
+    sys = units.UnitSystem(["N", "kN"])               # beide force
+    assert sys.unit_for("force") == "kN"
+
+
+def test_unit_system_unknown_unit_raises():
+    with pytest.raises(units.UnitConversionError, match="unknown unit in system"):
+        units.UnitSystem(["kN", "furlong"])


### PR DESCRIPTION
## Was

Native, reine-Python **Einheiten-Konvertierung** in `sdata.units` (kuratierte Tabelle, keine neue Abhängigkeit) plus `DataFrame.convert_units(...)`, um eine Tabelle in ein konsistentes Einheitensystem umzurechnen.

### `sdata.units`
- `convert(value, from, to)` / `convert_factor(from, to)` / `quantity_of(unit)` — für Skalare, Listen/Tupel, NumPy-Arrays und pandas-Series.
- Deckt **Länge, Kraft, Zeit, Masse, Druck, Dehnrate, Temperatur** ab (Temperatur inkl. Offset-Einheiten `degC`↔`K`).
- `UnitConversionError` bei unbekannten oder inkompatiblen Einheiten.
- **`UnitSystem`** — konsistentes Einheitensystem (z. B. `["kN", "mm", "ms"]`); je physikalischer Größe genau eine Einheit; `target_for(unit)` liefert die System-Einheit derselben Größe.

### `DataFrame.convert_units(units, inplace=False)`
- `units` = Einheiten-Liste, `UnitSystem` oder `{Spalte: Einheit}`.
- Skaliert die Daten jeder adressierten Spalte und aktualisiert die `unit`-Annotation; gibt standardmäßig eine **umgerechnete Kopie** zurück (`inplace=True` mutiert).
- Spalten ohne Einheit / dimensionslose Spalten / nicht abgedeckte Größen bleiben unverändert.

### Doku
Detailliertes **Zugversuch-Beispiel** (`force [N]` / `time [s]` / `displacement [mm]`), semantisch vollständig beschriebene Spalten (Einheit, Label, Beschreibung, Ontologie-Klasse), Umrechnung in **[kN, mm, ms]**, plus Konvertierungs-Referenz in `usage/dataframe.md`. CHANGELOG (Unreleased).

## Verifikation
- `ci/local-ci.sh` grün; **TOTAL 5012 stmts, 100 %** (`units.py` 100 %, `sclass/dataframe.py` 100 %); 643 passed, 7 skipped.
- `mkdocs build --strict` grün (Cross-Refs auf `UnitSystem`/`UnitConversionError` lösen auf).
- Strikt additiv, rückwärtskompatibel.