### PR TITLE
docs(rfc): RFC 0006 v2 — konsistente Einheitensysteme via Dimensions-Algebra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,11 @@ All notable changes to **sdata** are documented here. The format is based on
 - **Docs.** A worked tensile-test example (`force [N]` / `time [s]` /
   `displacement [mm]`, fully semantically described, converted to `[kN, mm, ms]`) and
   a unit-conversion reference in `usage/dataframe.md`.
-- **RFC 0006 (proposed).** Design for executing the conversion when the unit system is
-  set (`set_unit_system`) and for relabeling mislabeled units without rescaling the
-  values (`convert(..., rescale=False)`); proposal only, not yet implemented.
+- **RFC 0006 (proposed, v2).** Design for **consistent unit systems via dimensional
+  algebra**: a `UnitSystem` is solved from its base units, so *all* derived units
+  (stress→`GPa`, energy→`J`, velocity→`m/s`) are rescaled when converting into it
+  (`convert(system, inplace=True)`); plus a safe `relabel_units({col: unit})` for
+  fixing mislabeled units without rescaling. Proposal only, not yet implemented.
 
 ## [1.3.0] - 2026-06-29
 

--- a/docs/rfc/0006-unit-system-conversion-on-set.md
+++ b/docs/rfc/0006-unit-system-conversion-on-set.md
@@ -1,174 +1,271 @@
-# RFC 0006 — Einheitensystem: Umrechnung beim Setzen & Relabeling falscher Einheiten
+# RFC 0006 — Konsistente Einheitensysteme via Dimensions-Algebra
 
-| Feld        | Wert                                                              |
-|-------------|------------------------------------------------------------------|
-| Status      | Proposed (Entwurf) — noch nicht implementiert                    |
-| Datum       | 2026-06-30                                                       |
-| Autor       | lepy <lepy@tuta.io>                                              |
-| Komponente  | `sdata/sclass/dataframe.py`, `sdata/units.py`                    |
-| Betrifft    | `DataFrame.unit_system`, `DataFrame.convert`, neu `set_unit_system` |
-| Validierung | (geplant) 100 % Line-Coverage; Round-Trip- und Relabel-Tests     |
+| Feld        | Wert                                                                 |
+|-------------|----------------------------------------------------------------------|
+| Status      | Proposed (Entwurf), **v2** — ersetzt den v1-Entwurf                  |
+| Datum       | 2026-06-30                                                           |
+| Autor       | lepy <lepy@tuta.io>                                                  |
+| Komponente  | `sdata/units.py`, `sdata/sclass/dataframe.py`                       |
+| Betrifft    | `UnitSystem`, `DataFrame.convert`, `DataFrame.unit_system`, neu `relabel_units` |
+| Validierung | (geplant) 100 % Branch-Coverage; Solver- und Round-Trip-Tests        |
 
-> **Umsetzungsstand.** Vorschlag. Baut auf dem in PR #86–#88 ausgelieferten
-> `units.convert`/`UnitSystem`, `DataFrame.convert` und der settbaren Property
-> `DataFrame.unit_system` (heute *record-only*) auf.
+> **Umsetzungsstand.** Vorschlag (v2). Baut auf dem in PR #86–#88 ausgelieferten
+> `units.convert`/`convert_factor`, `DataFrame.convert` und der record-only-Property
+> `DataFrame.unit_system` auf. v2 **ersetzt** den v1-Entwurf nach dem Review.
+
+## 0. Was sich gegenüber v1 ändert
+
+Der v1-Entwurf (flacher `Größe→Einheit`-Lookup, `set_unit_system(mode=…)`) hatte im
+Review fünf belastbare Schwächen. v2 adressiert sie:
+
+| # | v1-Problem | v2-Antwort |
+|---|------------|------------|
+| 1 | „Unit system" war **nicht konsistent**: abgeleitete Größen (Spannung, Energie, Geschwindigkeit) wurden still **nicht** umgerechnet (`MPa`-Spalte blieb bei `[kN, mm, ms]` unverändert). | **Dimensions-Algebra**: das System wird aus Basis-Einheiten gelöst, **jede** abgeleitete Einheit wird hergeleitet (Spannung→`GPa`, Energie→`J`, Geschwindigkeit→`m/s`). |
+| 2/3 | Relabel hing am **System-Pfad**, der echte Mislabels (falsche Dimension) verfehlt; Zielbestimmung aus dem als falsch erklärten Label ist zirkulär. | Relabel **nur** über expliziten Dict (`relabel_units({col: unit})`); System-Pfad-Relabel gestrichen. |
+| 4 | Inkompatibles Relabel überschrieb still, nur optionale Warnung. | Inkompatibler Dimensionswechsel verlangt `force=True`, **immer** geloggt, gibt einen **Report** zurück. |
+| 5/6/7 | `set_unit_system` kollidierte namentlich mit dem Setter, war als einzige Op inplace-by-default, `mode="record"` war redundant. | `set_unit_system` **gestrichen**. „Setzen = umrechnen" ist `convert(system, inplace=True)`; die Property bleibt record-only. |
+| 8 | `rescale=False` benannte die Wirkung nicht. | Eigene Methode `relabel_units(...)`; `convert` bleibt rein „umrechnen". |
 
 ## 1. Zusammenfassung
 
-Dieser RFC ergänzt zwei **optionale** Verhaltensweisen rund um das Ziel-Einheiten­system
-eines `DataFrame`:
+Ein **konsistentes Einheitensystem** (z. B. `[kN, mm, ms]`) wird über **Dimensions-Algebra**
+modelliert: aus den angegebenen Basis-Einheiten werden die Skalen der Basis-Dimensionen
+(Länge L, Masse M, Zeit T, Temperatur Θ) gelöst, und **jede** Spalten-Einheit — auch
+abgeleitete wie Spannung, Energie, Geschwindigkeit, Dehnrate — wird daraus deterministisch
+hergeleitet und umgerechnet.
 
-1. **Umrechnung beim Setzen.** `set_unit_system(system)` rechnet die Spalten direkt um
-   (Zahlenwerte skalieren **und** Einheiten umschreiben), statt — wie heute der
-   Property-Setter — nur die Absicht zu speichern.
-2. **Relabeling ohne Umrechnung.** Für **fehlerhaft zugewiesene** Einheiten sollen die
-   Spalten auf die neuen Einheiten gesetzt werden, **ohne** die Zahlenwerte zu ändern
-   (Korrektur falscher Labels) — `set_unit_system(system, mode="relabel")` bzw.
-   `convert(..., rescale=False)`.
-
-Die Property `unit_system` bleibt bewusst **record-only**: ein `=` skaliert nie still
-die Daten. Aktive Effekte laufen ausschließlich über benannte, sichtbare Aufrufe.
+* **Umrechnen** in ein System: `DataFrame.convert(system, inplace=True)` (rechnet Werte um
+  **und** schreibt die abgeleiteten Einheiten). Das ist zugleich „beim Setzen umrechnen".
+* **Merken** ohne Datenänderung: `sdf.unit_system = system` (record-only, unverändert).
+* **Falsche Einheiten korrigieren** ohne Wertänderung: `relabel_units({col: unit})` —
+  explizit pro Spalte, gibt einen Report zurück, verlangt `force=True` für
+  Dimensionswechsel.
 
 ## 2. Motivation
 
-* **Ein Schritt statt zwei.** Heute ist „System setzen" und „umrechnen" getrennt
-  (`sdf.unit_system = …; sdf.convert(inplace=True)`). Häufig ist gemeint: *„diese
-  Tabelle ist ab jetzt in diesem System"* — das soll ein Aufruf leisten.
-* **Falsche Labels kommen vor.** Reale Daten tragen oft falsche Einheiten-Annotationen:
-  ein Export liefert bereits **kN**, ist aber als **N** gelabelt; oder eine Kraft-Spalte
-  trägt versehentlich **kg**. Eine normale Umrechnung würde die Werte (fälschlich)
-  skalieren. Gebraucht wird ein **Relabel ohne Skalierung**, das nur die Annotation
-  korrigiert.
-* **Sicherheit vor Bequemlichkeit.** Ein `=` darf keine Zahlenwerte still verändern
-  (Datenkorruptionsrisiko, „principle of least astonishment"). Die aktiven Operationen
-  bekommen daher explizite, lesbare Namen/Flags.
+* **Konsistenz ist der Sinn eines Einheitensystems.** In der Mechanik/FE (LS-DYNA u. a.)
+  bedeutet `[kN, mm, ms]` *genau*, dass **alle** abgeleiteten Einheiten daraus folgen
+  (Spannung `kN/mm² = GPa`, Energie `kN·mm = J`, Geschwindigkeit `mm/ms = m/s`, Masse
+  `kg`). Ein Werkzeug, das Kraft/Länge/Zeit umrechnet, eine `MPa`-Spannungsspalte aber
+  unangetastet lässt, erzeugt genau die halbkonsistenten Daten, die ein Einheitensystem
+  verhindern soll.
+* **Ein Aufruf.** „System setzen = Tabelle ist im System" soll ein Schritt sein.
+* **Falsche Labels kommen vor**, müssen aber **gezielt** und **sicher** korrigierbar sein
+  (nur benannte Spalten, mit Audit-Spur), nicht über einen heuristischen System-Pfad.
+* **Sicherheit vor Bequemlichkeit.** `=` skaliert nie still Daten; ein Relabel, das die
+  *Bedeutung* ohne die *Zahlen* ändert, ist protokolliert und nachvollziehbar.
 
 ## 3. Entwurf
 
-### 3.1 Zwei orthogonale Operationen
+### 3.1 Dimensions-Modell
 
-| Operation   | Wirkung                                  |
-|-------------|------------------------------------------|
-| **Rescale** | Zahlenwerte umrechnen (`from` → `to`)    |
-| **Relabel** | nur das `unit`-Feld der Spalte setzen    |
+Jede Größe hat einen **Dimensionsvektor** über den Basis-Dimensionen `(L, M, T, Θ)`
+(erweiterbar um I, N, J). Jede Einheit bildet auf `(dimvector, factor, offset)` ab, wobei
+`factor` einen Wert in die **SI-kohärente** Einheit dieser Dimension überführt
+(`si = wert · factor + offset`; `offset ≠ 0` nur für reine Temperatur):
 
-Daraus ergeben sich drei Modi:
+| Einheit | Dimvektor `(L,M,T,Θ)` | factor | Größe |
+|---------|-----------------------|--------|-------|
+| `m`, `mm`, `µm` | `(1,0,0,0)` | `1`, `1e-3`, `1e-6` | Länge |
+| `kg`, `g`, `t` | `(0,1,0,0)` | `1`, `1e-3`, `1e3` | Masse |
+| `s`, `ms`, `µs` | `(0,0,1,0)` | `1`, `1e-3`, `1e-6` | Zeit |
+| `K`, `degC` | `(0,0,0,1)` | `1` (offset `0`, `273.15`) | Temperatur |
+| `N`, `kN`, `MN` | `(1,1,-2,0)` | `1`, `1e3`, `1e6` | Kraft |
+| `Pa`, `MPa`, `GPa` | `(-1,1,-2,0)` | `1`, `1e6`, `1e9` | Druck/Spannung |
+| `J`, `kJ` | `(2,1,-2,0)` | `1`, `1e3` | Energie |
+| `W` | `(2,1,-3,0)` | `1` | Leistung |
+| `m/s` | `(1,0,-1,0)` | `1` | Geschwindigkeit |
+| `1/s`, `1/ms` | `(0,0,-1,0)` | `1`, `1e3` | Rate |
+| `-`, `%` | `(0,0,0,0)` | `1`, `1e-2` | dimensionslos |
 
-* **convert** = Rescale **+** Relabel (die normale Umrechnung, heutiges Verhalten),
-* **relabel** = nur Relabel (Korrektur falscher Einheiten, **ohne** Wertänderung),
-* **record**  = keins von beiden (nur das Ziel-System merken — heutiger Setter).
+Zwei Einheiten sind **umrechenbar gdw. ihre Dimvektoren gleich sind**; das ersetzt den
+alten String-Größennamen-Vergleich. `units.dimension_of(unit) -> DimVector` ist die neue
+Kern-Abfrage; `quantity_of` bleibt als Komfort-Name (aus dem Dimvektor abgeleitet).
 
-### 3.2 API
+### 3.2 `UnitSystem` aus Basis-Einheiten (der Solver)
+
+Eine Liste wie `["kN", "mm", "ms"]` liefert Einheiten mit Dimvektoren
+Kraft `(1,1,-2,0)`, Länge `(1,0,0,0)`, Zeit `(0,0,1,0)`. Im **Log-Raum** ist die
+Umrechnung linear:
+
+```
+log(factor_i) = Σ_d  dimvec_i[d] · x_d        mit  x_d = log(Skala der Basis-Dimension d)
+```
+
+Die angegebenen Einheiten bilden ein lineares Gleichungssystem in `x_d`. Für `[kN, mm, ms]`:
+
+```
+Länge : 1·x_L                 = log(1e-3)   →  x_L = log(1e-3)   (mm)
+Zeit  :              1·x_T    = log(1e-3)   →  x_T = log(1e-3)   (ms)
+Kraft : x_L + x_M − 2·x_T     = log(1e3)    →  x_M = log(1)      (kg!)
+```
+
+→ das System fixiert `L=mm, T=ms, M=kg`. Damit ist die **kohärente System-Einheit jeder
+Dimension** `g` bestimmt: `log(system_factor(g)) = Σ_d g[d]·x_d`. Eigenschaften:
+
+* **FLT oder MLT.** Der Nutzer darf Kraft *oder* Masse als Basis geben (`[kN, mm, ms]` ist
+  force-length-time; `[kg, mm, ms]` mass-length-time) — der Solver löst beide; bei `[kN,
+  mm, ms]` ergibt sich die Masse-Einheit zu `kg`.
+* **Temperatur** ist standardmäßig `K`, sofern keine Temperatur-Einheit angegeben ist.
+* **Unter­bestimmt.** Spannen die angegebenen Einheiten eine Dimension nicht auf (z. B.
+  `[kN, mm]` ohne Zeit → Geschwindigkeit nicht lösbar), bleiben Spalten dieser Dimension
+  **unverändert** (geloggt) — analog „Größe nicht im System".
+* **Über­bestimmt.** Redundante, *konsistente* Angaben sind erlaubt (z. B. zusätzlich
+  `GPa`, das aus `[kN, mm, ms]` bereits folgt); *widersprüchliche* Angaben sind ein Fehler
+  (`UnitConversionError`).
+* **Exaktheit.** Der Solver arbeitet über `fractions.Fraction`-Exponenten (die Dimvektor-
+  Komponenten sind kleine ganze/rationale Zahlen), sodass die hergeleiteten Exponenten
+  driftfrei sind; nur der numerische Faktor ist `float`.
+
+### 3.3 Hergeleitete Einheit: Faktor **und** Label
+
+Für eine Spalte mit Einheit `u` (Dimvektor `g`, `factor_u`) ist der Zielwert
+`wert · factor_u / system_factor(g)`. Das **Label** der Zieleinheit wird so gewählt:
+
+1. **Kanonischer Registry-Treffer:** gibt es eine bekannte Einheit mit exakt `(g,
+   system_factor(g))`, wird deren Symbol verwendet (`GPa`, `J`, `m/s`, `N`). Bevorzugt,
+   weil lesbar und interoperabel.
+2. **Sonst komponiert** aus den **Basis-Symbolen des Systems**, indem `g` in der Basis der
+   angegebenen System-Einheiten ausgedrückt wird (z. B. Dichte → `kg/mm³`,
+   Beschleunigung → `mm/ms²`).
+
+Bei `[kN, mm, ms]` liefert das u. a. Spannung→`GPa`, Energie→`J`, Geschwindigkeit→`m/s`,
+Dehnrate→`1/ms`, Masse→`kg`, Dichte→`kg/mm³` — alle numerisch konsistent.
+
+> **Wrinkle.** Manche Dimvektoren sind mehrdeutig benannt (`1/s` vs. `Hz` vs. `Bq`,
+> Drehmoment `N·m` vs. Energie `J`). Schritt 1 nutzt eine **eindeutige** Vorzugs-Symbol-
+> Tabelle pro Dimvektor; bei Ambiguität wird Schritt 2 (komponiert) gewählt. Siehe §7.
+
+### 3.4 API
 
 ```python
-# Basis-Primitive: convert() bekommt ein rescale-Flag
-DataFrame.convert(units=None, inplace=False, rescale=True)
-#   rescale=True  -> wie bisher: Werte skalieren + Einheiten umschreiben
-#   rescale=False -> nur Einheiten umschreiben (Relabel), Werte unverändert
+# umrechnen in ein System (inkl. abgeleiteter Einheiten) — auch "beim Setzen umrechnen"
+DataFrame.convert(units=None, inplace=False)
+#   units: UnitSystem | Einheiten-Liste | {Spalte: Einheit} | None(=self.unit_system)
+#   None+inplace=True  -> die Tabelle ist danach im gemerkten System
+#   gibt standardmäßig eine umgerechnete Kopie zurück (Default inplace=False)
 
-# Ergonomische Hülle: Setzen + (optional) Anwenden in einem Aufruf
-DataFrame.set_unit_system(system, mode="convert")
-#   mode="convert" (Default) -> record + convert(system, inplace=True, rescale=True)
-#   mode="relabel"           -> record + convert(system, inplace=True, rescale=False)
-#   mode="record"            -> nur record (identisch zum Property-Setter)
-
-# unverändert: Property-Setter bleibt record-only (== mode="record")
+# Ziel-System nur MERKEN (kein Daten-Seiteneffekt) — unverändert
 sdf.unit_system = ["kN", "mm", "ms"]
+
+# falsche Einheiten KORRIGIEREN, Werte NICHT ändern (explizit pro Spalte)
+DataFrame.relabel_units(mapping, *, force=False) -> RelabelReport
+#   setzt unit der genannten Spalten ohne Skalierung; gleiche Dimension: ok + geloggt;
+#   andere Dimension: nur mit force=True, sonst UnitConversionError; Report listet alt→neu
+
+# units-Modul
+units.dimension_of(unit) -> DimVector
+units.UnitSystem(base_units)          # löst Basis-Dimensionen (§3.2)
+system.factor_for(dimvector) -> float
+system.unit_for(dimvector) -> (factor, label)   # §3.3
+units.convert / units.convert_factor            # unverändert (zwei Einheiten gleicher Dim)
 ```
 
-`set_unit_system` mutiert **in place** (der Name sagt „auf diesem Objekt setzen") und
-gibt `self` zurück. Wer eine umgerechnete **Kopie** will, nutzt weiterhin
-`copy = sdf.convert(system)` (non-inplace).
+`convert` verliert das v1-`rescale`-Flag; reines Umlabeln ist jetzt `relabel_units`
+(ehrlich benannt, mit Report und `force`).
 
-### 3.3 Semantik je Spalte
+### 3.5 Semantik je Spalte
 
-Die Zielbestimmung ist identisch zu `convert` (System: pro Größe eine Einheit, aus der
-*aktuellen* Spalten-Einheit abgeleitet; Dict: explizit pro Spalte). Der Unterschied
-liegt nur in *Rescale ja/nein* und in der Behandlung von Sonderfällen:
+| Aktuell | System `[kN, mm, ms]` | `convert` | `relabel_units({col: ziel})` |
+|---------|------------------------|-----------|------------------------------|
+| Kraft `N` | Ziel `kN` | Werte ÷1000, →`kN` | nur `relabel_units({"f":"kN"})`: →`kN`, Werte unverändert |
+| Spannung `MPa` | Ziel `GPa` (**hergeleitet**) | Werte ·1e-3, →`GPa` | nach Bedarf |
+| Energie `J` | Ziel `J` (`kN·mm`) | Werte ·1, →`J` | nach Bedarf |
+| Geschw. `m/s` | Ziel `m/s` (`mm/ms`) | Werte ·1, →`m/s` | nach Bedarf |
+| Länge `mm` | Ziel `mm` | no-op | no-op |
+| ohne Einheit | — | übersprungen (Dim unbekannt) | `{"x":"kN"}`: →`kN` (Label-Fix), Werte unverändert |
+| Kraft `N`, Ziel `mm` (inkompatibel) | — | n/a | nur `force=True`: →`mm` + Log + Report |
 
-| Aktuell | Ziel | `convert` (rescale=True) | `relabel` (rescale=False) |
-|---------|------|--------------------------|---------------------------|
-| Kraft `N` | `kN` | Werte ÷1000, Einheit→`kN` | Einheit→`kN`, **Werte unverändert** |
-| Länge `mm` | `mm` | no-op | no-op |
-| Druck `MPa` | (nicht im System) | unverändert | unverändert |
-| ohne Einheit, Dict `{"force":"kN"}` | `kN` | Warnung + übersprungen | Einheit→`kN` (Label-Fix), Werte unverändert |
-| inkompatibel, Dict `{"force":"mm"}` | `mm` | `UnitConversionError` | Einheit→`mm` (überschreiben, **kein Fehler**) |
-
-**Zentrale Unterschiede des `relabel`-Modus:**
-
-* **Keine Skalierung** der Zahlenwerte und keine dtype-Änderung.
-* **Keine Quantity-Prüfung / kein `UnitConversionError`.** Mislabels sind genau die
-  Fälle, in denen das alte Label (und damit seine Größe) falsch ist — ein
-  Kompatibilitäts-Check würde den Use-Case verhindern. Daher: **überschreiben**.
-* **System-Pfad:** relabelt nur Spalten mit *bekannter* aktueller Einheit (deren Größe
-  ableitbar ist); Spalten ohne/mit unbekannter Einheit werden übersprungen (die Größe
-  ist nicht bestimmbar).
-* **Dict-Pfad:** relabelt **jede genannte Spalte** — auch ohne oder mit falscher
-  aktueller Einheit. Das ist das eigentliche Werkzeug für Mislabels.
-* **Optional:** Warnung loggen, wenn die Ziel-Einheit unbekannt ist
-  (`units.validate_unit`), ohne den Vorgang abzubrechen.
-
-### 3.4 Beispiele
+## 4. Worked Example `[kN, mm, ms]`
 
 ```python
-# 1) Setzen = umrechnen (der Primärwunsch dieses RFC)
-sdf.set_unit_system(["kN", "mm", "ms"])           # Werte umgerechnet + Einheiten gesetzt
-# äquivalent zu:  sdf.unit_system = [...]; sdf.convert(inplace=True)
+import pandas as pd
+from sdata.sclass.dataframe import DataFrame
+from sdata.units import UnitSystem
 
-# 2) Fehlerhaftes Label korrigieren, Zahlenwerte NICHT ändern
-#    (force-Spalte ist faktisch in kN, aber als "N" gelabelt)
-sdf.set_unit_system(["kN", "mm", "ms"], mode="relabel")   # nur Annotationen
-#    oder gezielt für einzelne Spalten:
-sdf.convert({"force": "kN"}, inplace=True, rescale=False)
+df = pd.DataFrame({"force":[5000.], "stroke":[2.4], "time":[0.5],
+                   "stress":[200.0], "v":[3.0], "energy":[12.0]})
+sdf = DataFrame(df=df, name="test")
+sdf.set_column("force", unit="N");   sdf.set_column("stroke", unit="mm")
+sdf.set_column("time",  unit="s");   sdf.set_column("stress", unit="MPa")
+sdf.set_column("v",     unit="m/s"); sdf.set_column("energy", unit="J")
 
-# 3) record-only (unverändertes Verhalten)
-sdf.unit_system = ["kN", "mm", "ms"]              # nur Absicht; convert() wendet an
-si = sdf.convert()                                # umgerechnete Kopie im gemerkten System
+si = sdf.convert(UnitSystem(["kN", "mm", "ms"]))
 ```
 
-## 4. Designentscheidungen
+| Spalte | vorher | nachher | Faktor | Herleitung |
+|--------|--------|---------|--------|------------|
+| force  | `5000 N`   | `5 kN`     | ÷1e3 | Basis |
+| stroke | `2.4 mm`   | `2.4 mm`   | ·1   | Basis |
+| time   | `0.5 s`    | `500 ms`   | ·1e3 | Basis |
+| stress | `200 MPa`  | `0.2 GPa`  | ·1e-3 | `kN/mm² = GPa` |
+| v      | `3 m/s`    | `3 m/s`    | ·1   | `mm/ms = m/s` |
+| energy | `12 J`     | `12 J`     | ·1   | `kN·mm = J` |
 
-* **Property bleibt record-only.** `sdf.unit_system = …` darf keine Daten skalieren
-  (Astonishment + Datenkorruptionsrisiko). Aktive Effekte nur über benannte Aufrufe
-  (`set_unit_system`, `rescale=`). Rückwärtskompatibel zu PR #88.
-* **`rescale`-Flag statt Policy-Attribut.** Ein zustandsbehaftetes
-  `unit_system_policy`, das still ändert, *was* `=` tut, wäre versteckt und
-  überraschend. Ein explizites Argument am Aufrufpunkt ist lokal lesbar.
-* **`mode=` (drei Werte) statt mehrerer Booleans.** Ein Aufzählungs-Argument vermeidet
-  widersprüchliche Kombinationen (`convert=True, relabel=True`).
-* **Relabel erzwingt keine Kompatibilität.** Bewusst — siehe 3.3. Optionale Warnung bei
-  unbekannter Zieleinheit statt Fehler.
-* **`convert(rescale=)` als Basis-Primitive, `set_unit_system` nur als Hülle.** Hält
-  die testbare Oberfläche klein; `set_unit_system` ist reine Komposition aus
-  „record" + `convert(..., inplace=True, rescale=…)`.
+Genau die abgeleiteten Spalten (`stress`, `v`, `energy`), die v1 still ignorierte, werden
+jetzt korrekt mitgeführt.
 
-## 5. Tests / Coverage (geplant)
+## 5. Designentscheidungen
 
-* `set_unit_system` in `mode="convert"` / `"relabel"` / `"record"` (inkl. Default).
-* `convert(rescale=False)`:
-  * System-Pfad-Relabel (z. B. `N`→`kN` **ohne** Skalierung der Werte),
-  * Dict-Pfad-Relabel: Label einer einheitenlosen Spalte setzen; inkompatible Einheit
-    überschreiben **ohne** `UnitConversionError`,
-  * optionale Warnung bei unbekannter Zieleinheit.
-* Property-Setter bleibt nachweislich **record-only** (keine Wertänderung).
-* **100 % Line-Coverage**; die bestehenden `convert`/`unit_system`-Tests bleiben grün.
+* **Dimensions-Algebra statt flacher Tabelle.** Nur so ist „konsistentes System" wahr:
+  abgeleitete Einheiten werden hergeleitet, nicht zufällig getroffen. Kosten: ein kleiner
+  Linearsolver (4×n) — pure Python, `fractions` für exakte Exponenten, kein numpy nötig.
+* **Kanonische Labels bevorzugt, sonst komponiert.** `GPa`/`J`/`m/s` sind lesbar und
+  interoperabel; ohne Treffer eine ehrliche Komposition aus den Basis-Symbolen.
+* **Relabel nur per explizitem Dict.** Der System-Pfad-Relabel aus v1 ist zirkulär und
+  verfehlt echte Mislabels — gestrichen. `relabel_units` benennt genau die zu
+  korrigierenden Spalten.
+* **Kein magischer Setter.** `set_unit_system` gestrichen; „setzen = umrechnen" ist das
+  bereits vorhandene `convert(system, inplace=True)`; die Property bleibt record-only.
+  Beseitigt die Namens-Kollision und die inplace-Asymmetrie.
+* **Inkompatibles Relabel: `force` + Log + Report.** Für eine semantikzentrierte
+  Bibliothek darf ein Dimensionswechsel des Labels nicht still passieren.
 
-## 6. Kompatibilität / Migration
+## 6. Sicherheit & semantische Schicht
 
-Strikt **additiv** und rückwärtskompatibel:
+* **Audit-Spur.** `convert` loggt jede umgerechnete Spalte (`alt → neu`); `relabel_units`
+  gibt zusätzlich einen `RelabelReport` (Liste `{column, old, new, dimension_changed}`)
+  zurück.
+* **JSON-LD/QUDT bleibt konsistent.** Eine geänderte Einheit aktualisiert konsequent den
+  `qudt:Quantity`/`unitRef`-Knoten der Spalte (das `to_jsonld`-Spalten-Mapping liest die
+  `unit` der Spalte). Bei `relabel_units` mit `dimension_changed` wird zusätzlich gewarnt,
+  falls die hinterlegte `ontology`/Größenklasse der Spalte nicht mehr zur neuen Einheit
+  passt (kein Auto-Override der Ontologie).
 
-* `convert` erhält den **neuen Default** `rescale=True` → unverändertes Verhalten.
-* `set_unit_system` und `mode=` sind **neu**.
-* Der `unit_system`-Property-Setter bleibt **unverändert** (record-only).
-* Keine Breaking Changes; keine neue Abhängigkeit (reine Standardbibliothek).
+## 7. Tests / Coverage (geplant)
 
-## 7. Offene Punkte / Zukunft
+* **Solver:** FLT (`[kN, mm, ms]`→ Masse `kg`), MLT (`[t, mm, s]`), unterbestimmt
+  (`[kN, mm]` → Geschwindigkeit unverändert), überbestimmt-konsistent (`[kN, mm, ms, GPa]`),
+  überbestimmt-widersprüchlich (Fehler).
+* **Abgeleitete Umrechnung:** Spannung `MPa→GPa`, Energie `J→J`, Geschwindigkeit `m/s`,
+  Dehnrate `1/s→1/ms`, Dichte (komponiertes Label `kg/mm³`).
+* **Relabel:** gleiche Dimension (ok+Report), einheitenlose Spalte labeln, inkompatibel
+  ohne/mit `force` (Fehler / Override+Warnung+Report).
+* **Temperatur:** `degC↔K` (offset), Verbot von Offset in zusammengesetzten Dimensionen.
+* **Property** bleibt nachweislich record-only.
+* **Branch-Coverage** (nicht nur Line) für die neuen Verzweigungen; bestehende
+  `convert`/`unit_system`-Tests bleiben grün.
 
-* **Kopie vs. in place für `set_unit_system`.** Vorschlag: `set_unit_system` mutiert
-  immer in place (Name impliziert das); für Kopien dient `convert(system)`.
-* **Strict-Modus beim Relabel.** Optionales `strict=`/Warnung, wenn die Zieleinheit
-  unbekannt ist (`units.validate_unit`, mit `pint` erweiterbar).
-* **dtype-Verhalten dokumentieren.** Relabel ändert nie Werte/dtype; Convert kann
-  `int` → `float` heben (Division).
-* **Persistenz** des `unit_system` über die Serialisierung (Parquet/dict/JSON-LD) —
-  eigenständig von diesem RFC.
+## 8. Kompatibilität / Migration
+
+* `units.convert` / `units.convert_factor` (zwei Einheiten gleicher Dimension) bleiben
+  **unverändert**.
+* `UnitSystem(["kN","mm","ms"])` konstruiert weiter; `target_for("N") == "kN"` bleibt.
+  **Verhaltens­änderung (gewollt, da unveröffentlicht):** `target_for("MPa")` liefert jetzt
+  `GPa` statt `None` — abgeleitete Größen werden umgerechnet.
+* `convert(units, inplace=…)` und die `unit_system`-Property bleiben signaturgleich; das
+  v1-`rescale`-Flag entfällt (war nie released). `relabel_units` ist neu.
+* Strikt additiv ansonsten; keine neue Laufzeit-Abhängigkeit (`fractions` ist stdlib).
+
+## 9. Offene Punkte / Zukunft
+
+* **Mehrdeutige Dimvektoren** (`1/s`/`Hz`, `N·m`/`J`): Vorzugs-Symbol-Tabelle pflegen oder
+  bei Ambiguität bewusst komponieren (§3.3-Wrinkle).
+* **Persistenz** des `unit_system` über Serialisierung (Parquet/dict/JSON-LD) — separater
+  Folge-RFC; ohne sie ist das gemerkte System transient.
+* **`pint`-Interop** für Einheiten außerhalb der kuratierten Tabelle (optional, wie bei
+  `validate_unit`).
+* **Winkel/Logarithmische Einheiten** (rad/deg, dB) sind dimensionslos-aber-distinkt und
+  bleiben vorerst außen vor.
+* **Über das DataFrame hinaus:** dieselbe Algebra kann skalare `Attribute` (mit `unit`) im
+  `Metadata` umrechnen — späterer Schritt.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,6 @@ nav:
       - "0003 — Blob as data foundation": rfc/0003-blob-as-data-foundation.md
       - "0004 — DataFrame and Blob": rfc/0004-dataframe-and-blob.md
       - "0005 — Native image metadata": rfc/0005-native-image-metadata.md
-      - "0006 — Unit-system conversion on set (proposed)": rfc/0006-unit-system-conversion-on-set.md
+      - "0006 — Consistent unit systems (dimensional algebra, proposed)": rfc/0006-unit-system-conversion-on-set.md
   - Releasing: releasing.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Was

Überarbeitung von **RFC 0006** zu **v2** nach dem Review-Grilling. Kernänderung: der flache `Größe→Einheit`-Lookup wird durch echte **Dimensions-Algebra** ersetzt.

### Dimensions-Algebra
- `UnitSystem` wird aus seinen **Basis-Einheiten gelöst** (lineares System im Log-Raum über den Basis-Dimensionen L/M/T/Θ; exakte Exponenten via `fractions`).
- **Jede abgeleitete Einheit wird hergeleitet** — `[kN, mm, ms]` rechnet damit auch Spannung (`MPa→GPa`), Energie (`J`), Geschwindigkeit (`m/s`) und Dehnrate (`1/ms`) konsistent um. v1 ließ genau diese Spalten still unverändert (der Haupt-Reviewbefund).
- Label: kanonischer Registry-Treffer bevorzugt (`GPa`/`J`/`m/s`), sonst aus den Basis-Symbolen komponiert (`kg/mm³`, `mm/ms²`).

### Review-Befunde adressiert (Abschnitt 0)
| v1-Problem | v2 |
|---|---|
| abgeleitete Größen nicht umgerechnet | Dimensions-Algebra |
| zirkulärer System-Pfad-Relabel | `relabel_units({col: unit})` nur explizit, mit Report + `force=` |
| inkompatibles Relabel still | `force=True` + Pflicht-Log + Report |
| `set_unit_system` Namens-Kollision/inplace-Asymmetrie | gestrichen; „setzen = umrechnen" ist `convert(system, inplace=True)` |
| `rescale=False` unklar benannt | eigene Methode `relabel_units` |

Enthält Solver-Beschreibung (FLT/MLT, unter-/überbestimmt), Worked Example `[kN, mm, ms]` mit abgeleiteten Spalten, Sicherheits-/Semantik-Abschnitt (QUDT/JSON-LD), Test-/Coverage-Plan (Branch-Coverage) und Migration.

## Umfang
Reine **Doku** — RFC ersetzt, Nav-Titel + CHANGELOG aktualisiert. Kein Code; `mkdocs build --strict` grün.