### PR TITLE
feat(dataframe): settbares unit_system auf dem DataFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,15 @@ All notable changes to **sdata** are documented here. The format is based on
   engineering quantities (length, force, time, mass, pressure, strain-rate,
   temperature incl. offset units), works on scalars/lists/NumPy arrays/pandas Series,
   and raises a clear `UnitConversionError` on incompatible quantities.
-- **`DataFrame.convert(units, inplace=False)`.** Rescale a table's columns into
+- **`DataFrame.convert(units=None, inplace=False)`.** Rescale a table's columns into
   a target unit system (a unit list, a `UnitSystem`, or an explicit `{column: unit}`
   mapping) and update the per-column `unit` annotations in one step — returning a
   converted copy by default. Columns without a unit or whose quantity the system does
   not cover are left unchanged.
+- **`DataFrame.unit_system`.** A settable target unit system on the table (a
+  `UnitSystem` or unit list, also via the `unit_system=` constructor keyword);
+  `convert()` with no argument rescales into it. Setting only records the target
+  (the data is rescaled by `convert()`), and a converted copy carries it over.
 - **Docs.** A worked tensile-test example (`force [N]` / `time [s]` /
   `displacement [mm]`, fully semantically described, converted to `[kN, mm, ms]`) and
   a unit-conversion reference in `usage/dataframe.md`.

--- a/docs/usage/dataframe.md
+++ b/docs/usage/dataframe.md
@@ -181,6 +181,25 @@ sdf.convert(["kN", "mm", "ms"], inplace=True)        # mutate in place
 sdf.convert({"stress": "GPa", "strain": "%"})
 ```
 
+The target system can also be **set on the DataFrame** — as a
+[`UnitSystem`][sdata.units.UnitSystem] or a unit list — and reused by `convert()`
+without arguments (also settable via the `unit_system=` constructor keyword):
+
+```python
+from sdata.units import UnitSystem
+
+sdf.unit_system = UnitSystem(["kN", "mm", "ms"])   # or just ["kN", "mm", "ms"]
+si = sdf.convert()                                 # converts into sdf.unit_system
+
+DataFrame(df=raw, name="run", unit_system=["kN", "mm", "ms"])
+```
+
+Setting `unit_system` only *records* the target — it does not rescale the data (call
+`convert()` to apply), which keeps it robust when the system is set before the column
+units. A converted copy carries the system over, and applying a full system sets the
+result's `unit_system`; `convert()` raises `ValueError` if neither an argument nor a
+`unit_system` is set.
+
 Only columns whose physical quantity the system addresses are touched; columns
 without a unit, dimensionless columns, and quantities the system does not cover are
 left unchanged. Converting across incompatible quantities (e.g. a length column to a

--- a/sdata/sclass/dataframe.py
+++ b/sdata/sclass/dataframe.py
@@ -49,6 +49,7 @@ class DataFrame(ContentIntegrityMixin, Base):
             column_metadata: Optional[
                 Union[Dict[str, Dict[str, str]], Metadata]
             ] = None,
+            unit_system=None,
             **kwargs: Any
     ) -> None:
         """
@@ -62,6 +63,9 @@ class DataFrame(ContentIntegrityMixin, Base):
         :param column_metadata: Optional per-column metadata, either a dict
           ``{colname: {'label': ..., 'unit': ...}}`` or a :class:`Metadata`. Keys
           that do not match a df column are kept but a warning is logged.
+        :param unit_system: optional target :class:`~sdata.units.UnitSystem` (or a
+          unit list like ``["kN", "mm", "ms"]``) recorded on the table; see
+          :attr:`unit_system` and :meth:`convert`.
         :param kwargs: forwarded to :class:`~sdata.base.Base` (e.g. ``name``,
           ``description``, ``project``).
         """
@@ -78,6 +82,9 @@ class DataFrame(ContentIntegrityMixin, Base):
             self._column_metadata = Metadata(name="column_metadata")
 
         self._df = pd.DataFrame()
+        self._unit_system = None
+        if unit_system is not None:
+            self.unit_system = unit_system
         if df is not None:
             # Bei der Konstruktion vom Nutzer gelieferte column_metadata bewahren
             # (kein Prune); Waisen werden nur gemeldet.
@@ -214,12 +221,36 @@ class DataFrame(ContentIntegrityMixin, Base):
                 units[str(col)] = attr.unit
         return units
 
+    @property
+    def unit_system(self):
+        """The table's target :class:`~sdata.units.UnitSystem` (or ``None``).
+
+        Assign a :class:`~sdata.units.UnitSystem` **or** a unit list (e.g.
+        ``["kN", "mm", "ms"]``, wrapped automatically) to record the unit system
+        this table should be expressed in; :meth:`convert` with no argument then
+        rescales the data into it. Setting only records the target — it does **not**
+        mutate the data (call :meth:`convert` to apply), which keeps it robust when
+        the system is set before the column units. Assign ``None`` to clear.
+
+        :return: the recorded :class:`~sdata.units.UnitSystem`, or ``None``.
+        """
+        return self._unit_system
+
+    @unit_system.setter
+    def unit_system(self, value):
+        from sdata import units as U
+        if value is None or isinstance(value, U.UnitSystem):
+            self._unit_system = value
+        else:
+            self._unit_system = U.UnitSystem(value)
+
     def _converted_copy(self):
         """Tiefe Kopie dieses DataFrame (Daten + Metadaten) für nicht-mutierende Ops."""
         new = self.__class__(df=self._df.copy(deep=True))
         new.metadata = self.metadata.copy()
         new._column_metadata = self._column_metadata.copy()
         new.description = self.description
+        new._unit_system = self._unit_system
         return new
 
     def _resolve_unit_targets(self, units, U):
@@ -239,11 +270,12 @@ class DataFrame(ContentIntegrityMixin, Base):
                 targets[str(col)] = system.target_for(attr.unit)
         return targets
 
-    def convert(self, units, inplace=False):
+    def convert(self, units=None, inplace=False):
         """Convert numeric columns into a target unit system (or explicit units).
 
         ``units`` may be
 
+        * ``None`` (the default) — use this table's :attr:`unit_system`,
         * a :class:`~sdata.units.UnitSystem`,
         * a list/tuple of unit symbols, e.g. ``["kN", "mm", "ms"]`` — wrapped into a
           :class:`~sdata.units.UnitSystem` (one unit per physical quantity), or
@@ -254,15 +286,23 @@ class DataFrame(ContentIntegrityMixin, Base):
         its ``unit`` annotation updated. Columns without a unit, dimensionless
         columns, and quantities the system does not cover are left untouched. By
         default a converted **copy** is returned (data + metadata); pass
-        ``inplace=True`` to mutate this DataFrame.
+        ``inplace=True`` to mutate this DataFrame. When a full unit system (not a
+        per-column dict) is applied, the result's :attr:`unit_system` is set to it.
 
-        :param units: target unit system, unit list, or ``{column: unit}`` mapping.
+        :param units: target unit system, unit list, or ``{column: unit}`` mapping;
+          ``None`` uses :attr:`unit_system`.
         :param inplace: mutate this DataFrame instead of returning a converted copy.
         :return: the converted :class:`DataFrame` (``self`` if ``inplace``).
+        :raises ValueError: if ``units`` is ``None`` and no :attr:`unit_system` is set.
         :raises sdata.units.UnitConversionError: on incompatible units (e.g. an
           explicit mapping that converts a length column to a force unit).
         """
         from sdata import units as U
+        if units is None:
+            units = self._unit_system
+        if units is None:
+            raise ValueError(
+                "no unit system: pass units to convert() or set .unit_system")
         targets = self._resolve_unit_targets(units, U)
         sdf = self if inplace else self._converted_copy()
         for col, target in targets.items():
@@ -278,6 +318,9 @@ class DataFrame(ContentIntegrityMixin, Base):
             sdf._df[col] = U.convert(sdf._df[col], current, target)
             sdf.set_column(col, unit=str(target))
             logger.info("convert: %s %s -> %s", col, current, target)
+        if not isinstance(units, dict):
+            sdf._unit_system = units if isinstance(units, U.UnitSystem) \
+                else U.UnitSystem(units)
         return sdf
 
     def validate_table(self, schema=None):

--- a/tests/test_sclass_dataframe_units.py
+++ b/tests/test_sclass_dataframe_units.py
@@ -81,6 +81,60 @@ def test_convert_dict_mapping():
     conv = sdf.convert({"stress": "GPa"})
     assert conv.column_units["stress"] == "GPa"
     assert list(conv.df["stress"]) == [1.0]          # 1000 MPa -> 1 GPa
+    assert conv.unit_system is None                   # dict path records no system
+
+
+# ---------------------------------------------------------- settable unit_system
+def test_unit_system_default_none():
+    assert DataFrame(df=pd.DataFrame({"a": [1]}), name="d").unit_system is None
+
+
+def test_set_unit_system_object_and_convert_without_args():
+    sdf = _tensile()
+    sdf.unit_system = units.UnitSystem(["kN", "mm", "ms"])
+    assert isinstance(sdf.unit_system, units.UnitSystem)
+
+    si = sdf.convert()                               # uses the recorded system
+    assert si.column_units == {"force": "kN", "time": "ms", "displacement": "mm"}
+    assert list(si.df["force"]) == [0.0, 2.5, 5.0]
+    assert repr(si.unit_system) == "UnitSystem(['kN', 'mm', 'ms'])"
+    # setting only records intent — the data is untouched until convert()
+    assert sdf.column_units["force"] == "N"
+
+
+def test_set_unit_system_from_list_is_wrapped():
+    sdf = _tensile()
+    sdf.unit_system = ["kN", "mm", "ms"]             # list -> UnitSystem
+    assert isinstance(sdf.unit_system, units.UnitSystem)
+    assert sdf.unit_system.unit_for("force") == "kN"
+
+
+def test_unit_system_constructor_kwarg():
+    sdf = DataFrame(df=pd.DataFrame({"force": [1000.0]}), name="d",
+                    unit_system=["kN", "mm", "ms"])
+    sdf.set_column("force", unit="N")
+    assert isinstance(sdf.unit_system, units.UnitSystem)
+    assert list(sdf.convert().df["force"]) == [1.0]
+
+
+def test_unit_system_clear():
+    sdf = _tensile()
+    sdf.unit_system = ["kN", "mm", "ms"]
+    sdf.unit_system = None
+    assert sdf.unit_system is None
+
+
+def test_convert_without_units_or_system_raises():
+    sdf = _tensile()
+    with pytest.raises(ValueError, match="no unit system"):
+        sdf.convert()
+
+
+def test_convert_copy_preserves_unit_system():
+    sdf = _tensile()
+    sdf.unit_system = ["kN", "mm", "ms"]
+    copy = sdf.convert(inplace=False)               # converted copy keeps the system
+    assert isinstance(copy.unit_system, units.UnitSystem)
 
 
 def test_convert_dict_column_without_unit_warns(caplog):


### PR DESCRIPTION
## Was

Das Ziel-Einheitensystem ist jetzt direkt **auf dem DataFrame setzbar**:

```python
from sdata.units import UnitSystem

sdf.unit_system = UnitSystem(["kN", "mm", "ms"])   # oder einfach ["kN", "mm", "ms"]
si = sdf.convert()                                 # rechnet in sdf.unit_system um

DataFrame(df=raw, name="run", unit_system=["kN", "mm", "ms"])   # Konstruktor-kwarg
```

- **`DataFrame.unit_system`** — settbare Property; nimmt ein `UnitSystem` **oder** eine Einheiten-Liste (wird gewrappt); `None` löscht.
- **Konstruktor-kwarg** `unit_system=`.
- **`convert(units=None)`** nutzt ohne Argument das gesetzte `unit_system`; `ValueError`, wenn weder Argument noch System gesetzt sind.
- Das Setzen **speichert nur die Absicht** (mutiert die Daten nicht — `convert()` wendet an). Das ist robust gegenüber der Reihenfolge „System vor Spalten-Units".
- Beim Anwenden eines vollen Systems trägt das Ergebnis dessen `unit_system`; eine umgerechnete Kopie übernimmt das System.

## Verifikation
- `ci/local-ci.sh` grün; **TOTAL 5031 stmts, 100 %** (`sclass/dataframe.py` 100 %, `units.py` 100 %); 650 passed, 7 skipped.
- `mkdocs build --strict` grün.
- Strikt additiv (neuer Default-Wert `units=None`, neue Property/kwarg) — rückwärtskompatibel.