### PR TITLE
fix(metadata): from_json wirft ValueError bei fehlender Quelle (RFC 0008, A2)

### DIFF
--- a/sdata/metadata.py
+++ b/sdata/metadata.py
@@ -580,6 +580,7 @@ class Metadata(object):
         :param jsonstr: json str
         :param filepath: filepath to json file
         :return: Metadata
+        :raises ValueError: if neither jsonstr nor an existing filepath is given
         """
 
         if filepath is not None and os.path.exists(filepath):
@@ -589,6 +590,11 @@ class Metadata(object):
         elif jsonstr is not None:
             j = json.loads(jsonstr)
             metadata = cls.from_dict(j)
+        else:
+            if filepath is not None:
+                raise ValueError(
+                    f"Metadata.from_json: file not found and no jsonstr given: {filepath!r}")
+            raise ValueError("Metadata.from_json requires jsonstr or filepath")
         return metadata
 
     def to_list(self):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -128,6 +128,22 @@ def test_metadata():
     assert m.get_attr("foo").value==m6.get_attr("foo").value
     print(m.to_dataframe())
 
+def test_from_json_missing_source_raises():
+    import pytest
+    # keine Quelle -> klarer ValueError (statt UnboundLocalError, RFC 0008 A2)
+    with pytest.raises(ValueError, match="requires jsonstr or filepath"):
+        sdata.metadata.Metadata.from_json()
+    # filepath gesetzt, aber nicht existent, kein jsonstr -> ValueError nennt den Pfad
+    with pytest.raises(ValueError, match="file not found"):
+        sdata.metadata.Metadata.from_json(filepath="/tmp/does-not-exist-sdata.json")
+    # nicht existenter filepath MIT jsonstr -> Fallback auf jsonstr bleibt erhalten
+    m = sdata.metadata.Metadata(name="otto")
+    m.add("foo", 1.2, unit="m")
+    m2 = sdata.metadata.Metadata.from_json(
+        jsonstr=m.to_json(), filepath="/tmp/does-not-exist-sdata.json")
+    assert m2.get_attr("foo").value == 1.2
+
+
 def test_timestamp():
     t = sdata.timestamp.TimeStamp()
     print(t)


### PR DESCRIPTION
## Was

Umsetzung von **Punkt A2** der RFC-0008-Roadmap (Befund B3): `Metadata.from_json()` lief ohne `jsonstr` und ohne existierenden `filepath` in einen `UnboundLocalError` (`metadata` wurde nie zugewiesen).

- Jetzt expliziter `ValueError`; bei gesetztem, aber nicht existierendem `filepath` nennt die Meldung den Pfad
- Bestehendes Verhalten bleibt: nicht existenter `filepath` **mit** `jsonstr` fällt weiter auf `jsonstr` zurück
- Docstring um `:raises ValueError:` ergänzt; Test deckt alle drei Fälle ab

## Validierung

`make ci` grün, Coverage 100 % (5302/5302 Statements).

Teil der Umsetzung von RFC 0008 (#93).