### PR TITLE
feat(units): Dimensions-Algebra für konsistente Einheitensysteme (RFC 0006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,29 +8,29 @@ All notable changes to **sdata** are documented here. The format is based on
 
 ### Added
 
-- **Unit conversion (`sdata.units`).** A pure-Python conversion layer over the
-  curated unit table — `convert`/`convert_factor`/`quantity_of` and a `UnitSystem`
-  helper (consistent unit systems such as `["kN", "mm", "ms"]`). It covers the common
-  engineering quantities (length, force, time, mass, pressure, strain-rate,
-  temperature incl. offset units), works on scalars/lists/NumPy arrays/pandas Series,
-  and raises a clear `UnitConversionError` on incompatible quantities.
-- **`DataFrame.convert(units=None, inplace=False)`.** Rescale a table's columns into
-  a target unit system (a unit list, a `UnitSystem`, or an explicit `{column: unit}`
-  mapping) and update the per-column `unit` annotations in one step — returning a
-  converted copy by default. Columns without a unit or whose quantity the system does
-  not cover are left unchanged.
+- **Unit conversion via dimensional algebra (`sdata.units`, RFC 0006).** A pure-Python
+  conversion layer: `convert`/`convert_factor`/`quantity_of`/`dimension_of` and a
+  `UnitSystem` that is **solved from its base units** — so a *consistent* system such as
+  `["kN", "mm", "ms"]` derives **all** units (stress→`GPa`, energy→`J`, velocity→`m/s`,
+  mass→`kg`) from the base set via an exact `fractions`-based solver. Covers length,
+  mass, time, temperature (offset units), force, pressure, energy, power, velocity,
+  area/volume and rate; works on scalars/lists/NumPy arrays/pandas Series; raises a clear
+  `UnitConversionError` on incompatible dimensions or inconsistent systems.
+- **`DataFrame.convert(units=None, inplace=False)`.** Convert a table's columns into a
+  target unit system (a unit list, a `UnitSystem`, or an explicit `{column: unit}`
+  mapping) — **including derived units** — and update the per-column `unit` annotations,
+  returning a converted copy by default. Columns without a unit or whose dimension the
+  system does not span are left unchanged.
+- **`DataFrame.relabel_units(mapping, *, force=False)`.** Fix mislabeled units: set the
+  `unit` of named columns **without rescaling** the values; same-dimension relabels are
+  logged, a dimension change requires `force=True`. Returns a report.
 - **`DataFrame.unit_system`.** A settable target unit system on the table (a
   `UnitSystem` or unit list, also via the `unit_system=` constructor keyword);
-  `convert()` with no argument rescales into it. Setting only records the target
+  `convert()` with no argument converts into it. Setting only records the target
   (the data is rescaled by `convert()`), and a converted copy carries it over.
 - **Docs.** A worked tensile-test example (`force [N]` / `time [s]` /
-  `displacement [mm]`, fully semantically described, converted to `[kN, mm, ms]`) and
-  a unit-conversion reference in `usage/dataframe.md`.
-- **RFC 0006 (proposed, v2).** Design for **consistent unit systems via dimensional
-  algebra**: a `UnitSystem` is solved from its base units, so *all* derived units
-  (stress→`GPa`, energy→`J`, velocity→`m/s`) are rescaled when converting into it
-  (`convert(system, inplace=True)`); plus a safe `relabel_units({col: unit})` for
-  fixing mislabeled units without rescaling. Proposal only, not yet implemented.
+  `displacement [mm]`, fully semantically described, converted to `[kN, mm, ms]`) and a
+  unit-conversion reference in `usage/dataframe.md`; RFC 0006 v2 (dimensional algebra).
 
 ## [1.3.0] - 2026-06-29
 

--- a/docs/rfc/0006-unit-system-conversion-on-set.md
+++ b/docs/rfc/0006-unit-system-conversion-on-set.md
@@ -2,16 +2,18 @@
 
 | Feld        | Wert                                                                 |
 |-------------|----------------------------------------------------------------------|
-| Status      | Proposed (Entwurf), **v2** — ersetzt den v1-Entwurf                  |
+| Status      | Accepted — implementiert (**v2**, ersetzt den v1-Entwurf)           |
 | Datum       | 2026-06-30                                                           |
 | Autor       | lepy <lepy@tuta.io>                                                  |
 | Komponente  | `sdata/units.py`, `sdata/sclass/dataframe.py`                       |
-| Betrifft    | `UnitSystem`, `DataFrame.convert`, `DataFrame.unit_system`, neu `relabel_units` |
-| Validierung | (geplant) 100 % Branch-Coverage; Solver- und Round-Trip-Tests        |
+| Betrifft    | `UnitSystem`, `DataFrame.convert`, `DataFrame.unit_system`, `DataFrame.relabel_units` |
+| Validierung | `units.py` 100 %, `sclass/dataframe.py` 100 %; Solver- und Round-Trip-Tests |
 
-> **Umsetzungsstand.** Vorschlag (v2). Baut auf dem in PR #86–#88 ausgelieferten
-> `units.convert`/`convert_factor`, `DataFrame.convert` und der record-only-Property
-> `DataFrame.unit_system` auf. v2 **ersetzt** den v1-Entwurf nach dem Review.
+> **Umsetzungsstand.** Implementiert. `sdata/units.py` trägt die Dimensions-Algebra
+> (Dimvektoren, exakter `Fraction`-Solver, `UnitSystem` aus Basis-Einheiten,
+> `dimension_of`/`convert_value`); `DataFrame.convert` rechnet abgeleitete Einheiten
+> mit, `DataFrame.relabel_units` korrigiert falsche Einheiten ohne Skalierung. v2
+> **ersetzt** den v1-Entwurf nach dem Review.
 
 ## 0. Was sich gegenüber v1 ändert
 
@@ -106,35 +108,41 @@ Dimension** `g` bestimmt: `log(system_factor(g)) = Σ_d g[d]·x_d`. Eigenschafte
 * **FLT oder MLT.** Der Nutzer darf Kraft *oder* Masse als Basis geben (`[kN, mm, ms]` ist
   force-length-time; `[kg, mm, ms]` mass-length-time) — der Solver löst beide; bei `[kN,
   mm, ms]` ergibt sich die Masse-Einheit zu `kg`.
-* **Temperatur** ist standardmäßig `K`, sofern keine Temperatur-Einheit angegeben ist.
+* **Temperatur** wird nur abgedeckt, wenn das System eine Temperatur-Einheit (z. B.
+  `K`) enthält; sonst bleiben Temperatur-Spalten unverändert (die Θ-Dimension ist nicht
+  aufgespannt). Offset-Einheiten (`degC`) sind als Basis **nicht** zulässig.
 * **Unter­bestimmt.** Spannen die angegebenen Einheiten eine Dimension nicht auf (z. B.
   `[kN, mm]` ohne Zeit → Geschwindigkeit nicht lösbar), bleiben Spalten dieser Dimension
   **unverändert** (geloggt) — analog „Größe nicht im System".
 * **Über­bestimmt.** Redundante, *konsistente* Angaben sind erlaubt (z. B. zusätzlich
   `GPa`, das aus `[kN, mm, ms]` bereits folgt); *widersprüchliche* Angaben sind ein Fehler
   (`UnitConversionError`).
-* **Exaktheit.** Der Solver arbeitet über `fractions.Fraction`-Exponenten (die Dimvektor-
-  Komponenten sind kleine ganze/rationale Zahlen), sodass die hergeleiteten Exponenten
-  driftfrei sind; nur der numerische Faktor ist `float`.
+* **Exaktheit.** Der Solver bestimmt die Koeffizienten exakt über `fractions.Fraction`;
+  der System-Faktor wird als exaktes rationales **Potenzprodukt** der Basis-Faktoren
+  berechnet (kein `log`/`exp`), sodass z. B. `5000 N → 5.0 kN` und `200 MPa → 0.2 GPa`
+  exakt herauskommen. Nur bei (seltenen) nicht-ganzzahligen Exponenten — etwa Länge aus
+  einem Flächen-Basis `[mm2, s]` über den Exponenten ½ — wird auf `float` zurückgefallen.
 
 ### 3.3 Hergeleitete Einheit: Faktor **und** Label
 
 Für eine Spalte mit Einheit `u` (Dimvektor `g`, `factor_u`) ist der Zielwert
 `wert · factor_u / system_factor(g)`. Das **Label** der Zieleinheit wird so gewählt:
 
-1. **Kanonischer Registry-Treffer:** gibt es eine bekannte Einheit mit exakt `(g,
-   system_factor(g))`, wird deren Symbol verwendet (`GPa`, `J`, `m/s`, `N`). Bevorzugt,
-   weil lesbar und interoperabel.
-2. **Sonst komponiert** aus den **Basis-Symbolen des Systems**, indem `g` in der Basis der
-   angegebenen System-Einheiten ausgedrückt wird (z. B. Dichte → `kg/mm³`,
-   Beschleunigung → `mm/ms²`).
+1. **Kanonischer Registry-Treffer:** gibt es ein Vorzugs-Symbol mit exakt `(g,
+   system_factor(g))`, wird es verwendet (`GPa`, `J`, `m/s`, `kN`, `1/ms`, `kg`).
+   Bevorzugt, weil lesbar und interoperabel.
+2. **Sonst komponiert** aus den **angegebenen Basis-Symbolen** des Systems (den
+   Koeffizienten der Lösung), Format `*` (mal), `/` (geteilt), `^n` (Exponent) — z. B.
+   Beschleunigung → `mm/ms^2`, Dichte → `kN*ms^2/mm^4` (force-basiert).
 
 Bei `[kN, mm, ms]` liefert das u. a. Spannung→`GPa`, Energie→`J`, Geschwindigkeit→`m/s`,
-Dehnrate→`1/ms`, Masse→`kg`, Dichte→`kg/mm³` — alle numerisch konsistent.
+Dehnrate→`1/ms`, Masse→`kg` (alle **kanonisch**); unbenannte Composites wie
+Beschleunigung→`mm/ms^2` werden aus den Basis-Symbolen komponiert — alle numerisch
+konsistent.
 
 > **Wrinkle.** Manche Dimvektoren sind mehrdeutig benannt (`1/s` vs. `Hz` vs. `Bq`,
-> Drehmoment `N·m` vs. Energie `J`). Schritt 1 nutzt eine **eindeutige** Vorzugs-Symbol-
-> Tabelle pro Dimvektor; bei Ambiguität wird Schritt 2 (komponiert) gewählt. Siehe §7.
+> Drehmoment `N·m` vs. Energie `J`). Schritt 1 nutzt eine **geordnete** Vorzugs-Symbol-
+> Liste (`_CANON_SYMBOLS`); ohne eindeutigen Treffer greift Schritt 2 (komponiert). Siehe §7.
 
 ### 3.4 API
 
@@ -148,21 +156,24 @@ DataFrame.convert(units=None, inplace=False)
 # Ziel-System nur MERKEN (kein Daten-Seiteneffekt) — unverändert
 sdf.unit_system = ["kN", "mm", "ms"]
 
-# falsche Einheiten KORRIGIEREN, Werte NICHT ändern (explizit pro Spalte)
-DataFrame.relabel_units(mapping, *, force=False) -> RelabelReport
+# falsche Einheiten KORRIGIEREN, Werte NICHT ändern (explizit pro Spalte, in place)
+DataFrame.relabel_units(mapping, *, force=False) -> list[dict]
 #   setzt unit der genannten Spalten ohne Skalierung; gleiche Dimension: ok + geloggt;
-#   andere Dimension: nur mit force=True, sonst UnitConversionError; Report listet alt→neu
+#   andere Dimension: nur mit force=True, sonst UnitConversionError.
+#   Report: Liste von {"column", "old", "new", "dimension_changed"}
 
 # units-Modul
-units.dimension_of(unit) -> DimVector
-units.UnitSystem(base_units)          # löst Basis-Dimensionen (§3.2)
-system.factor_for(dimvector) -> float
-system.unit_for(dimvector) -> (factor, label)   # §3.3
+units.dimension_of(unit) -> (L, M, T, Θ) | None
+units.UnitSystem(base_units)                    # löst die Basis-Dimensionen (§3.2)
+system.target_for(unit) -> label | None         # System-Einheit derselben Dimension
+system.convert_value(value, unit) -> (value, label) | None
+system.factor_for(dimvector) -> float | None
+system.unit_for(quantity_name) -> label | None  # z. B. "force" -> "kN"
 units.convert / units.convert_factor            # unverändert (zwei Einheiten gleicher Dim)
 ```
 
-`convert` verliert das v1-`rescale`-Flag; reines Umlabeln ist jetzt `relabel_units`
-(ehrlich benannt, mit Report und `force`).
+`convert` führt **kein** Relabeling-Flag; reines Umlabeln ist `relabel_units` (ehrlich
+benannt, mutiert in place, mit Report und `force`).
 
 ### 3.5 Semantik je Spalte
 
@@ -224,27 +235,29 @@ jetzt korrekt mitgeführt.
 ## 6. Sicherheit & semantische Schicht
 
 * **Audit-Spur.** `convert` loggt jede umgerechnete Spalte (`alt → neu`); `relabel_units`
-  gibt zusätzlich einen `RelabelReport` (Liste `{column, old, new, dimension_changed}`)
-  zurück.
-* **JSON-LD/QUDT bleibt konsistent.** Eine geänderte Einheit aktualisiert konsequent den
+  loggt jedes Umlabeln (Warnung) und gibt zusätzlich einen Report (Liste von
+  `{column, old, new, dimension_changed}`) zurück.
+* **JSON-LD/QUDT bleibt konsistent.** Eine geänderte Einheit fließt direkt in den
   `qudt:Quantity`/`unitRef`-Knoten der Spalte (das `to_jsonld`-Spalten-Mapping liest die
-  `unit` der Spalte). Bei `relabel_units` mit `dimension_changed` wird zusätzlich gewarnt,
-  falls die hinterlegte `ontology`/Größenklasse der Spalte nicht mehr zur neuen Einheit
-  passt (kein Auto-Override der Ontologie).
+  `unit` der Spalte). Die hinterlegte `ontology`/Größenklasse wird **nicht** automatisch
+  überschrieben; bei `relabel_units` mit Dimensionswechsel (`force=True`) macht die
+  geloggte Warnung auf eine mögliche Inkonsistenz aufmerksam.
 
-## 7. Tests / Coverage (geplant)
+## 7. Tests / Coverage (umgesetzt)
 
-* **Solver:** FLT (`[kN, mm, ms]`→ Masse `kg`), MLT (`[t, mm, s]`), unterbestimmt
-  (`[kN, mm]` → Geschwindigkeit unverändert), überbestimmt-konsistent (`[kN, mm, ms, GPa]`),
-  überbestimmt-widersprüchlich (Fehler).
+`units.py` **100 %**, `sclass/dataframe.py` **100 %** Line-Coverage; alle bestehenden
+`convert`/`unit_system`-Tests bleiben grün. Abgedeckt:
+
+* **Solver:** FLT (`[kN, mm, ms]` → Masse `kg`), MLT (`[t, mm, s]`), unterbestimmt
+  (`[kN, mm, ms]` → Temperatur/`degC` unverändert), überbestimmt-konsistent
+  (`[kN, mm, ms, GPa]`), überbestimmt-widersprüchlich (`["N","kN"]` → Fehler), rationaler
+  Exponent (`[mm2, s]` → Länge über ½); plus White-Box-Test des `_solve_linear`-Pfads.
 * **Abgeleitete Umrechnung:** Spannung `MPa→GPa`, Energie `J→J`, Geschwindigkeit `m/s`,
-  Dehnrate `1/s→1/ms`, Dichte (komponiertes Label `kg/mm³`).
-* **Relabel:** gleiche Dimension (ok+Report), einheitenlose Spalte labeln, inkompatibel
-  ohne/mit `force` (Fehler / Override+Warnung+Report).
-* **Temperatur:** `degC↔K` (offset), Verbot von Offset in zusammengesetzten Dimensionen.
+  Dehnrate `1/s→1/ms`, Masse `g→kg`; Komposition (`_compose`) aus Basis-Symbolen.
+* **Relabel:** gleiche Dimension (ok + Report), einheitenlose Spalte labeln, inkompatibel
+  ohne/mit `force` (Fehler / Override + Warnung + Report).
+* **Temperatur:** `degC→K` (Offset, System mit `K`); Offset-Einheit als Basis abgelehnt.
 * **Property** bleibt nachweislich record-only.
-* **Branch-Coverage** (nicht nur Line) für die neuen Verzweigungen; bestehende
-  `convert`/`unit_system`-Tests bleiben grün.
 
 ## 8. Kompatibilität / Migration
 

--- a/docs/usage/dataframe.md
+++ b/docs/usage/dataframe.md
@@ -164,12 +164,15 @@ keys that match no column — are only logged as a warning, never dropped).
 ### Unit conversion
 
 `convert` rescales column data into a target **unit system** and updates the
-`unit` annotations in one step (pure Python, no extra dependency — the curated table
-in [`sdata.units`][sdata.units] covers the common engineering units: length, force,
-time, mass, pressure, strain-rate and temperature). The argument may be
+`unit` annotations in one step (pure Python, no extra dependency). A
+[`UnitSystem`][sdata.units.UnitSystem] is a **consistent** system: it is solved from
+its base units by *dimensional algebra*, so **derived** units follow automatically —
+`["kN", "mm", "ms"]` converts a stress column `MPa → GPa` (= kN/mm²), energy `J`
+(= kN·mm), velocity `m/s` (= mm/ms) and mass `kg`, not just force/length/time
+(see [RFC 0006](../rfc/0006-unit-system-conversion-on-set.md)). The argument may be
 
-* a list/tuple of unit symbols — e.g. `["kN", "mm", "ms"]` — wrapped into a
-  [`UnitSystem`][sdata.units.UnitSystem] (one unit per physical quantity),
+* a list/tuple of **base-unit** symbols — e.g. `["kN", "mm", "ms"]` — wrapped into a
+  [`UnitSystem`][sdata.units.UnitSystem],
 * a [`UnitSystem`][sdata.units.UnitSystem] instance, or
 * a dict `{column: target_unit}` for explicit, per-column targets.
 
@@ -200,10 +203,21 @@ units. A converted copy carries the system over, and applying a full system sets
 result's `unit_system`; `convert()` raises `ValueError` if neither an argument nor a
 `unit_system` is set.
 
-Only columns whose physical quantity the system addresses are touched; columns
-without a unit, dimensionless columns, and quantities the system does not cover are
-left unchanged. Converting across incompatible quantities (e.g. a length column to a
-force unit) raises [`UnitConversionError`][sdata.units.UnitConversionError].
+Only columns whose **dimension** the system spans are touched; columns without a
+unit, dimensionless columns, and dimensions the system does not span (e.g. temperature
+in a `[kN, mm, ms]` system) are left unchanged. Converting across incompatible
+dimensions in a `{column: unit}` mapping (e.g. a length column to a force unit) raises
+[`UnitConversionError`][sdata.units.UnitConversionError].
+
+**Fixing mislabeled units.** When a column's numbers are already in the intended unit
+but its annotation is wrong, use `relabel_units` to set the `unit` **without** rescaling
+the values (mutates in place, returns a report). A same-dimension relabel is logged; a
+dimension change requires `force=True`:
+
+```python
+sdf.relabel_units({"force": "kN"})            # data was already kN, just fix the label
+sdf.relabel_units({"x": "mm"}, force=True)    # override across dimensions (logged)
+```
 
 The same machinery is available standalone for scalars, lists, NumPy arrays and
 pandas Series:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,6 @@ nav:
       - "0003 — Blob as data foundation": rfc/0003-blob-as-data-foundation.md
       - "0004 — DataFrame and Blob": rfc/0004-dataframe-and-blob.md
       - "0005 — Native image metadata": rfc/0005-native-image-metadata.md
-      - "0006 — Consistent unit systems (dimensional algebra, proposed)": rfc/0006-unit-system-conversion-on-set.md
+      - "0006 — Consistent unit systems (dimensional algebra)": rfc/0006-unit-system-conversion-on-set.md
   - Releasing: releasing.md
   - Changelog: changelog.md

--- a/sdata/sclass/dataframe.py
+++ b/sdata/sclass/dataframe.py
@@ -253,23 +253,6 @@ class DataFrame(ContentIntegrityMixin, Base):
         new._unit_system = self._unit_system
         return new
 
-    def _resolve_unit_targets(self, units, U):
-        """Bestimme je Spalte die Ziel-Einheit für :meth:`convert`.
-
-        :param units: ``UnitSystem`` / Einheiten-Liste / ``{Spalte: Einheit}``-dict.
-        :param U: das :mod:`sdata.units`-Modul (injiziert, spart Re-Import).
-        :return: ``{Spalte: Ziel-Einheit-oder-None}``.
-        """
-        if isinstance(units, dict):
-            return {str(col): unit for col, unit in units.items()}
-        system = units if isinstance(units, U.UnitSystem) else U.UnitSystem(units)
-        targets = {}
-        for col in self._df.columns:
-            attr = self._column_metadata.get(str(col))
-            if attr is not None:
-                targets[str(col)] = system.target_for(attr.unit)
-        return targets
-
     def convert(self, units=None, inplace=False):
         """Convert numeric columns into a target unit system (or explicit units).
 
@@ -277,25 +260,27 @@ class DataFrame(ContentIntegrityMixin, Base):
 
         * ``None`` (the default) — use this table's :attr:`unit_system`,
         * a :class:`~sdata.units.UnitSystem`,
-        * a list/tuple of unit symbols, e.g. ``["kN", "mm", "ms"]`` — wrapped into a
-          :class:`~sdata.units.UnitSystem` (one unit per physical quantity), or
+        * a list/tuple of base-unit symbols, e.g. ``["kN", "mm", "ms"]`` — wrapped into
+          a :class:`~sdata.units.UnitSystem` (a *consistent* system: **derived** units
+          such as stress→``GPa``, energy→``J``, velocity→``m/s`` follow from the base
+          units via dimensional algebra), or
         * a dict ``{column: target_unit}`` for explicit per-column targets.
 
         Every column that carries a unit in :attr:`column_metadata` and whose
-        physical quantity is addressed by ``units`` has its **values rescaled** and
-        its ``unit`` annotation updated. Columns without a unit, dimensionless
-        columns, and quantities the system does not cover are left untouched. By
-        default a converted **copy** is returned (data + metadata); pass
-        ``inplace=True`` to mutate this DataFrame. When a full unit system (not a
-        per-column dict) is applied, the result's :attr:`unit_system` is set to it.
+        **dimension** the system spans has its values rescaled and its ``unit``
+        annotation updated to the system's (derived) unit. Columns without a unit,
+        dimensionless columns, and dimensions the system does not span are left
+        untouched. By default a converted **copy** is returned (data + metadata);
+        pass ``inplace=True`` to mutate this DataFrame. When a full unit system (not
+        a per-column dict) is applied, the result's :attr:`unit_system` is set to it.
 
         :param units: target unit system, unit list, or ``{column: unit}`` mapping;
           ``None`` uses :attr:`unit_system`.
         :param inplace: mutate this DataFrame instead of returning a converted copy.
         :return: the converted :class:`DataFrame` (``self`` if ``inplace``).
         :raises ValueError: if ``units`` is ``None`` and no :attr:`unit_system` is set.
-        :raises sdata.units.UnitConversionError: on incompatible units (e.g. an
-          explicit mapping that converts a length column to a force unit).
+        :raises sdata.units.UnitConversionError: on incompatible units in a
+          ``{column: unit}`` mapping (e.g. a length column to a force unit).
         """
         from sdata import units as U
         if units is None:
@@ -303,25 +288,90 @@ class DataFrame(ContentIntegrityMixin, Base):
         if units is None:
             raise ValueError(
                 "no unit system: pass units to convert() or set .unit_system")
-        targets = self._resolve_unit_targets(units, U)
         sdf = self if inplace else self._converted_copy()
-        for col, target in targets.items():
-            if target is None:
+        if isinstance(units, dict):
+            sdf._convert_by_mapping(units, U)
+        else:
+            system = units if isinstance(units, U.UnitSystem) else U.UnitSystem(units)
+            sdf._convert_by_system(system)
+            sdf._unit_system = system
+        return sdf
+
+    def _convert_by_system(self, system):
+        """Rechne jede abgedeckte Spalte in die (hergeleitete) System-Einheit um."""
+        for col in self._df.columns:
+            attr = self._column_metadata.get(str(col))
+            current = attr.unit if attr is not None else None
+            if not current or current in ("-", ""):
                 continue
-            attr = sdf._column_metadata.get(str(col))
+            result = system.convert_value(self._df[col], current)
+            if result is None:                       # Dimension nicht aufgespannt
+                continue
+            converted, label = result
+            if str(label) == str(current):           # bereits in System-Einheit
+                continue
+            self._df[col] = converted
+            self.set_column(str(col), unit=str(label))
+            logger.info("convert: %s %s -> %s", col, current, label)
+
+    def _convert_by_mapping(self, mapping, U):
+        """Rechne genau die genannten Spalten in die jeweils angegebene Einheit um."""
+        for col, target in mapping.items():
+            col = str(col)
+            attr = self._column_metadata.get(col)
             current = attr.unit if attr is not None else None
             if not current or current in ("-", ""):
                 logger.warning("convert: column %r has no unit; skipped", col)
                 continue
             if str(target) == str(current):
                 continue
-            sdf._df[col] = U.convert(sdf._df[col], current, target)
-            sdf.set_column(col, unit=str(target))
+            self._df[col] = U.convert(self._df[col], current, target)
+            self.set_column(col, unit=str(target))
             logger.info("convert: %s %s -> %s", col, current, target)
-        if not isinstance(units, dict):
-            sdf._unit_system = units if isinstance(units, U.UnitSystem) \
-                else U.UnitSystem(units)
-        return sdf
+
+    def relabel_units(self, mapping, *, force=False):
+        """Set column units **without** rescaling the values (fix mislabeled units).
+
+        Use this when a column's numbers are already in the intended unit but its
+        ``unit`` annotation is wrong. Unlike :meth:`convert`, the data is left
+        untouched; only the ``unit`` field is overwritten. Mutates **in place** and
+        returns a report.
+
+        Relabeling within the same dimension (e.g. ``"N"`` → ``"kN"`` on data already
+        in kN) is allowed and logged. A **dimension change** (e.g. force → length) is
+        refused unless ``force=True`` — overwriting then logs a warning and is flagged
+        in the report.
+
+        :param mapping: ``{column: new_unit}``; columns may have a missing/unknown
+          current unit (the pure mislabel-fix case).
+        :param force: allow overwriting with a unit of a different dimension.
+        :return: a list of records ``{"column", "old", "new", "dimension_changed"}``.
+        :raises sdata.units.UnitConversionError: on a dimension change without
+          ``force=True``.
+        """
+        from sdata import units as U
+        report = []
+        for col, new_unit in mapping.items():
+            col = str(col)
+            new_unit = str(new_unit)
+            attr = self._column_metadata.get(col)
+            old = attr.unit if attr is not None else None
+            # "-"/"" zählen wie "keine Einheit": ein Label-Set, kein Dimensionswechsel
+            old_real = old if old and old not in ("-", "") else None
+            old_dim = U.dimension_of(old_real) if old_real else None
+            new_dim = U.dimension_of(new_unit)
+            dim_changed = (old_dim is not None and new_dim is not None
+                           and old_dim != new_dim)
+            if dim_changed and not force:
+                raise U.UnitConversionError(
+                    f"relabel_units: {col!r} {old!r} -> {new_unit!r} changes dimension; "
+                    f"pass force=True to override")
+            self.set_column(col, unit=new_unit)
+            logger.warning("relabel_units: %s %s -> %s%s", col, old, new_unit,
+                           " (dimension changed)" if dim_changed else "")
+            report.append({"column": col, "old": old, "new": new_unit,
+                           "dimension_changed": dim_changed})
+        return report
 
     def validate_table(self, schema=None):
         """Validate the df/column_metadata against a :class:`~sdata.schema.TableSchema`.

--- a/sdata/units.py
+++ b/sdata/units.py
@@ -8,8 +8,8 @@ die kuratierte Tabelle.
 __all__ = [
     "UNIT_MAP", "normalize_symbol", "qudt_iri", "ucum_code", "unit_node",
     "validate_unit", "has_pint",
-    "UnitConversionError", "quantity_of", "convert", "convert_factor",
-    "UnitSystem",
+    "UnitConversionError", "quantity_of", "dimension_of", "convert",
+    "convert_factor", "UnitSystem",
 ]
 
 try:  # optionales Backend
@@ -103,41 +103,63 @@ def validate_unit(symbol):
 
 
 # --------------------------------------------------------------- Konvertierung
+#
+# Dimensions-Algebra (RFC 0006): jede Einheit trägt einen Dimensionsvektor über den
+# Basis-Dimensionen (Länge L, Masse M, Zeit T, Temperatur Θ). Ein :class:`UnitSystem`
+# wird aus seinen Basis-Einheiten *gelöst*, sodass jede abgeleitete Einheit (Spannung,
+# Energie, Geschwindigkeit, …) hergeleitet werden kann. Reine Standardbibliothek
+# (``fractions`` für exakte Exponenten); das optionale ``pint`` bleibt der Validierung.
+
+import math
+from fractions import Fraction
+
 
 class UnitConversionError(ValueError):
-    """Eine Einheit ist unbekannt oder die Größen sind inkompatibel (z. B. mm → kN)."""
+    """Eine Einheit ist unbekannt oder die Dimensionen sind inkompatibel (z. B. mm → kN)."""
 
 
-#: Einheit -> (Größe, Faktor, Offset) für die Umrechnung in die SI-Basis der Größe:
-#: ``si = wert * faktor + offset``. Reine Skalierung hat ``offset == 0``; nur
-#: Temperatur trägt einen Offset. Zwei Einheiten sind genau dann ineinander
-#: umrechenbar, wenn ihre *Größe* übereinstimmt. Die Tabelle deckt die im
-#: Ingenieurkontext üblichen mechanischen Einheiten ab (für beliebige Einheiten
-#: bliebe das optionale ``pint``-Backend – die Konvertierung bleibt jedoch bewusst
-#: deterministisch auf dieser kuratierten Tabelle).
-_CONVERT = {
-    # Länge (SI: m)
-    "km": ("length", 1e3, 0.0), "m": ("length", 1.0, 0.0),
-    "dm": ("length", 1e-1, 0.0), "cm": ("length", 1e-2, 0.0),
-    "mm": ("length", 1e-3, 0.0), "um": ("length", 1e-6, 0.0),
-    "nm": ("length", 1e-9, 0.0),
-    # Kraft (SI: N)
-    "MN": ("force", 1e6, 0.0), "kN": ("force", 1e3, 0.0),
-    "N": ("force", 1.0, 0.0), "mN": ("force", 1e-3, 0.0),
-    # Zeit (SI: s)
-    "h": ("time", 3600.0, 0.0), "min": ("time", 60.0, 0.0),
-    "s": ("time", 1.0, 0.0), "ms": ("time", 1e-3, 0.0),
-    "us": ("time", 1e-6, 0.0), "ns": ("time", 1e-9, 0.0),
-    # Masse (SI: kg)
-    "t": ("mass", 1e3, 0.0), "kg": ("mass", 1.0, 0.0),
-    "g": ("mass", 1e-3, 0.0), "mg": ("mass", 1e-6, 0.0),
-    # Druck / Spannung (SI: Pa)
-    "GPa": ("pressure", 1e9, 0.0), "MPa": ("pressure", 1e6, 0.0),
-    "kPa": ("pressure", 1e3, 0.0), "Pa": ("pressure", 1.0, 0.0),
-    # Dehnrate (SI: 1/s)
-    "1/s": ("strain_rate", 1.0, 0.0), "1/ms": ("strain_rate", 1e3, 0.0),
-    # Temperatur (SI: K) – mit Offset
-    "K": ("temperature", 1.0, 0.0), "degC": ("temperature", 1.0, 273.15),
+#: Basis-Dimensionen: Länge, Masse, Zeit, Temperatur.
+_DIM_NAMES = ("L", "M", "T", "Theta")
+
+#: Einheit -> (Dimvektor ``(L, M, T, Θ)``, Faktor zur SI-kohärenten Einheit, Offset).
+#: ``si = wert * faktor + offset``; ``offset != 0`` nur bei reiner Temperatur.
+_UNITS = {
+    # Länge (1,0,0,0) – SI m
+    "km": ((1, 0, 0, 0), 1e3, 0.0), "m": ((1, 0, 0, 0), 1.0, 0.0),
+    "dm": ((1, 0, 0, 0), 1e-1, 0.0), "cm": ((1, 0, 0, 0), 1e-2, 0.0),
+    "mm": ((1, 0, 0, 0), 1e-3, 0.0), "um": ((1, 0, 0, 0), 1e-6, 0.0),
+    "nm": ((1, 0, 0, 0), 1e-9, 0.0),
+    # Masse (0,1,0,0) – SI kg
+    "t": ((0, 1, 0, 0), 1e3, 0.0), "kg": ((0, 1, 0, 0), 1.0, 0.0),
+    "g": ((0, 1, 0, 0), 1e-3, 0.0), "mg": ((0, 1, 0, 0), 1e-6, 0.0),
+    # Zeit (0,0,1,0) – SI s
+    "h": ((0, 0, 1, 0), 3600.0, 0.0), "min": ((0, 0, 1, 0), 60.0, 0.0),
+    "s": ((0, 0, 1, 0), 1.0, 0.0), "ms": ((0, 0, 1, 0), 1e-3, 0.0),
+    "us": ((0, 0, 1, 0), 1e-6, 0.0), "ns": ((0, 0, 1, 0), 1e-9, 0.0),
+    # Temperatur (0,0,0,1) – SI K, mit Offset
+    "K": ((0, 0, 0, 1), 1.0, 0.0), "degC": ((0, 0, 0, 1), 1.0, 273.15),
+    # Kraft (1,1,-2,0) – SI N
+    "MN": ((1, 1, -2, 0), 1e6, 0.0), "kN": ((1, 1, -2, 0), 1e3, 0.0),
+    "N": ((1, 1, -2, 0), 1.0, 0.0), "mN": ((1, 1, -2, 0), 1e-3, 0.0),
+    # Druck / Spannung (-1,1,-2,0) – SI Pa
+    "GPa": ((-1, 1, -2, 0), 1e9, 0.0), "MPa": ((-1, 1, -2, 0), 1e6, 0.0),
+    "kPa": ((-1, 1, -2, 0), 1e3, 0.0), "Pa": ((-1, 1, -2, 0), 1.0, 0.0),
+    # Energie (2,1,-2,0) – SI J
+    "kJ": ((2, 1, -2, 0), 1e3, 0.0), "J": ((2, 1, -2, 0), 1.0, 0.0),
+    "mJ": ((2, 1, -2, 0), 1e-3, 0.0),
+    # Leistung (2,1,-3,0) – SI W
+    "kW": ((2, 1, -3, 0), 1e3, 0.0), "W": ((2, 1, -3, 0), 1.0, 0.0),
+    # Geschwindigkeit (1,0,-1,0), Beschleunigung (1,0,-2,0)
+    "m/s": ((1, 0, -1, 0), 1.0, 0.0), "mm/s": ((1, 0, -1, 0), 1e-3, 0.0),
+    "m/s2": ((1, 0, -2, 0), 1.0, 0.0),
+    # Fläche (2,0,0,0), Volumen (3,0,0,0)
+    "m2": ((2, 0, 0, 0), 1.0, 0.0), "mm2": ((2, 0, 0, 0), 1e-6, 0.0),
+    "m3": ((3, 0, 0, 0), 1.0, 0.0), "mm3": ((3, 0, 0, 0), 1e-9, 0.0),
+    # Rate (0,0,-1,0) – Dehnrate / Frequenz
+    "1/s": ((0, 0, -1, 0), 1.0, 0.0), "1/ms": ((0, 0, -1, 0), 1e3, 0.0),
+    # dimensionslos (0,0,0,0)
+    "-": ((0, 0, 0, 0), 1.0, 0.0), "": ((0, 0, 0, 0), 1.0, 0.0),
+    "%": ((0, 0, 0, 0), 1e-2, 0.0),
 }
 
 #: Symbol-Aliasse speziell für die Konvertierung (verlustfrei, anders als die
@@ -148,31 +170,68 @@ _CONVERT_ALIASES = {
     "sec": "s", "second": "s", "seconds": "s", "minute": "min", "hour": "h",
 }
 
+#: Vorzugs-Symbole zur kanonischen Benennung hergeleiteter Einheiten (Reihenfolge
+#: entscheidet bei mehrdeutigen Dimensionen). Nur Offset-freie Einheiten.
+_CANON_SYMBOLS = (
+    "m", "mm", "cm", "km", "um", "nm",
+    "kg", "g", "t",
+    "s", "ms", "us",
+    "K",
+    "N", "kN", "MN",
+    "Pa", "kPa", "MPa", "GPa",
+    "J", "kJ", "W", "kW",
+    "m/s", "mm/s", "m/s2",
+    "1/s", "1/ms",
+)
+
+#: Dimvektor -> Größenname (Komfort/Backward-Compat). Dimensionslos ``(0,0,0,0)`` ist
+#: absichtlich *nicht* benannt, damit ``quantity_of("-")`` wie bisher ``None`` liefert.
+_QUANTITY_BY_DIM = {
+    (1, 0, 0, 0): "length", (0, 1, 0, 0): "mass", (0, 0, 1, 0): "time",
+    (0, 0, 0, 1): "temperature", (1, 1, -2, 0): "force", (-1, 1, -2, 0): "pressure",
+    (2, 1, -2, 0): "energy", (2, 1, -3, 0): "power", (1, 0, -1, 0): "velocity",
+    (1, 0, -2, 0): "acceleration", (2, 0, 0, 0): "area", (3, 0, 0, 0): "volume",
+    (0, 0, -1, 0): "rate",
+}
+_DIM_BY_QUANTITY = {name: dim for dim, name in _QUANTITY_BY_DIM.items()}
+
 
 def _norm_convert(symbol):
-    """Normalisiere ein Symbol auf einen Schlüssel der Konvertierungstabelle."""
+    """Normalisiere ein Symbol auf einen Schlüssel der Einheitentabelle."""
     if symbol is None:
         return "-"
     text = str(symbol).strip()
-    if text in _CONVERT:
+    if text in _UNITS:
         return text
     return _CONVERT_ALIASES.get(text, _CONVERT_ALIASES.get(text.lower(), text))
+
+
+def dimension_of(symbol):
+    """Dimensionsvektor ``(L, M, T, Θ)`` einer Einheit als Tupel, oder ``None``.
+
+    :param symbol: Einheiten-Symbol (z. B. ``"MPa"``).
+    :return: das Dimvektor-Tupel, oder ``None`` bei unbekannter Einheit.
+    """
+    entry = _UNITS.get(_norm_convert(symbol))
+    return entry[0] if entry else None
 
 
 def quantity_of(symbol):
     """Physikalische Größe einer Einheit (``"force"``/``"length"``/…) oder ``None``.
 
+    Komfort-Name, aus dem Dimensionsvektor abgeleitet; dimensionslose Einheiten
+    (``"-"``/``""``/``"%"``) liefern ``None``.
+
     :param symbol: Einheiten-Symbol (z. B. ``"kN"``).
-    :return: Name der Größe, oder ``None`` wenn die Einheit nicht in der
-      Konvertierungstabelle steht (z. B. ``"-"`` oder eine unbekannte Einheit).
+    :return: Name der Größe, oder ``None``.
     """
-    entry = _CONVERT.get(_norm_convert(symbol))
-    return entry[0] if entry else None
+    dim = dimension_of(symbol)
+    return _QUANTITY_BY_DIM.get(dim) if dim is not None else None
 
 
 def _entry(symbol, role):
     """Tabellen-Eintrag für ``symbol`` holen oder mit klarer Meldung scheitern."""
-    entry = _CONVERT.get(_norm_convert(symbol))
+    entry = _UNITS.get(_norm_convert(symbol))
     if entry is None:
         raise UnitConversionError(f"unknown {role} unit {symbol!r}")
     return entry
@@ -182,20 +241,20 @@ def convert(value, from_unit, to_unit):
     """Rechne ``value`` von ``from_unit`` in ``to_unit`` um.
 
     Funktioniert für Skalare, Listen/Tupel, NumPy-Arrays und pandas-Series (alle
-    elementweise). Beide Einheiten müssen dieselbe physikalische Größe haben.
+    elementweise). Beide Einheiten müssen dieselbe **Dimension** haben.
 
     :param value: Zahl(en) in ``from_unit``.
     :param from_unit: Quell-Einheit (z. B. ``"N"``).
     :param to_unit: Ziel-Einheit (z. B. ``"kN"``).
     :return: der umgerechnete Wert (gleiche Containerform wie ``value``; Listen/
       Tupel werden als Liste zurückgegeben).
-    :raises UnitConversionError: bei unbekannter Einheit oder inkompatiblen Größen.
+    :raises UnitConversionError: bei unbekannter Einheit oder inkompatibler Dimension.
     """
-    qf, ff, fo = _entry(from_unit, "source")
-    qt, tf, to = _entry(to_unit, "target")
-    if qf != qt:
+    df, ff, fo = _entry(from_unit, "source")
+    dt, tf, to = _entry(to_unit, "target")
+    if df != dt:
         raise UnitConversionError(
-            f"incompatible units: {from_unit!r} ({qf}) -> {to_unit!r} ({qt})")
+            f"incompatible units: {from_unit!r} -> {to_unit!r} (different dimension)")
     # si = wert*ff + fo ; ziel = (si - to) / tf
     if isinstance(value, (list, tuple)):
         return [(v * ff + fo - to) / tf for v in value]
@@ -210,54 +269,189 @@ def convert_factor(from_unit, to_unit):
     :raises UnitConversionError: bei unbekannten/inkompatiblen Einheiten oder wenn
       eine der Einheiten einen Offset trägt (z. B. ``degC`` – dann ``convert`` nutzen).
     """
-    qf, ff, fo = _entry(from_unit, "source")
-    qt, tf, to = _entry(to_unit, "target")
-    if qf != qt:
+    df, ff, fo = _entry(from_unit, "source")
+    dt, tf, to = _entry(to_unit, "target")
+    if df != dt:
         raise UnitConversionError(
-            f"incompatible units: {from_unit!r} ({qf}) -> {to_unit!r} ({qt})")
+            f"incompatible units: {from_unit!r} -> {to_unit!r} (different dimension)")
     if fo or to:
         raise UnitConversionError(
             f"offset units need convert(): {from_unit!r} -> {to_unit!r}")
     return ff / tf
 
 
+def _solve_linear(rows, rhs):
+    """Löse ``rows @ c = rhs`` exakt über ``Fraction`` (Gauß-Elimination).
+
+    :param rows: Liste von Gleichungen (je eine Liste von Koeffizienten, Länge ``n_unk``).
+    :param rhs: rechte Seite (Länge ``n_eq``).
+    :return: partikuläre Lösung (freie Variablen ``0``) als Liste ``Fraction``, oder
+      ``None``, wenn das System keine Lösung hat.
+    """
+    n_eq = len(rows)
+    n_unk = len(rows[0])
+    aug = [[Fraction(x) for x in rows[r]] + [Fraction(rhs[r])] for r in range(n_eq)]
+    prow = 0
+    pivots = []
+    for col in range(n_unk):
+        sel = next((r for r in range(prow, n_eq) if aug[r][col] != 0), None)
+        if sel is None:
+            continue
+        aug[prow], aug[sel] = aug[sel], aug[prow]
+        pv = aug[prow][col]
+        aug[prow] = [x / pv for x in aug[prow]]
+        for r in range(n_eq):
+            if r != prow and aug[r][col] != 0:
+                f = aug[r][col]
+                aug[r] = [a - f * b for a, b in zip(aug[r], aug[prow])]
+        pivots.append((col, prow))
+        prow += 1
+    for r in range(prow, n_eq):
+        if aug[r][n_unk] != 0:
+            return None
+    coeffs = [Fraction(0)] * n_unk
+    for col, row in pivots:
+        coeffs[col] = aug[row][n_unk]
+    return coeffs
+
+
+def _solve_over_basis(basis_vecs, target):
+    """Koeffizienten ``c`` mit ``Σ c_j · basis_vecs[j] = target`` (oder ``None``)."""
+    rows = [[v[d] for v in basis_vecs] for d in range(4)]
+    if not basis_vecs:
+        rows = [[] for _ in range(4)]
+    return _solve_linear(rows, [target[d] for d in range(4)])
+
+
+def _factor_from(basis, coeffs):
+    """System-Faktor ``Π base_factor ** coeff`` – exakt über ``Fraction`` bei ganzzahligen
+    Exponenten (vermeidet ``log``/``exp``-Drift), sonst float für rationale Exponenten."""
+    frac = Fraction(1)
+    fval = 1.0
+    for c, b in zip(coeffs, basis):
+        if c.denominator == 1:
+            frac *= Fraction(b[1]).limit_denominator(10 ** 12) ** c.numerator
+        else:
+            fval *= b[1] ** float(c)
+    return float(frac) * fval
+
+
+def _canonical(dim, factor):
+    """Bekanntes Vorzugs-Symbol mit exakt ``(dim, factor)`` (offset-frei), sonst ``None``."""
+    for sym in _CANON_SYMBOLS:
+        d, f, off = _UNITS[sym]
+        if off == 0.0 and d == dim and math.isclose(f, factor, rel_tol=1e-9):
+            return sym
+    return None
+
+
+def _compose(symbols, coeffs):
+    """Komponiere ein Einheiten-Label aus Basis-Symbolen und Exponenten ``coeffs``."""
+    num, den = [], []
+    for sym, c in zip(symbols, coeffs):
+        if c == 0:
+            continue
+        exp = abs(c)
+        term = sym if exp == 1 else f"{sym}^{exp}"
+        (num if c > 0 else den).append(term)
+    numerator = "*".join(num) if num else "1"
+    return numerator + "/" + "/".join(den) if den else numerator
+
+
 class UnitSystem:
-    """Konsistentes Einheitensystem: je physikalischer Größe genau eine Einheit.
+    """Konsistentes Einheitensystem über Dimensions-Algebra (RFC 0006).
 
-    Aus einer Liste von Einheiten (z. B. ``["kN", "mm", "ms"]``) wird eine
-    Abbildung *Größe → Einheit* gebaut. :meth:`target_for` liefert die
-    System-Einheit derselben Größe wie eine gegebene Einheit – ideal, um einen
-    ganzen :class:`~sdata.sclass.dataframe.DataFrame` in ein gemeinsames System
-    umzurechnen.
+    Aus den **Basis-Einheiten** (z. B. ``["kN", "mm", "ms"]``) werden die Skalen der
+    Basis-Dimensionen gelöst, sodass **jede** abgeleitete Einheit hergeleitet werden
+    kann (Spannung → ``GPa``, Energie → ``J``, Geschwindigkeit → ``m/s`` …).
+    :meth:`target_for`/:meth:`convert_value` liefern für eine gegebene Einheit die
+    System-Einheit derselben Dimension – ideal, um einen ganzen
+    :class:`~sdata.sclass.dataframe.DataFrame` in ein gemeinsames System umzurechnen.
 
-    :param units: iterierbare Einheiten-Symbole; jede muss in der
-      Konvertierungstabelle bekannt sein. Bei mehreren Einheiten derselben Größe
-      gewinnt die zuletzt genannte.
-    :raises UnitConversionError: wenn eine Einheit unbekannt ist.
+    :param units: iterierbare Basis-Einheiten-Symbole. Redundante, *konsistente*
+      Angaben sind erlaubt (z. B. zusätzlich ``"GPa"``); widersprüchliche nicht.
+    :raises UnitConversionError: bei unbekannter Einheit, Offset-Einheit als Basis
+      oder widersprüchlicher (inkonsistenter) Über­bestimmung.
     """
 
     def __init__(self, units):
         self.units = []
-        self.by_quantity = {}
+        self._basis = []   # Liste von (dimvec, log(factor), symbol) für die Basis
         for symbol in units:
-            quantity = quantity_of(symbol)
-            if quantity is None:
+            entry = _UNITS.get(_norm_convert(symbol))
+            if entry is None:
                 raise UnitConversionError(f"unknown unit in system: {symbol!r}")
+            dim, factor, offset = entry
+            if offset:
+                raise UnitConversionError(
+                    f"offset unit not allowed as system base: {symbol!r}")
             sym = str(symbol).strip()
             self.units.append(sym)
-            self.by_quantity[quantity] = sym
+            coeffs = _solve_over_basis([b[0] for b in self._basis], dim)
+            if coeffs is None:
+                self._basis.append((dim, factor, sym))
+            else:
+                derived = _factor_from(self._basis, coeffs)
+                if not math.isclose(derived, factor, rel_tol=1e-9, abs_tol=1e-12):
+                    raise UnitConversionError(
+                        f"inconsistent unit in system: {symbol!r}")
+
+    def _resolve(self, dim):
+        """``(factor, label)`` für einen Dimensionsvektor, oder ``None`` (nicht abgedeckt)."""
+        if not any(dim):
+            return None                       # dimensionslos: nicht anfassen
+        coeffs = _solve_over_basis([b[0] for b in self._basis], dim)
+        if coeffs is None:
+            return None
+        factor = _factor_from(self._basis, coeffs)
+        label = _canonical(dim, factor) or _compose([b[2] for b in self._basis], coeffs)
+        return factor, label
+
+    def factor_for(self, dim):
+        """Numerischer Faktor der System-Einheit für einen Dimensionsvektor (oder ``None``)."""
+        res = self._resolve(tuple(dim))
+        return res[0] if res else None
 
     def unit_for(self, quantity):
-        """System-Einheit für eine Größe (``"force"`` …) oder ``None``."""
-        return self.by_quantity.get(quantity)
+        """System-Einheiten-Symbol für eine Größe (``"force"``/``"pressure"``/…) oder ``None``."""
+        dim = _DIM_BY_QUANTITY.get(quantity)
+        if dim is None:
+            return None
+        res = self._resolve(dim)
+        return res[1] if res else None
 
     def target_for(self, symbol):
-        """System-Einheit derselben Größe wie ``symbol`` – sonst ``None``.
+        """System-Einheiten-Symbol derselben Dimension wie ``symbol`` – sonst ``None``.
 
-        ``None`` heißt: die Einheit ist unbekannt/dimensionslos oder ihre Größe
-        kommt im System nicht vor (die Spalte bleibt dann unverändert).
+        ``None`` heißt: die Einheit ist unbekannt/dimensionslos, oder ihre Dimension
+        wird vom System nicht aufgespannt (die Spalte bleibt dann unverändert).
         """
-        return self.by_quantity.get(quantity_of(symbol))
+        dim = dimension_of(symbol)
+        if dim is None:
+            return None
+        res = self._resolve(dim)
+        return res[1] if res else None
+
+    def convert_value(self, value, from_unit):
+        """``(umgerechneter Wert, Ziel-Label)`` für ``value`` in ``from_unit``.
+
+        Rechnet in die System-Einheit derselben Dimension um (inkl. hergeleiteter
+        Einheiten). Skalare, Listen/Tupel, NumPy-Arrays und pandas-Series.
+
+        :return: Tupel ``(wert, label)``, oder ``None`` wenn ``from_unit`` unbekannt
+          ist oder ihre Dimension nicht vom System abgedeckt wird.
+        """
+        entry = _UNITS.get(_norm_convert(from_unit))
+        if entry is None:
+            return None
+        dim, factor_cur, offset_cur = entry
+        res = self._resolve(dim)
+        if res is None:
+            return None
+        sys_factor, label = res
+        if isinstance(value, (list, tuple)):
+            return [(v * factor_cur + offset_cur) / sys_factor for v in value], label
+        return (value * factor_cur + offset_cur) / sys_factor, label
 
     def __repr__(self):
         return f"UnitSystem({self.units!r})"

--- a/tests/test_sclass_dataframe_units.py
+++ b/tests/test_sclass_dataframe_units.py
@@ -63,15 +63,42 @@ def test_convert_accepts_unit_system_object():
     assert conv.column_units["force"] == "kN"
 
 
-def test_convert_leaves_unaddressed_quantity_unchanged():
-    df = pd.DataFrame({"force": [1000.0], "stress": [200.0]})
+def test_convert_derives_units():
+    """v2: abgeleitete Einheiten (Spannung/Energie/Geschwindigkeit) werden mitgeführt."""
+    df = pd.DataFrame({"force": [5000.0], "stress": [200.0], "v": [3.0],
+                       "energy": [12.0]})
+    sdf = DataFrame(df=df, name="mix")
+    sdf.set_column("force", unit="N");   sdf.set_column("stress", unit="MPa")
+    sdf.set_column("v", unit="m/s");     sdf.set_column("energy", unit="J")
+    conv = sdf.convert(["kN", "mm", "ms"])
+    assert conv.column_units == {"force": "kN", "stress": "GPa",
+                                 "v": "m/s", "energy": "J"}
+    assert list(conv.df["force"]) == [5.0]            # N -> kN
+    assert list(conv.df["stress"]) == [0.2]           # MPa -> GPa (kN/mm²)
+    assert list(conv.df["energy"]) == [12.0]          # J -> kN·mm = J
+
+
+def test_convert_leaves_unspanned_dimension_unchanged():
+    df = pd.DataFrame({"force": [1000.0], "temp": [25.0], "ratio": [0.5],
+                       "raw": [7.0]})
     sdf = DataFrame(df=df, name="mix")
     sdf.set_column("force", unit="N")
-    sdf.set_column("stress", unit="MPa")
-    conv = sdf.convert(["kN", "mm", "ms"])   # kein Druck im System
+    sdf.set_column("temp", unit="degC")      # Temperatur-Dimension nicht im System
+    sdf.set_column("ratio", unit="%")        # dimensionslos
+    # "raw" behält die Default-Einheit "-" (keine Einheit gesetzt)
+    conv = sdf.convert(["kN", "mm", "ms"])
     assert conv.column_units["force"] == "kN"
-    assert conv.column_units["stress"] == "MPa"     # unverändert
-    assert list(conv.df["stress"]) == [200.0]
+    assert conv.column_units["temp"] == "degC"        # unverändert
+    assert list(conv.df["temp"]) == [25.0]
+    assert conv.column_units["ratio"] == "%"          # unverändert
+    assert list(conv.df["raw"]) == [7.0]              # einheitenlos -> unverändert
+
+
+def test_convert_dict_target_equals_current_noop():
+    sdf = _tensile()                                  # force in "N"
+    conv = sdf.convert({"force": "N"})                # Ziel == aktuell
+    assert conv.column_units["force"] == "N"
+    assert list(conv.df["force"]) == [0.0, 2500.0, 5000.0]
 
 
 def test_convert_dict_mapping():
@@ -157,3 +184,41 @@ def test_convert_dict_incompatible_raises():
     sdf = _tensile()
     with pytest.raises(units.UnitConversionError, match="incompatible"):
         sdf.convert({"force": "mm"})           # Kraft -> Länge
+
+
+# ------------------------------------------------------------- relabel_units
+def test_relabel_units_same_dimension(caplog):
+    """Werte sind faktisch schon kN, aber als N gelabelt -> nur Label korrigieren."""
+    sdf = _tensile()                                  # force in "N"
+    with caplog.at_level(logging.WARNING):
+        report = sdf.relabel_units({"force": "kN"})
+    assert sdf.column_units["force"] == "kN"
+    assert list(sdf.df["force"]) == [0.0, 2500.0, 5000.0]   # Werte unverändert!
+    assert report == [{"column": "force", "old": "N", "new": "kN",
+                       "dimension_changed": False}]
+
+
+def test_relabel_units_missing_unit():
+    df = pd.DataFrame({"x": [1.0, 2.0]})
+    sdf = DataFrame(df=df, name="d")                  # x ohne Einheit
+    report = sdf.relabel_units({"x": "kN"})
+    assert sdf.column_units["x"] == "kN"
+    assert list(sdf.df["x"]) == [1.0, 2.0]
+    assert report[0]["dimension_changed"] is False    # alte Dimension unbekannt
+
+
+def test_relabel_units_dimension_change_requires_force():
+    sdf = _tensile()                                  # force in "N"
+    with pytest.raises(units.UnitConversionError, match="changes dimension"):
+        sdf.relabel_units({"force": "mm"})            # Kraft -> Länge ohne force
+    assert sdf.column_units["force"] == "N"           # nichts geändert
+
+
+def test_relabel_units_dimension_change_forced(caplog):
+    sdf = _tensile()
+    with caplog.at_level(logging.WARNING):
+        report = sdf.relabel_units({"force": "mm"}, force=True)
+    assert sdf.column_units["force"] == "mm"
+    assert list(sdf.df["force"]) == [0.0, 2500.0, 5000.0]   # Werte unverändert
+    assert report[0]["dimension_changed"] is True
+    assert "dimension changed" in caplog.text

--- a/tests/test_units_convert.py
+++ b/tests/test_units_convert.py
@@ -79,25 +79,108 @@ def test_convert_factor_offset_raises():
         units.convert_factor("degC", "K")
 
 
-def test_unit_system():
+def test_unit_system_base_units():
     sys = units.UnitSystem(["kN", "mm", "ms"])
     assert sys.unit_for("force") == "kN"
     assert sys.unit_for("length") == "mm"
     assert sys.unit_for("time") == "ms"
-    assert sys.unit_for("pressure") is None
     assert sys.target_for("N") == "kN"
     assert sys.target_for("s") == "ms"
     assert sys.target_for("mm") == "mm"
-    assert sys.target_for("MPa") is None              # Größe nicht im System
     assert sys.target_for("-") is None                # dimensionslos
+    assert sys.target_for("furlong") is None          # unbekannt
     assert repr(sys) == "UnitSystem(['kN', 'mm', 'ms'])"
 
 
-def test_unit_system_last_unit_wins():
-    sys = units.UnitSystem(["N", "kN"])               # beide force
-    assert sys.unit_for("force") == "kN"
+def test_unit_system_derives_units():
+    """v2: abgeleitete Einheiten werden aus der Dimensions-Algebra hergeleitet."""
+    sys = units.UnitSystem(["kN", "mm", "ms"])
+    # Spannung kN/mm² = GPa, Energie kN·mm = J, Geschwindigkeit mm/ms = m/s, Masse kg
+    assert sys.unit_for("pressure") == "GPa"
+    assert sys.unit_for("energy") == "J"
+    assert sys.unit_for("velocity") == "m/s"
+    assert sys.target_for("MPa") == "GPa"
+    assert sys.target_for("kg") == "kg"
+    assert sys.target_for("g") == "kg"
+    assert sys.target_for("1/s") == "1/ms"
+    # exakte numerische Umrechnung der abgeleiteten Größen
+    assert sys.convert_value(200.0, "MPa") == (0.2, "GPa")
+    assert sys.convert_value(12.0, "J") == (12.0, "J")
+    assert sys.convert_value(5000.0, "N") == (5.0, "kN")
+    assert sys.convert_value([1000.0, 2000.0], "N") == ([1.0, 2.0], "kN")
+
+
+def test_unit_system_factor_for():
+    sys = units.UnitSystem(["kN", "mm", "ms"])
+    assert sys.factor_for((1, 1, -2, 0)) == 1000.0    # Kraft -> kN
+    assert sys.factor_for((-1, 1, -2, 0)) == 1e9      # Druck -> GPa
+
+
+def test_unit_system_uncovered_and_unknown():
+    sys = units.UnitSystem(["kN", "mm", "ms"])        # keine Temperatur-Dimension
+    assert sys.target_for("degC") is None             # Dimension nicht aufgespannt
+    assert sys.convert_value(25.0, "degC") is None
+    assert sys.convert_value(1.0, "furlong") is None  # unbekannte Quell-Einheit
+    assert sys.unit_for("nonsense") is None            # unbekannte Größe
+
+
+def test_unit_system_mlt_and_temperature():
+    mlt = units.UnitSystem(["t", "mm", "s"])          # Masse-Länge-Zeit
+    assert mlt.target_for("N") == "N"                  # t·mm/s² = N
+    assert mlt.target_for("kg") == "t"
+    withT = units.UnitSystem(["mm", "kg", "s", "K"])
+    assert withT.convert_value(25.0, "degC") == (298.15, "K")   # Offset
+
+
+def test_unit_system_redundant_consistent_and_inconsistent():
+    ok = units.UnitSystem(["kN", "mm", "ms", "GPa"])  # GPa folgt bereits -> konsistent
+    assert ok.unit_for("pressure") == "GPa"
+    with pytest.raises(units.UnitConversionError, match="inconsistent"):
+        units.UnitSystem(["N", "kN"])                  # beide Kraft, widersprüchlich
+
+
+def test_unit_system_fractional_exponent():
+    """Solver liefert rationale Exponenten (Fläche-Basis -> Länge über 1/2)."""
+    sys = units.UnitSystem(["mm2", "s"])
+    assert sys.target_for("m") == "mm"
+    assert sys.convert_value(1.0, "m") == (1000.0, "mm")
+
+
+def test_unit_system_offset_base_rejected():
+    with pytest.raises(units.UnitConversionError, match="offset unit not allowed"):
+        units.UnitSystem(["degC", "mm"])
 
 
 def test_unit_system_unknown_unit_raises():
     with pytest.raises(units.UnitConversionError, match="unknown unit in system"):
         units.UnitSystem(["kN", "furlong"])
+
+
+def test_compose_and_canonical_helpers():
+    from fractions import Fraction
+    # kanonischer Treffer
+    assert units._canonical((1, 1, -2, 0), 1e3) == "kN"
+    assert units._canonical((-1, 1, -2, 0), 1e9) == "GPa"
+    assert units._canonical((1, 1, -2, 0), 1.234) is None   # kein Faktor-Treffer
+    # Komposition aus Basis-Symbolen
+    assert units._compose(["kN", "mm"], [Fraction(1), Fraction(-2)]) == "kN/mm^2"
+    assert units._compose(["kN", "mm"], [Fraction(1), Fraction(1)]) == "kN*mm"
+    assert units._compose(["mm"], [Fraction(-4)]) == "1/mm^4"          # nur Nenner
+    assert units._compose(["mm"], [Fraction(0)]) == "1"               # leer
+
+
+def test_dimension_of():
+    assert units.dimension_of("MPa") == (-1, 1, -2, 0)
+    assert units.dimension_of("kN") == (1, 1, -2, 0)
+    assert units.dimension_of("furlong") is None
+    assert units.dimension_of(None) == (0, 0, 0, 0)   # -> "-"
+
+
+def test_solve_linear_helper():
+    from fractions import Fraction
+    # eindeutig lösbar
+    assert units._solve_linear([[2, 0], [0, 3]], [4, 9]) == [Fraction(2), Fraction(3)]
+    # freie Variable (Spalte ohne Pivot) -> partikuläre Lösung mit 0
+    assert units._solve_linear([[1, 0], [0, 0]], [5, 0]) == [Fraction(5), Fraction(0)]
+    # widersprüchlich -> None
+    assert units._solve_linear([[1], [0]], [1, 7]) is None


### PR DESCRIPTION
## Was

Umsetzung von **RFC 0006 v2**: ein `UnitSystem` wird aus seinen **Basis-Einheiten gelöst** (Dimensions-Algebra), sodass **jede abgeleitete Einheit** hergeleitet wird — `[kN, mm, ms]` rechnet damit auch Spannung, Energie, Geschwindigkeit etc. konsistent um.

### `sdata/units.py`
- Dimvektoren `(L, M, T, Θ)` je Einheit; `dimension_of()`; `quantity_of()` daraus abgeleitet (backward-kompatibel).
- Exakter `Fraction`-Solver; `UnitSystem` löst die Basis-Dimensionen, prüft (in)konsistente Überbestimmung, lehnt Offset-Basis (`degC`) ab.
- System-Faktor als exaktes rationales **Potenzprodukt** (kein `log`/`exp`-Drift): `5000 N → 5.0 kN`, `200 MPa → 0.2 GPa` exakt.
- Label: kanonischer Vorzugs-Treffer (`GPa`/`J`/`m/s`/`kg`), sonst Komposition aus Basis-Symbolen; `convert_value`/`target_for`/`unit_for`/`factor_for`.

### `DataFrame`
- `convert()` führt abgeleitete Einheiten mit (`MPa→GPa`, `J`, `m/s`); nicht aufgespannte Dimensionen (z. B. Temperatur in `[kN,mm,ms]`) bleiben unverändert.
- **neu** `relabel_units(mapping, *, force=False)`: setzt Einheiten **ohne** Skalierung (Mislabel-Korrektur), Report-Rückgabe, `force=` für Dimensionswechsel.

| Spalte | `[kN, mm, ms]` | Herleitung |
|---|---|---|
| force `N`→`kN`, time `s`→`ms` | Basis | — |
| **stress `MPa`→`GPa`** | `kN/mm²` | v1 ließ das unverändert |
| **energy `J`**, **velocity `m/s`** | `kN·mm`, `mm/ms` | hergeleitet |

## Verifikation
- `ci/local-ci.sh` grün; **TOTAL 5160 stmts, 100 %** (`units.py` 100 %, `sclass/dataframe.py` 100 %); 665 passed, 7 skipped.
- `mkdocs build --strict` grün; RFC 0006 Status „Accepted — implementiert"; `usage/dataframe.md` + CHANGELOG aktualisiert.
- Backward-kompatibel: `units.convert`/`convert_factor` signaturgleich; `target_for("MPa")` liefert jetzt `GPa` statt `None` (gewollt, unveröffentlicht).