### PR TITLE
refactor(dataframe): convert_units -> convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to **sdata** are documented here. The format is based on
   engineering quantities (length, force, time, mass, pressure, strain-rate,
   temperature incl. offset units), works on scalars/lists/NumPy arrays/pandas Series,
   and raises a clear `UnitConversionError` on incompatible quantities.
-- **`DataFrame.convert_units(units, inplace=False)`.** Rescale a table's columns into
+- **`DataFrame.convert(units, inplace=False)`.** Rescale a table's columns into
   a target unit system (a unit list, a `UnitSystem`, or an explicit `{column: unit}`
   mapping) and update the per-column `unit` annotations in one step — returning a
   converted copy by default. Columns without a unit or whose quantity the system does

--- a/docs/usage/dataframe.md
+++ b/docs/usage/dataframe.md
@@ -69,13 +69,13 @@ QUDT IRI, the pandas dtype maps to an XSD datatype:
 ]
 ```
 
-Now convert the whole table into the **[kN, mm, ms]** unit system. `convert_units`
+Now convert the whole table into the **[kN, mm, ms]** unit system. `convert`
 rescales the data of every column whose physical quantity the system addresses and
 updates its `unit` annotation — by default returning a converted copy, so the
 original stays in SI:
 
 ```python
-si = sdf.convert_units(["kN", "mm", "ms"])
+si = sdf.convert(["kN", "mm", "ms"])
 
 si.column_units              # {'time': 'ms', 'force': 'kN', 'displacement': 'mm'}
 list(si.df["force"])         # [0.0, 2.5, 5.0]     N  -> kN  (÷ 1000)
@@ -163,7 +163,7 @@ keys that match no column — are only logged as a warning, never dropped).
 
 ### Unit conversion
 
-`convert_units` rescales column data into a target **unit system** and updates the
+`convert` rescales column data into a target **unit system** and updates the
 `unit` annotations in one step (pure Python, no extra dependency — the curated table
 in [`sdata.units`][sdata.units] covers the common engineering units: length, force,
 time, mass, pressure, strain-rate and temperature). The argument may be
@@ -174,11 +174,11 @@ time, mass, pressure, strain-rate and temperature). The argument may be
 * a dict `{column: target_unit}` for explicit, per-column targets.
 
 ```python
-si = sdf.convert_units(["kN", "mm", "ms"])      # -> converted copy (original kept)
-sdf.convert_units(["kN", "mm", "ms"], inplace=True)   # mutate in place
+si = sdf.convert(["kN", "mm", "ms"])            # -> converted copy (original kept)
+sdf.convert(["kN", "mm", "ms"], inplace=True)        # mutate in place
 
 # explicit per-column targets
-sdf.convert_units({"stress": "GPa", "strain": "%"})
+sdf.convert({"stress": "GPa", "strain": "%"})
 ```
 
 Only columns whose physical quantity the system addresses are touched; columns

--- a/sdata/sclass/dataframe.py
+++ b/sdata/sclass/dataframe.py
@@ -223,7 +223,7 @@ class DataFrame(ContentIntegrityMixin, Base):
         return new
 
     def _resolve_unit_targets(self, units, U):
-        """Bestimme je Spalte die Ziel-Einheit für :meth:`convert_units`.
+        """Bestimme je Spalte die Ziel-Einheit für :meth:`convert`.
 
         :param units: ``UnitSystem`` / Einheiten-Liste / ``{Spalte: Einheit}``-dict.
         :param U: das :mod:`sdata.units`-Modul (injiziert, spart Re-Import).
@@ -239,7 +239,7 @@ class DataFrame(ContentIntegrityMixin, Base):
                 targets[str(col)] = system.target_for(attr.unit)
         return targets
 
-    def convert_units(self, units, inplace=False):
+    def convert(self, units, inplace=False):
         """Convert numeric columns into a target unit system (or explicit units).
 
         ``units`` may be
@@ -271,13 +271,13 @@ class DataFrame(ContentIntegrityMixin, Base):
             attr = sdf._column_metadata.get(str(col))
             current = attr.unit if attr is not None else None
             if not current or current in ("-", ""):
-                logger.warning("convert_units: column %r has no unit; skipped", col)
+                logger.warning("convert: column %r has no unit; skipped", col)
                 continue
             if str(target) == str(current):
                 continue
             sdf._df[col] = U.convert(sdf._df[col], current, target)
             sdf.set_column(col, unit=str(target))
-            logger.info("convert_units: %s %s -> %s", col, current, target)
+            logger.info("convert: %s %s -> %s", col, current, target)
         return sdf
 
     def validate_table(self, schema=None):

--- a/tests/test_sclass_dataframe_units.py
+++ b/tests/test_sclass_dataframe_units.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Tests für DataFrame.convert_units (Umrechnung in ein Einheitensystem)."""
+"""Tests für DataFrame.convert (Umrechnung in ein Einheitensystem)."""
 import logging
 
 import pandas as pd
@@ -26,7 +26,7 @@ def _tensile():
 
 def test_convert_to_unit_system_copy():
     sdf = _tensile()
-    conv = sdf.convert_units(["kN", "mm", "ms"])
+    conv = sdf.convert(["kN", "mm", "ms"])
 
     # umgerechnete Kopie
     assert conv.column_units == {"force": "kN", "time": "ms", "displacement": "mm"}
@@ -42,7 +42,7 @@ def test_convert_to_unit_system_copy():
 
 def test_convert_preserves_other_column_metadata():
     sdf = _tensile()
-    conv = sdf.convert_units(["kN", "mm", "ms"])
+    conv = sdf.convert(["kN", "mm", "ms"])
     assert conv.get_column("force").label == "Force"
     assert conv.get_column("force").ontology == "bfo:Quality"
     assert conv.description == "a tension test"
@@ -50,7 +50,7 @@ def test_convert_preserves_other_column_metadata():
 
 def test_convert_inplace():
     sdf = _tensile()
-    ret = sdf.convert_units(["kN", "mm", "ms"], inplace=True)
+    ret = sdf.convert(["kN", "mm", "ms"], inplace=True)
     assert ret is sdf
     assert list(sdf.df["force"]) == [0.0, 2.5, 5.0]
     assert sdf.column_units["time"] == "ms"
@@ -59,7 +59,7 @@ def test_convert_inplace():
 def test_convert_accepts_unit_system_object():
     sdf = _tensile()
     system = units.UnitSystem(["kN", "mm", "ms"])
-    conv = sdf.convert_units(system)
+    conv = sdf.convert(system)
     assert conv.column_units["force"] == "kN"
 
 
@@ -68,7 +68,7 @@ def test_convert_leaves_unaddressed_quantity_unchanged():
     sdf = DataFrame(df=df, name="mix")
     sdf.set_column("force", unit="N")
     sdf.set_column("stress", unit="MPa")
-    conv = sdf.convert_units(["kN", "mm", "ms"])   # kein Druck im System
+    conv = sdf.convert(["kN", "mm", "ms"])   # kein Druck im System
     assert conv.column_units["force"] == "kN"
     assert conv.column_units["stress"] == "MPa"     # unverändert
     assert list(conv.df["stress"]) == [200.0]
@@ -78,7 +78,7 @@ def test_convert_dict_mapping():
     df = pd.DataFrame({"stress": [1000.0]})
     sdf = DataFrame(df=df, name="d")
     sdf.set_column("stress", unit="MPa")
-    conv = sdf.convert_units({"stress": "GPa"})
+    conv = sdf.convert({"stress": "GPa"})
     assert conv.column_units["stress"] == "GPa"
     assert list(conv.df["stress"]) == [1.0]          # 1000 MPa -> 1 GPa
 
@@ -87,7 +87,7 @@ def test_convert_dict_column_without_unit_warns(caplog):
     df = pd.DataFrame({"x": [1.0, 2.0]})
     sdf = DataFrame(df=df, name="d")                 # x hat keine Einheit ("-")
     with caplog.at_level(logging.WARNING):
-        conv = sdf.convert_units({"x": "kN"})
+        conv = sdf.convert({"x": "kN"})
     assert "has no unit" in caplog.text
     assert list(conv.df["x"]) == [1.0, 2.0]          # unverändert
 
@@ -95,11 +95,11 @@ def test_convert_dict_column_without_unit_warns(caplog):
 def test_convert_dict_unknown_column_warns(caplog):
     sdf = _tensile()
     with caplog.at_level(logging.WARNING):
-        sdf.convert_units({"ghost": "kN"})           # Spalte existiert nicht
+        sdf.convert({"ghost": "kN"})           # Spalte existiert nicht
     assert "has no unit" in caplog.text
 
 
 def test_convert_dict_incompatible_raises():
     sdf = _tensile()
     with pytest.raises(units.UnitConversionError, match="incompatible"):
-        sdf.convert_units({"force": "mm"})           # Kraft -> Länge
+        sdf.convert({"force": "mm"})           # Kraft -> Länge


### PR DESCRIPTION
## Was

Benennt die in #86 eingeführte Methode `DataFrame.convert_units` in das kürzere, direkte **`DataFrame.convert`** um — die Umrechnung wirkt direkt auf den DataFrame:

```python
si = sdf.convert(["kN", "mm", "ms"])          # umgerechnete Kopie
sdf.convert(["kN", "mm", "ms"], inplace=True) # in place
sdf.convert({"stress": "GPa"})                # explizite Ziel-Einheiten
```

Verhalten unverändert (Liste / `UnitSystem` / `{Spalte: Einheit}`, `inplace=`, Default = umgerechnete Kopie). Das Feature ist erst eine Session alt und unveröffentlicht (`[Unreleased]`), daher sauberer Rename ohne Kompatibilitäts-Alias. Doku (`usage/dataframe.md`), CHANGELOG und Tests umgestellt.

## Verifikation
- `ci/local-ci.sh` grün; **TOTAL 5012 stmts, 100 %** (`sclass/dataframe.py` 100 %, `units.py` 100 %); 643 passed, 7 skipped.
- `mkdocs build --strict` grün.
- Keine verbleibenden `convert_units`-Referenzen im Repo.